### PR TITLE
Fix to_string for error case

### DIFF
--- a/R/log.R
+++ b/R/log.R
@@ -19,7 +19,7 @@ to_string <- function(...) {
                         ""
                     }
                 },
-                error = function(e) x)
+                error = function(e) x$message)
             }, character(1L))
     } else {
         str <- ""


### PR DESCRIPTION
`error` is usually a list of vectors including `message` and `call`, which violates the `vapply` check for `character(1)`.