### PR TITLE
Fix completion

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -181,14 +181,14 @@ completion_reply <- function(id, uri, workspace, document, position) {
         if (is.null(package)) {
             completions <- c(
                 completions,
-                package_completion(token))
+                constant_completion(token),
+                package_completion(token),
+                scope_completion(uri, workspace, token, position))
         }
         completions <- c(
             completions,
-            constant_completion(token),
             workspace_completion(
-                workspace, token, package, token_result$accessor == "::"),
-            scope_completion(uri, workspace, token, position))
+                workspace, token, package, token_result$accessor == "::"))
     }
 
     call_result <- document$detect_call(position)


### PR DESCRIPTION
This PR moves `constant_completion` and `scope_completion` to work only in non-package completion, to fix the following cases:

<img width="537" alt="image" src="https://user-images.githubusercontent.com/4662568/66881227-cbb3d900-eff8-11e9-8e3a-037a0c43be3c.png">

<img width="562" alt="image" src="https://user-images.githubusercontent.com/4662568/66881297-06b60c80-eff9-11e9-9d2f-8a9f3fe97abd.png">
