### PR TITLE
Transfer content in bytes to support non-ascii characters in document

### DIFF
--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -180,7 +180,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
 
         read_char = function(n) {
             if (self$tcp) {
-                readChar(self$inputcon, n)
+                readChar(self$inputcon, n, TRUE)
             } else {
                 stdin_read_char(n)
             }


### PR DESCRIPTION
This PR fixes #50 so that non-ascii characters can be correctly handled.