### PR TITLE
Initial implementation of scope completion using xpath

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,9 @@ Imports:
     stringr,
     styler (>= 1.0.2),
     tools,
-    utils
+    utils,
+    xml2,
+    xmlparsedata
 Suggests:
     processx,
     knitr,

--- a/R/document.R
+++ b/R/document.R
@@ -157,6 +157,8 @@ parse_env <- function() {
     env$formals <- list()
     env$signatures <- list()
     env$definition_ranges <- list()
+    env$xml_file <- NULL
+    env$xml_doc <- NULL
     env
 }
 
@@ -167,7 +169,7 @@ parse_env <- function() {
 #' signatures in the document in order to add them to the current [Workspace].
 #'
 #' @keywords internal
-parse_document <- function(path) {
+parse_document <- function(path, tmpdir) {
     temp_file <- NULL
     on.exit({
         if (!is.null(temp_file) && file.exists(temp_file)) {
@@ -176,7 +178,7 @@ parse_document <- function(path) {
     })
     is_rmd <- is_rmarkdown(path)
     if (is_rmd) {
-        temp_file <- tempfile(fileext = ".R")
+        temp_file <- tempfile(fileext = ".R", tmpdir = tmpdir)
         path <- tryCatch({
             knitr::purl(path, output = temp_file, quiet = TRUE)
         },
@@ -188,6 +190,12 @@ parse_document <- function(path) {
     parse_expr(expr, env, is_rmd = is_rmd)
     env$packages <- resolve_package_dependencies(env$packages)
     fix_definition_ranges(env, path)
+    env$xml_file <- tryCatch({
+        xml_text <- xmlparsedata::xml_parse_data(expr)
+        xml_file <- tempfile(basename(path), tmpdir = tmpdir, fileext = ".xml")
+        write(xml_text, xml_file)
+        xml_file
+    }, error = function(e) NULL)
     env
 }
 

--- a/R/document.R
+++ b/R/document.R
@@ -188,7 +188,6 @@ parse_document <- function(path, tmpdir) {
     expr <- tryCatch(parse(path, keep.source = TRUE), error = function(e) NULL)
     env <- parse_env()
     parse_expr(expr, env, is_rmd = is_rmd)
-    env$packages <- resolve_package_dependencies(env$packages)
     fix_definition_ranges(env, path)
     env$xml_file <- tryCatch({
         xml_text <- xmlparsedata::xml_parse_data(expr)

--- a/R/handlers-textsync.R
+++ b/R/handlers-textsync.R
@@ -11,7 +11,7 @@ text_document_did_open <- function(self, params) {
     } else {
         self$documents[[uri]]$set(content)
     }
-    self$text_sync(uri, document = NULL, run_lintr = TRUE, parse = TRUE)
+    self$text_sync(uri, document = NULL, run_lintr = TRUE, parse = TRUE, resolve = TRUE)
 }
 
 #' `textDocument/didChange` notification handler
@@ -32,7 +32,7 @@ text_document_did_change <- function(self, params) {
         self$documents[[uri]]$set(content)
         doc <- self$documents[[uri]]
     }
-    self$text_sync(uri, document = doc, run_lintr = TRUE, parse = FALSE)
+    self$text_sync(uri, document = doc, run_lintr = TRUE, parse = TRUE, resolve = FALSE)
 }
 
 #' `textDocument/willSave` notification handler
@@ -53,7 +53,7 @@ text_document_did_save <- function(self, params) {
     logger$info("did save:", uri)
     content <- readLines(path_from_uri(uri), warn = FALSE)
     self$documents[[uri]] <- Document$new(uri, content)
-    self$text_sync(uri, document = NULL, run_lintr = TRUE, parse = TRUE)
+    self$text_sync(uri, document = NULL, run_lintr = TRUE, parse = TRUE, resolve = TRUE)
 }
 
 #' `textDocument/didClose` notification handler

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -72,7 +72,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
             self$process_reply_queue()
         },
 
-        text_sync = function(uri, document = NULL, run_lintr = TRUE, parse = TRUE) {
+        text_sync = function(uri, document = NULL, run_lintr = TRUE, parse = TRUE, resolve = TRUE) {
             if (self$sync_in$has(uri)) {
                 # make sure we do not accidentially override list call with `parse = FALSE`
                 item <- self$sync_in$pop(uri)
@@ -80,7 +80,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
                 run_lintr <- run_lintr || item$run_lintr
             }
             self$sync_in$set(
-                uri, list(document = document, run_lintr = run_lintr, parse = parse)
+                uri, list(document = document, run_lintr = run_lintr, parse = parse, resolve = resolve)
             )
         },
 

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -180,9 +180,11 @@ Workspace <- R6::R6Class("Workspace",
 #'
 #' internal use only
 #' @param uri the file uri
+#' @param temp_dir the temporary directory to store intermediate files
 #' @param temp_file the file to lint, determine from \code{uri} if \code{NULL}
 #' @param run_lintr set \code{FALSE} to disable lintr diagnostics
 #' @param parse set \code{FALSE} to disable parsing file
+#' @param resolve set \code{FALSE} to disable resolving package dependencies
 #' @export
 workspace_sync <- function(uri, temp_dir = NULL, temp_file = NULL, run_lintr = TRUE, parse = FALSE, resolve = FALSE) {
     if (is.null(temp_file)) {

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -184,7 +184,7 @@ Workspace <- R6::R6Class("Workspace",
 #' @param run_lintr set \code{FALSE} to disable lintr diagnostics
 #' @param parse set \code{FALSE} to disable parsing file
 #' @export
-workspace_sync <- function(uri, temp_dir = NULL, temp_file = NULL, run_lintr = TRUE, parse = FALSE) {
+workspace_sync <- function(uri, temp_dir = NULL, temp_file = NULL, run_lintr = TRUE, parse = FALSE, resolve = FALSE) {
     if (is.null(temp_file)) {
         path <- path_from_uri(uri)
     } else {
@@ -194,6 +194,9 @@ workspace_sync <- function(uri, temp_dir = NULL, temp_file = NULL, run_lintr = T
     if (parse) {
         parse_data <- tryCatch(parse_document(path, temp_dir), error = function(e) NULL)
         # parse_data <- parse_document(path)
+        if (resolve) {
+            parse_data$packages <- resolve_package_dependencies(parse_data$packages)
+        }
     } else {
         parse_data <- NULL
     }
@@ -236,6 +239,7 @@ process_sync_in <- function(self) {
         item <- sync_in$pop(uri)
         run_lintr <- item$run_lintr && self$run_lintr
         parse <- parse || item$parse
+        resolve <- item$resolve
         doc <- item$document
         path <- path_from_uri(uri)
         if (is.null(doc)) {
@@ -255,7 +259,8 @@ process_sync_in <- function(self) {
                         temp_dir = tempdir(),
                         temp_file = temp_file,
                         run_lintr = run_lintr,
-                        parse = parse
+                        parse = parse,
+                        resolve = resolve
                     ),
                     system_profile = TRUE, user_profile = TRUE
                 ),

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -155,8 +155,10 @@ Workspace <- R6::R6Class("Workspace",
         },
 
         parse_file = function(uri, parse_data) {
-            if (file.exists(parse_data$xml_file)) {
+            if (!is.null(parse_data$xml_file) && 
+                file.exists(parse_data$xml_file)) {
                 parse_data$xml_doc <- xml2::read_xml(parse_data$xml_file)
+                file.remove(parse_data$xml_file)
             }
 
             private$parse_data[[uri]] <- parse_data

--- a/man/parse_document.Rd
+++ b/man/parse_document.Rd
@@ -4,7 +4,7 @@
 \alias{parse_document}
 \title{Parse a document}
 \usage{
-parse_document(path)
+parse_document(path, tmpdir)
 }
 \description{
 Build the list of called packages, functions, variables, formals and

--- a/man/workspace_sync.Rd
+++ b/man/workspace_sync.Rd
@@ -10,11 +10,15 @@ workspace_sync(uri, temp_dir = NULL, temp_file = NULL,
 \arguments{
 \item{uri}{the file uri}
 
+\item{temp_dir}{the temporary directory to store intermediate files}
+
 \item{temp_file}{the file to lint, determine from \code{uri} if \code{NULL}}
 
 \item{run_lintr}{set \code{FALSE} to disable lintr diagnostics}
 
 \item{parse}{set \code{FALSE} to disable parsing file}
+
+\item{resolve}{set \code{FALSE} to disable resolving package dependencies}
 }
 \description{
 internal use only

--- a/man/workspace_sync.Rd
+++ b/man/workspace_sync.Rd
@@ -5,7 +5,7 @@
 \title{Determine workspace information for a given file}
 \usage{
 workspace_sync(uri, temp_dir = NULL, temp_file = NULL,
-  run_lintr = TRUE, parse = FALSE)
+  run_lintr = TRUE, parse = FALSE, resolve = FALSE)
 }
 \arguments{
 \item{uri}{the file uri}

--- a/man/workspace_sync.Rd
+++ b/man/workspace_sync.Rd
@@ -4,8 +4,8 @@
 \alias{workspace_sync}
 \title{Determine workspace information for a given file}
 \usage{
-workspace_sync(uri, temp_file = NULL, run_lintr = TRUE,
-  parse = FALSE)
+workspace_sync(uri, temp_dir = NULL, temp_file = NULL,
+  run_lintr = TRUE, parse = FALSE)
 }
 \arguments{
 \item{uri}{the file uri}


### PR DESCRIPTION
This is an initial attempt to address #57 using `xmlparsedata` and XPath selectors.

To provide completions in each local scope, all enclosing scopes are detected (except for the top-level). In each of them, all symbols in the assignment expression (`<-`, `->`, and `=`) and function formals in each of these enclosing scopes are collected as locally available symbols at the current position.

The following images demonstrates the scope completions:

![image](https://user-images.githubusercontent.com/4662568/66285391-f28a5500-e8fe-11e9-9cdf-d222941b4eb4.png)

![image](https://user-images.githubusercontent.com/4662568/66285396-fe761700-e8fe-11e9-8d1f-ae6fda4d2434.png)

![image](https://user-images.githubusercontent.com/4662568/66285401-0930ac00-e8ff-11e9-9b6e-9663290c9019.png)

One thing yet to improve is that adding new lines to document or removing lines from document make parsed document out-of-sync, so that the line positions are out-of-sync. We should consider parse documents more frequently (i.e. trigger by adding/removing lines) without loading packages (which is the main overhead. parsing is very fast in most cases).
