### PR TITLE
Only provide package exported objects at ::

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -59,13 +59,13 @@ workspace_completion <- function(workspace, token, package = NULL, exported_only
     completions <- list()
 
     if (is.null(package)) {
-        packages <- workspace$loaded_packages
+        packages <- c("_workspace_", workspace$loaded_packages)
     } else {
         packages <- c(package)
     }
 
     if (is.null(package) || exported_only) {
-        for (nsname in c("_workspace_", packages)) {
+        for (nsname in packages) {
             ns <- workspace$get_namespace(nsname)
             functs <- ns$functs[startsWith(ns$functs, token)]
             if (nsname == "_workspace_") {

--- a/man/become_orphan.Rd
+++ b/man/become_orphan.Rd
@@ -2,11 +2,11 @@
 % Please edit documentation in R/utils.R
 \name{become_orphan}
 \alias{become_orphan}
-\title{check if the current process become an orphan}
+\title{check if the current process becomes an orphan}
 \usage{
 become_orphan()
 }
 \description{
-check if the current process become an orphan
+check if the current process becomes an orphan
 }
 \keyword{internal}


### PR DESCRIPTION
Closes #83.

At `::`, workspace symbols are excluded and only package exported objects appear in the completion so that any choice would not refer to a non-existing object.