### PR TITLE
docker container for development

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,9 @@
 ^\.Rproj\.user$
 ^cran-comments\.md$
 man-roxygen
+Makefile
+docker_checker
+NEWS.md
+DEV.md
+lib
+checks

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .Rhistory
 .vscode
 CRAN-RELEASE
+lib
+checks

--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,33 @@
+## For developers
+
+
+
+### tests and check
+
+If you have all the dependencies (and suggests) installed:
+
+type:
+ - `make tests`: to run the tests
+ - `make check`: to check the package
+
+### docker-checker
+
+A Dockerfile (<docker_checker/Dockerfile>) is provided to help building the
+dev environment in which to develop and test the R package.
+
+type:
+
+ - `make docker/build`: to build the docker
+ - `make docker/run`: to run a shell in the docker with the current dir mounted
+ 	inside
+ - `make docker/check`: to check the package inside the docker
+ - `make docker/tests`: to run test tests of the package inside the docker
+
+### test on windows using rhub
+
+not working yet...
+
+```
+make docker/run
+make check_rhub_windows
+```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,67 @@
+R=R
+RSCRIPT=Rscript
+RCHECKER=language_server
+NCPUS=4
+
+
+.PHONY: tests
+
+clean:
+	rm -f  src/*.o src/*.so */*~ *~ src/*.rds manual.pdf
+	rm -rf lib
+	$(shell bash -c "shopt -s globstar && rm -f **/*.o **/*.so")
+
+lib:
+	mkdir -p $@
+
+install: lib
+	$(R) -e 'pkg=devtools::build(".", "lib");install.packages(pkg, "lib", INSTALL_opts = "--install-tests")'
+
+coverage:
+	$(R) -e 'covr::package_coverage()'
+
+# tests require an installed package
+tests: 
+	R_LIBS=lib $(RSCRIPT) -e 'devtools::test()'
+
+build:
+	$(R) CMD build .
+
+check: 
+	$(R) -q -e 'devtools::check(check_dir = "checks")'
+
+
+doc:
+	$(R) CMD Rd2pdf -o manual.pdf .
+
+
+################## docker checker ##################################
+# directory in which the local dir is mounted inside the container
+DIR=/root/rcpp_progress
+DOCKER_RUN=docker run --rm -ti -v $(PWD):$(PWD) -w $(PWD) -u $$(id -u):$$(id -g) $(RCHECKER) 
+
+docker/build:
+	docker build -t $(RCHECKER) docker_checker
+
+# check with r-base
+docker/check: 
+	#-docker rm  $(RCHECKER)
+	$(DOCKER_RUN) make install check
+
+docker/run: 
+	#@-docker rm  $(RCHECKER)
+	$(DOCKER_RUN) bash
+
+docker/tests: 
+	#@-docker rm  $(RCHECKER)
+	$(DOCKER_RUN) make install tests
+
+
+check_rhub_windows: 
+	XDG_DATA_HOME=$(PWD) $(RSCRIPT) -e 'rhub::check_on_windows()'
+
+win-builder-upload: build
+	lftp  -u anonymous,karl.forner@gmail.com -e "set ftp:passive-mode true; cd R-release; mput *.tar.gz; cd ../R-devel;  mput *.tar.gz; bye" ftp://win-builder.r-project.org
+
+
+

--- a/docker_checker/Dockerfile
+++ b/docker_checker/Dockerfile
@@ -1,0 +1,9 @@
+FROM rocker/tidyverse
+MAINTAINER karl.forner@gmail.com
+
+RUN install2.r -s -n 4 callr collections desc jsonlite knitr lintr processx R6 repr stringr styler testthat
+# for RHUB
+RUN install2.r  rhub
+
+
+


### PR DESCRIPTION
I added a Makefile and a Dockerfile to streamline the development, in particular the testing. 
Cf DEV.md
Basically, if you have docker installed, you just build the docker, then run the tests with `make docker/tests` even if you do not have R installed. 
We can easily extend it to test on multiple R versions. 

If you are interested, my next contributions will be to setup continuous integration with Travis. 
Then the test coverage. 
And then I'll start adding some tests to get a grip on the package implementation.



