### PR TITLE
Ignore missing packages in completion and definition

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -67,6 +67,9 @@ workspace_completion <- function(workspace, token, package = NULL, exported_only
     if (is.null(package) || exported_only) {
         for (nsname in packages) {
             ns <- workspace$get_namespace(nsname)
+            if (is.null(ns)) {
+                next
+            }
             functs <- ns$functs[startsWith(ns$functs, token)]
             if (nsname == "_workspace_") {
                 tag <- "[workspace]"
@@ -90,13 +93,17 @@ workspace_completion <- function(workspace, token, package = NULL, exported_only
         }
     } else {
         ns <- workspace$get_namespace(package)
-        unexports <- ns$unexports[startsWith(ns$unexports, token)]
-        unexports_completion <- lapply(unexports, function(object) {
-            list(label = object,
-                 kind = CompletionItemKind$Field,
-                 detail = paste0("{", package, "}"))
-        })
-        completions <- c(completions, unexports_completion)
+        if (!is.null(ns)) {
+            unexports <- ns$unexports[startsWith(ns$unexports, token)]
+            unexports_completion <- lapply(unexports, function(object) {
+                list(
+                    label = object,
+                    kind = CompletionItemKind$Field,
+                    detail = paste0("{", package, "}")
+                )
+            })
+            completions <- c(completions, unexports_completion)
+        }
     }
 
     completions


### PR DESCRIPTION
Closes #81 

This PR uses `find.package(pkg, quiet = TRUE)` to detect if a package is installed in `workspace$get_namespace()` and `workspace$get_code()` so that they may return `NULL` if the requested package is not installed. And subsequent calls to them ignores the case where package is missing so that writing and hovering on an non-installed package (e.g. `abc::`) in the code does not trigger extra logging to notice user that the package is not installed (in vscode the bottom panel jumps to extension logging, which is annoying).