### PR TITLE
formatting_reply works with document rather than uri

### DIFF
--- a/R/formatting.R
+++ b/R/formatting.R
@@ -28,7 +28,7 @@ style_file <- function(path, options) {
 #' @template document
 #' @param options a named list of options, with a `tabSize` parameter
 formatting_reply <- function(id, uri, document, options) {
-    newText <- style_file(path_from_uri(uri), options)
+    newText <- style_text(document, options)
     ndoc <- length(document)
     range <- range(
         start = position(line = 0, character = 0),


### PR DESCRIPTION
I observe that in VSCode, when formatting a current document, `formatting_reply` is called before the file is saved to disk.

Therefore, `formatting_reply` should format the input `document` content rather than format the file at `uri`.