### PR TITLE
Customizable style

### DIFF
--- a/R/formatting.R
+++ b/R/formatting.R
@@ -1,9 +1,9 @@
-get_style <- function(...) {
+get_style <- function(options) {
     style <- getOption("languageserver.formatting_style")
     if (is.null(style)) {
-        style <- styler::tidyverse_style(...)
+        style <- styler::tidyverse_style(indent_by = options$tabSize)
     } else {
-        style <- style(...)
+        style <- style(options)
     }
     style
 }
@@ -11,7 +11,7 @@ get_style <- function(...) {
 #' Style a file
 #'
 #' This functions formats a document using [styler::style_file()] with the
-#' [styler::tidyverse_style()] style.
+#' specified style.
 #'
 #' @keywords internal
 style_file <- function(path, style) {
@@ -57,7 +57,7 @@ style_text <- function(text, style, indentation = "") {
 #' @keywords internal
 formatting_reply <- function(id, uri, document, options) {
     # do not use `style_file` because the changes are not necessarily saved on disk.
-    style <- get_style(indent_by = options$tabSize)
+    style <- get_style(options)
     new_text <- style_text(document$content, style)
     if (is.null(new_text)) {
         return(Response$new(id, list()))
@@ -98,7 +98,7 @@ range_formatting_reply <- function(id, uri, document, range, options) {
         return(Response$new(id, list()))
     }
 
-    style <- get_style(indent_by = options$tabSize)
+    style <- get_style(options)
     # check if the selection contains complete lines
     if (character1 != 0 || character2 < ncodeunit(lastline)) {
         # disable assignment operator fix for partial selection

--- a/README.md
+++ b/README.md
@@ -110,11 +110,20 @@ setHook(
 ### Customizing formatting style
 
 The language server uses [`styler`](https://github.com/r-lib/styler) to perform code formatting. It uses `styler::tidyverse_style(indent_by = options$tabSize)` as the default style where `options` is the [formatting
-options](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_formatting) of the document.
+options](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_formatting).
 
 The formatting style can be customized by specifying `languageserver.formatting_style` option which
-is suppoed to be a funtion that accepts an `options` argument mentioned above. For example, to disable
-assignment operator fix (replacing `=` with `<-`), you may append the following code in your `.Rprofile`:
+is suppoed to be a function that accepts an `options` argument mentioned above. You could consider to put the code in `.Rprofile`.
+
+[`styler::tidyverse_style`](<https://styler.r-lib.org/reference/tidyverse_style.html>) provides numerous arguments to customize the formatting behavior. For example, to make it only work at indention scope:
+
+```r
+options(languageserver.formatting_style = function(options) {
+  styler::tidyverse_style(scope = "indention", indent_by = options$tabSize)
+}
+```
+
+To disable assignment operator fix (replacing `=` with `<-`):
 
 ```r
 options(languageserver.formatting_style = function(options) {
@@ -124,4 +133,4 @@ options(languageserver.formatting_style = function(options) {
 }
 ```
 
-To further customize the formatting style, please refer to <https://styler.r-lib.org/articles/customizing_styler.html>.
+To further customize the formatting style, please refer to [Customizing styler](https://styler.r-lib.org/articles/customizing_styler.html).

--- a/README.md
+++ b/README.md
@@ -106,3 +106,22 @@ setHook(
     }
 )
 ```
+
+### Customizing formatting style
+
+The language server uses [`styler`](https://github.com/r-lib/styler) to perform code formatting. It uses `styler::tidyverse_style(indent_by = options$tabSize)` as the default style where `options` is the [formatting
+options](https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_formatting) of the document.
+
+The formatting style can be customized by specifying `languageserver.formatting_style` option which
+is suppoed to be a funtion that accepts an `options` argument mentioned above. For example, to disable
+assignment operator fix (replacing `=` with `<-`), you may append the following code in your `.Rprofile`:
+
+```r
+options(languageserver.formatting_style = function(options) {
+  style <- styler::tidyverse_style(indent_by = options$tabSize)
+  style$token$force_assignment_op <- NULL
+  style
+}
+```
+
+To further customize the formatting style, please refer to <https://styler.r-lib.org/articles/customizing_styler.html>.

--- a/man/style_file.Rd
+++ b/man/style_file.Rd
@@ -4,7 +4,7 @@
 \alias{style_file}
 \title{Style a file}
 \usage{
-style_file(path, options)
+style_file(path, style)
 }
 \description{
 This functions formats a document using \code{\link[styler:style_file]{styler::style_file()}} with the

--- a/man/style_file.Rd
+++ b/man/style_file.Rd
@@ -8,6 +8,6 @@ style_file(path, style)
 }
 \description{
 This functions formats a document using \code{\link[styler:style_file]{styler::style_file()}} with the
-\code{\link[styler:tidyverse_style]{styler::tidyverse_style()}} style.
+specified style.
 }
 \keyword{internal}

--- a/man/style_text.Rd
+++ b/man/style_text.Rd
@@ -4,7 +4,7 @@
 \alias{style_text}
 \title{Edit code style}
 \usage{
-style_text(text, options, scope = "tokens", indentation = "")
+style_text(text, options, indentation = "")
 }
 \description{
 This functions formats a list of text using \code{\link[styler:style_text]{styler::style_text()}} with the

--- a/man/style_text.Rd
+++ b/man/style_text.Rd
@@ -4,10 +4,10 @@
 \alias{style_text}
 \title{Edit code style}
 \usage{
-style_text(text, options, indentation = "")
+style_text(text, style, indentation = "")
 }
 \description{
 This functions formats a list of text using \code{\link[styler:style_text]{styler::style_text()}} with the
-\code{\link[styler:tidyverse_style]{styler::tidyverse_style()}} style.
+specified style.
 }
 \keyword{internal}


### PR DESCRIPTION
Closes #85.

This PR allows user to customize formatting style by modifying `languageserver.formatting_style` option. For example, to only apply indention level of formatting scope:

```r
options(languageserver.formatting_style = function(...) {
  styler::tidyverse_style(scope = "indention", ...)
}
```

To disable assignment operator fix by default:

```r
options(languageserver.formatting_style = function(...) {
  style <- styler::tidyverse_style(...)
  style$token$force_assignment_op <- NULL
  style
}
```
