### PR TITLE
Fix to_string for handling complex objects

### DIFF
--- a/R/log.R
+++ b/R/log.R
@@ -23,7 +23,7 @@ to_string <- function(...) {
                         ""
                     }
                 } else {
-                    utils::capture.output(print(x))
+                    paste0(utils::capture.output(print(x)), collapse = "\n")
                 }
             }, character(1L)
         )

--- a/R/log.R
+++ b/R/log.R
@@ -11,7 +11,7 @@ to_string <- function(...) {
         str <- vapply(
             dots, function(x) {
                 if (is.atomic(x) || is.list(x)) {
-                    if (length(x) > 1) {
+                    if (is.list(x) || length(x) > 1) {
                         tryCatch(jsonlite::toJSON(x, auto_unbox = TRUE),
                             error = function(e) {
                                 paste0(e$message, utils::capture.output(print(x)), collapse = "\n")

--- a/R/log.R
+++ b/R/log.R
@@ -14,7 +14,7 @@ to_string <- function(...) {
                     if (length(x) > 1) {
                         tryCatch(jsonlite::toJSON(x, auto_unbox = TRUE),
                             error = function(e) {
-                                paste0(e$message, capture.output(print(x)), collapse = "\n")
+                                paste0(e$message, utils::capture.output(print(x)), collapse = "\n")
                             }
                         )
                     } else if (length(x) == 1) {
@@ -23,7 +23,7 @@ to_string <- function(...) {
                         ""
                     }
                 } else {
-                    capture.output(print(x))
+                    utils::capture.output(print(x))
                 }
             }, character(1L)
         )

--- a/R/log.R
+++ b/R/log.R
@@ -10,17 +10,23 @@ to_string <- function(...) {
     if (length(dots) > 0) {
         str <- vapply(
             dots, function(x) {
-                tryCatch({
+                if (is.atomic(x) || is.list(x)) {
                     if (length(x) > 1) {
-                        jsonlite::toJSON(x, auto_unbox = TRUE)
+                        tryCatch(jsonlite::toJSON(x, auto_unbox = TRUE),
+                            error = function(e) {
+                                paste0(e$message, capture.output(print(x)), collapse = "\n")
+                            }
+                        )
                     } else if (length(x) == 1) {
                         as.character(x)
                     } else {
                         ""
                     }
-                },
-                error = function(e) x$message)
-            }, character(1L))
+                } else {
+                    capture.output(print(x))
+                }
+            }, character(1L)
+        )
     } else {
         str <- ""
     }


### PR DESCRIPTION
Passing objects such as `environment` to `to_string()` causes error since `jsonlite::toJSON` cannot handle it.

This PR fixes this by directly using the printing content of non-atomic, non-list objects.