### PR TITLE
Add lazydata to namespace and completion

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -100,9 +100,16 @@ workspace_completion <- function(workspace, token, package = NULL, exported_only
                      kind = CompletionItemKind$Field,
                      detail = tag)
             })
+            lazydata <- ns$lazydata[startsWith(ns$lazydata, token)]
+            lazydata_completions <- lapply(lazydata, function(object) {
+                list(label = object,
+                     kind = CompletionItemKind$Field,
+                     detail = tag)
+            })
             completions <- c(completions,
                 functs_completions,
-                nonfuncts_completions)
+                nonfuncts_completions,
+                lazydata_completions)
         }
     } else {
         ns <- workspace$get_namespace(package)

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -10,6 +10,7 @@ Namespace <- R6::R6Class("Namespace",
         unexports = NULL,
         functs = NULL,
         nonfuncts = NULL,
+        lazydata = NULL,
 
         initialize = function(pkgname) {
             self$package_name <- pkgname
@@ -21,6 +22,8 @@ Namespace <- R6::R6Class("Namespace",
                         is.function(get(x, envir = ns))}, logical(1L), USE.NAMES = FALSE)
             self$functs <- self$exports[isf]
             self$nonfuncts <- setdiff(self$exports, self$functs)
+            self$lazydata <- if (length(ns$.__NAMESPACE__.$lazydata))
+                objects(ns$.__NAMESPACE__.$lazydata) else character()
         },
 
         exists = function(objname) {

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -10,12 +10,13 @@ Workspace <- R6::R6Class("Workspace",
         global_env = list(nonfuncts = character(0),
                           functs = character(0),
                           signatures = list(),
-                          formals = list()),
+                          formals = list(),
+                          lazydata = character()),
         namespaces = list(),
         definitions = NULL
     ),
     public = list(
-        loaded_packages = c("base", "stats", "methods", "utils", "graphics", "grDevices"),
+        loaded_packages = c("base", "stats", "methods", "utils", "graphics", "grDevices", "datasets"),
 
         initialize = function() {
             for (pkgname in self$loaded_packages) {


### PR DESCRIPTION
Closes #99.

This PR adds `lazydata` in package to `Namespace` and completion. Since `lazydata` is not part of package exports, I use a separate field `lazydata` in `Namespace` rather than combine it with `exports` to respect how these objects are organized in R namespace.
