### PR TITLE
Add documentation text to signature and arg completion

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -63,7 +63,7 @@ arg_completion <- function(workspace, token, funct, package = NULL) {
         completions <- lapply(token_args, function(arg) {
             list(label = arg, kind = CompletionItemKind$Variable,
                 detail = "parameter",
-                documentation = doc$arguments[[arg]])
+                documentation = paste0(doc$arguments[[arg]], collapse = ""))
         })
         completions
     }

--- a/R/completion.R
+++ b/R/completion.R
@@ -60,7 +60,8 @@ arg_completion <- function(workspace, token, funct, package = NULL) {
     if (is.character(args)) {
         token_args <- args[startsWith(args, token)]
         completions <- lapply(token_args, function(arg) {
-            list(label = arg, kind = CompletionItemKind$Variable)
+            list(label = arg, kind = CompletionItemKind$Variable,
+                documentation = paste0("argument: ", arg))
         })
         completions
     }

--- a/R/completion.R
+++ b/R/completion.R
@@ -63,7 +63,10 @@ arg_completion <- function(workspace, token, funct, package = NULL) {
         completions <- lapply(token_args, function(arg) {
             list(label = arg, kind = CompletionItemKind$Variable,
                 detail = "parameter",
-                documentation = paste0(doc$arguments[[arg]], collapse = ""))
+                documentation = list(
+                    kind = "markdown", 
+                    value = paste0(doc$arguments[[arg]], collapse = "")
+                ))
         })
         completions
     }

--- a/R/completion.R
+++ b/R/completion.R
@@ -61,12 +61,15 @@ arg_completion <- function(workspace, token, funct, package = NULL) {
         doc <- workspace$get_documentation(funct, package)
         token_args <- args[startsWith(args, token)]
         completions <- lapply(token_args, function(arg) {
+            doc_string <- doc$arguments[[arg]]
+            if (is.null(doc_string)) {
+                documentation <- ""
+            } else {
+                documentation <- list(kind = "markdown", value = doc_string)
+            }
             list(label = arg, kind = CompletionItemKind$Variable,
                 detail = "parameter",
-                documentation = list(
-                    kind = "markdown", 
-                    value = paste0(doc$arguments[[arg]], collapse = "")
-                ))
+                documentation = documentation)
         })
         completions
     }

--- a/R/completion.R
+++ b/R/completion.R
@@ -58,10 +58,12 @@ package_completion <- function(token) {
 arg_completion <- function(workspace, token, funct, package = NULL) {
     args <- names(workspace$get_formals(funct, package))
     if (is.character(args)) {
+        doc <- workspace$get_documentation(funct, package)
         token_args <- args[startsWith(args, token)]
         completions <- lapply(token_args, function(arg) {
             list(label = arg, kind = CompletionItemKind$Variable,
-                documentation = paste0("argument: ", arg))
+                detail = "parameter",
+                documentation = doc$arguments[[arg]])
         })
         completions
     }

--- a/R/hover.R
+++ b/R/hover.R
@@ -18,8 +18,8 @@ hover_reply <- function(id, uri, workspace, document, position) {
         logger$info("sig: ", sig)
         if (!is.null(sig)) {
             sig <- trimws(gsub("function\\s*", token_result$token, sig))
+            contents <- sprintf("```r\n%s\n```", sig)
         }
-        contents <- sprintf("```r\n%s\n```", sig)
     }
 
     if (is.null(contents)) {

--- a/R/hover.R
+++ b/R/hover.R
@@ -18,7 +18,7 @@ hover_reply <- function(id, uri, workspace, document, position) {
         logger$info("sig: ", sig)
         if (!is.null(sig)) {
             sig <- trimws(gsub("function\\s*", token_result$token, sig))
-            contents <- sprintf("```r\n%s\n```", sig)
+            contents <- list(kind = "markdown", value = sprintf("```r\n%s\n```", sig))
         }
     }
 
@@ -28,9 +28,7 @@ hover_reply <- function(id, uri, workspace, document, position) {
         Response$new(
             id,
             result = list(
-                contents = list(
-                    kind = "markdown",
-                    value = contents),
+                contents = contents,
                 range = token_result$range
             )
         )

--- a/R/hover.R
+++ b/R/hover.R
@@ -18,7 +18,7 @@ hover_reply <- function(id, uri, workspace, document, position) {
         logger$info("sig: ", sig)
         if (!is.null(sig)) {
             sig <- trimws(gsub("function\\s*", token_result$token, sig))
-            contents <- list(kind = "markdown", value = sprintf("```r\n%s\n```", sig))
+            contents <- sprintf("```r\n%s\n```", sig)
         }
     }
 

--- a/R/hover.R
+++ b/R/hover.R
@@ -19,7 +19,7 @@ hover_reply <- function(id, uri, workspace, document, position) {
         if (!is.null(sig)) {
             sig <- trimws(gsub("function\\s*", token_result$token, sig))
         }
-        contents <- sig
+        contents <- sprintf("```r\n%s\n```", sig)
     }
 
     if (is.null(contents)) {
@@ -28,7 +28,9 @@ hover_reply <- function(id, uri, workspace, document, position) {
         Response$new(
             id,
             result = list(
-                contents = contents,
+                contents = list(
+                    kind = "markdown",
+                    value = contents),
                 range = token_result$range
             )
         )

--- a/R/signature.R
+++ b/R/signature.R
@@ -23,13 +23,7 @@ signature_reply <- function(id, uri, workspace, document, position) {
             sig <- trimws(gsub("function\\s*", result$token, sig))
             SignatureInformation <- list(list(
                 label = sig,
-                documentation = paste0("documentation: ", result$token),
-                parameters = lapply(names(formals), function(param) {
-                    list(
-                        label = param,
-                        documentation = paste0("parameter: ", param)
-                    )
-                })
+                documentation = paste0("documentation: ", result$token)
             ))
             activeSignature <- 0
         }

--- a/R/signature.R
+++ b/R/signature.R
@@ -17,10 +17,20 @@ signature_reply <- function(id, uri, workspace, document, position) {
 
     if (nzchar(result$token)) {
         sig <- workspace$get_signature(result$token, result$package)
-        logger$info("sig: ", sig)
+        formals <- workspace$get_formals(result$token, result$package)
+        logger$info("sig: ", sig, ", formals: ", length(formals))
         if (!is.null(sig)) {
             sig <- trimws(gsub("function\\s*", result$token, sig))
-            SignatureInformation <- list(list(label = sig))
+            SignatureInformation <- list(list(
+                label = sig,
+                documentation = paste0("documentation: ", result$token),
+                parameters = lapply(names(formals), function(param) {
+                    list(
+                        label = param,
+                        documentation = paste0("parameter: ", param)
+                    )
+                })
+            ))
             activeSignature <- 0
         }
     }

--- a/R/signature.R
+++ b/R/signature.R
@@ -21,12 +21,15 @@ signature_reply <- function(id, uri, workspace, document, position) {
         logger$info("sig: ", sig)
         if (!is.null(sig)) {
             sig <- trimws(gsub("function\\s*", result$token, sig))
+            doc_string <- doc$description
+            if (is.null(doc_string)) {
+                documentation <- ""
+            } else {
+                documentation <- list(kind = "markdown", value = doc_string)
+            }
             SignatureInformation <- list(list(
                 label = sig,
-                documentation = list(
-                    kind = "markdown",
-                    value = paste0(doc$description, collapse = "")
-                )
+                documentation = documentation
             ))
             activeSignature <- 0
         }

--- a/R/signature.R
+++ b/R/signature.R
@@ -23,7 +23,7 @@ signature_reply <- function(id, uri, workspace, document, position) {
             sig <- trimws(gsub("function\\s*", result$token, sig))
             SignatureInformation <- list(list(
                 label = sig,
-                documentation = paste0(doc$title, "\n", doc$description)
+                documentation = paste0(doc$title, doc$description, collapse = "\n")
             ))
             activeSignature <- 0
         }

--- a/R/signature.R
+++ b/R/signature.R
@@ -17,13 +17,13 @@ signature_reply <- function(id, uri, workspace, document, position) {
 
     if (nzchar(result$token)) {
         sig <- workspace$get_signature(result$token, result$package)
-        formals <- workspace$get_formals(result$token, result$package)
-        logger$info("sig: ", sig, ", formals: ", length(formals))
+        doc <- workspace$get_documentation(result$token, result$package)
+        logger$info("sig: ", sig)
         if (!is.null(sig)) {
             sig <- trimws(gsub("function\\s*", result$token, sig))
             SignatureInformation <- list(list(
                 label = sig,
-                documentation = paste0("documentation: ", result$token)
+                documentation = paste0(doc$title, "\n", doc$description)
             ))
             activeSignature <- 0
         }

--- a/R/signature.R
+++ b/R/signature.R
@@ -23,7 +23,10 @@ signature_reply <- function(id, uri, workspace, document, position) {
             sig <- trimws(gsub("function\\s*", result$token, sig))
             SignatureInformation <- list(list(
                 label = sig,
-                documentation = paste0(doc$description, collapse = "")
+                documentation = list(
+                    kind = "markdown",
+                    value = paste0(doc$description, collapse = "")
+                )
             ))
             activeSignature <- 0
         }

--- a/R/signature.R
+++ b/R/signature.R
@@ -23,7 +23,7 @@ signature_reply <- function(id, uri, workspace, document, position) {
             sig <- trimws(gsub("function\\s*", result$token, sig))
             SignatureInformation <- list(list(
                 label = sig,
-                documentation = paste0(doc$title, doc$description, collapse = "\n")
+                documentation = paste0(doc$description, collapse = "")
             ))
             activeSignature <- 0
         }

--- a/R/utils.R
+++ b/R/utils.R
@@ -252,3 +252,11 @@ look_backward <- function(text) {
         token = na_to_empty_string(matches[4])
     )
 }
+
+find_doc_item <- function(doc, tag) {
+    for (item in doc) {
+        if (attr(item, "Rd_tag") == tag) {
+            return(item)
+        }
+    }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -260,3 +260,11 @@ find_doc_item <- function(doc, tag) {
         }
     }
 }
+
+convert_doc_string <- function(doc) {
+    paste0(rapply(doc, function(item) {
+        switch(attr(item, "Rd_tag"),
+            RCODE = sprintf("`%s`", item),
+            trimws(item))
+    }, classes = "character"), collapse = " ")
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -261,10 +261,19 @@ find_doc_item <- function(doc, tag) {
     }
 }
 
+convert_doc_to_markdown <- function(doc) {
+    lapply(doc, function(item) {
+        tag <- attr(item, "Rd_tag")
+        if (is.null(tag) || is.character(item)) {
+            trimws(item)
+        } else if (tag == "\\code") {
+            sprintf("`%s`", paste0(unlist(item), collapse = ""))
+        } else {
+            convert_doc_to_markdown(item)
+        }
+    })
+}
+
 convert_doc_string <- function(doc) {
-    paste0(rapply(doc, function(item) {
-        switch(attr(item, "Rd_tag"),
-            RCODE = sprintf("`%s`", item),
-            trimws(item))
-    }, classes = "character"), collapse = " ")
+    paste0(unlist(convert_doc_to_markdown(doc)), collapse = " ")
 }

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -127,18 +127,16 @@ Workspace <- R6::R6Class("Workspace",
                 pkgname <- self$guess_package(topic)
             }
             if (is.null(pkgname)) {
-                item <- topic
-                if (!is.null(private$documentation[[item]])) {
-                    return(private$documentation[[item]])
-                }
-                hfile <- utils::help((topic))
-            } else {
-                item <- paste0(pkgname, ".", topic)
-                if (!is.null(private$documentation[[item]])) {
-                    return(private$documentation[[item]])
-                }
-                hfile <- utils::help((topic), (pkgname))
+                # only provide documentation for objects in package
+                return(NULL)
             }
+
+            item <- paste0(pkgname, "::", topic)
+            if (!is.null(private$documentation[[item]])) {
+                return(private$documentation[[item]])
+            }
+            hfile <- utils::help((topic), (pkgname))
+
             if (length(hfile) > 0) {
                 doc <- utils:::.getHelpFile(hfile)
                 title_item <- self$find_doc_item(doc, "\\title")

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -124,7 +124,7 @@ Workspace <- R6::R6Class("Workspace",
 
         get_documentation = function(topic, pkgname = NULL) {
             if (is.null(pkgname)) {
-                pkgname <- self$guess_package(topic)
+                pkgname <- self$guess_namespace(topic)
             }
             if (is.null(pkgname) || pkgname == WORKSPACE) {
                 # only provide documentation for objects in package

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -142,8 +142,8 @@ Workspace <- R6::R6Class("Workspace",
                 title_item <- find_doc_item(doc, "\\title")
                 description_item <- find_doc_item(doc, "\\description")
                 arguments_item <- find_doc_item(doc, "\\arguments")
-                title <- paste0(trimws(unlist(title_item)), collapse = " ")
-                description <- paste0(trimws(unlist(description_item)), collapse = " ")
+                title <- convert_doc_string(title_item)
+                description <- convert_doc_string(description_item)
                 arguments <- list()
                 if (length(arguments_item)) {
                     arg_items <- arguments_item[vapply(arguments_item,
@@ -155,7 +155,7 @@ Workspace <- R6::R6Class("Workspace",
                     }, character(1L))
                     names(arg_items) <- arg_names
                     arguments <- lapply(arg_items, function(item) {
-                        paste0(trimws(unlist(item[[2]])), collapse = " ")
+                        convert_doc_string(item[[2]])
                     })
                 }
                 private$documentation[[item]] <- list(

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -139,9 +139,9 @@ Workspace <- R6::R6Class("Workspace",
 
             if (length(hfile) > 0) {
                 doc <- utils:::.getHelpFile(hfile)
-                title_item <- self$find_doc_item(doc, "\\title")
-                description_item <- self$find_doc_item(doc, "\\description")
-                arguments_item <- self$find_doc_item(doc, "\\arguments")
+                title_item <- find_doc_item(doc, "\\title")
+                description_item <- find_doc_item(doc, "\\description")
+                arguments_item <- find_doc_item(doc, "\\arguments")
                 title <- paste0(trimws(unlist(title_item)), collapse = " ")
                 description <- paste0(trimws(unlist(description_item)), collapse = " ")
                 arguments <- list()
@@ -213,14 +213,6 @@ Workspace <- R6::R6Class("Workspace",
             if (!is.null(parse_data$xml_data)) {
                 private$xml_docs[[uri]] <- tryCatch(
                     xml2::read_xml(parse_data$xml_data), error = function(e) NULL)
-            }
-        },
-
-        find_doc_item = function(doc, tag) {
-            for (item in doc) {
-                if (attr(item, "Rd_tag") == tag) {
-                    return(item)
-                }
             }
         }
     )

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -126,7 +126,7 @@ Workspace <- R6::R6Class("Workspace",
             if (is.null(pkgname)) {
                 pkgname <- self$guess_package(topic)
             }
-            if (is.null(pkgname)) {
+            if (is.null(pkgname) || pkgname == WORKSPACE) {
                 # only provide documentation for objects in package
                 return(NULL)
             }

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -36,6 +36,26 @@ test_that("Simple completion works", {
     expect_length(result$items %>% keep(~.$label == ".Machine"), 1)
 })
 
+test_that("Completion of function arguments works", {
+    skip_on_cran()
+    client <- language_client()
+    
+    withr::local_tempfile(c("temp_file"), fileext = ".R")
+    writeLines(
+        c(
+            "str(obj"
+        ),
+        temp_file)
+    
+    client %>% did_save(temp_file)
+
+    result <- client %>% respond_completion(temp_file, c(0, 6))
+    arg_items <- result$items %>% keep(~.$label == "object")
+    expect_length(arg_items, 1)
+    expect_equal(arg_items[[1]]$documentation$kind, "markdown")
+    expect_equal(arg_items[[1]]$documentation$value,
+        "any object about which you want to have some information.")
+})
 
 test_that("Completion of user function works", {
     skip_on_cran()

--- a/tests/testthat/test-hover.R
+++ b/tests/testthat/test-hover.R
@@ -24,3 +24,23 @@ test_that("Simple hover works", {
     expect_true(stringr::str_detect(result$contents[1], "path_real"))
     expect_equal(result$range$end$character, 13)
 })
+
+test_that("Hover on user function works", {
+    skip_on_cran()
+    client <- language_client()
+
+    withr::local_tempfile(c("temp_file"), fileext = ".R")
+    writeLines(
+        c(
+            "test1 <- function(x, y) x + 1",
+            "test1"
+        ),
+        temp_file)
+
+    client %>% did_save(temp_file)
+
+    result <- client %>% respond_hover(temp_file, c(1, 3))
+    expect_length(result$contents, 1)
+    expect_equal(result$contents[1], "```r\ntest1(x, y)\n```")
+    expect_equal(result$range$end$character, 5)
+})

--- a/tests/testthat/test-signature.R
+++ b/tests/testthat/test-signature.R
@@ -17,10 +17,16 @@ test_that("Simple signature works", {
     result <- client %>% respond_signature(temp_file, c(0, 10))
     expect_length(result$signatures, 1)
     expect_match(result$signatures[[1]]$label, "file\\.path\\(.*")
+    expect_equal(result$signatures[[1]]$documentation$kind, "markdown")
+    expect_match(result$signatures[[1]]$documentation$value,
+        ".*Construct the path to a file from components in a platform-independent way.*")
 
     result <- client %>% respond_signature(temp_file, c(1, 21))
     expect_length(result$signatures, 1)
     expect_match(result$signatures[[1]]$label, "path_home\\(.*")
+    expect_equal(result$signatures[[1]]$documentation$kind, "markdown")
+    expect_match(result$signatures[[1]]$documentation$value,
+        ".*`path_expand\\(\\)` performs tilde expansion on a path.*")
 })
 
 test_that("Signature of user function works", {


### PR DESCRIPTION
This PR is an attempt to address #108.

A documentation extractor is implemented and function description is provided in signature, and argument description is provided in arg completion.

![image](https://user-images.githubusercontent.com/4662568/69206457-b138c680-0b87-11ea-9347-bf0093e63ae2.png)

Originally, I wanted to provide `ParameterInformation` also in signature. But it's hard to determine which argument is the active parameter due to the complexities of R function argument matching.