### PR TITLE
Require latest styler release for more informative error message

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     R6,
     repr,
     stringr,
-    styler,
+    styler (>= 1.0.2),
     tools
 Suggests:
     testthat


### PR DESCRIPTION
I was happy to learn about styler being used in this project 😊. In https://github.com/r-lib/styler/issues/396, a user of your project mentioned that styler fails if Windows style EOL characters are used. We have decided to not support Windows style EOL at the moment, but instead ask the user to use Unix style EOL if they want to use styler. Windows style line endings now throw an informative error message with version `v1.0.2`. Hence, I suggest you make this minimal version requirement for the dependency styler.