### PR TITLE
Provide signature for primitive functions

### DIFF
--- a/R/namespace.R
+++ b/R/namespace.R
@@ -38,13 +38,9 @@ Namespace <- R6::R6Class("Namespace",
             pkgname <- self$package_name
             ns <- asNamespace(pkgname)
             fn <- get(funct, envir = ns)
-            if (is.primitive(fn)) {
-                NULL
-            } else {
-                sig <- utils::capture.output(print(args(fn)))
-                sig <- sig[-length(sig)]
-                paste0(trimws(sig, which = "left"), collapse = "\n")
-            }
+            sig <- utils::capture.output(print(args(fn)))
+            sig <- sig[-length(sig)]
+            paste0(trimws(sig, which = "left"), collapse = "\n")
         },
 
         get_formals = function(funct) {

--- a/R/signature.R
+++ b/R/signature.R
@@ -17,15 +17,14 @@ signature_reply <- function(id, uri, workspace, document, position) {
 
     if (nzchar(result$token)) {
         sig <- workspace$get_signature(result$token, result$package)
-        doc <- workspace$get_documentation(result$token, result$package)
         logger$info("sig: ", sig)
         if (!is.null(sig)) {
             sig <- trimws(gsub("function\\s*", result$token, sig))
-            doc_string <- doc$description
-            if (is.null(doc_string)) {
+            doc <- workspace$get_documentation(result$token, result$package)
+            if (is.null(doc$description)) {
                 documentation <- ""
             } else {
-                documentation <- list(kind = "markdown", value = doc_string)
+                documentation <- list(kind = "markdown", value = doc$description)
             }
             SignatureInformation <- list(list(
                 label = sig,

--- a/R/utils.R
+++ b/R/utils.R
@@ -268,6 +268,8 @@ convert_doc_to_markdown <- function(doc) {
             if (length(item)) {
                 convert_doc_to_markdown(item)
             }
+        } else if (tag == "\\R") {
+            "**R**"
         } else if (tag == "\\dots") {
             "..."
         } else if (tag == "\\code") {

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -148,5 +148,5 @@ test_that("Completion item resolve works", {
     resolve_result <- client %>% respond_completion_item_resolve(items[[1]])
     expect_equal(resolve_result$documentation$kind, "markdown")
     expect_match(resolve_result$documentation$value,
-        "`.Machine` is a variable holding information on the numerical characteristics of the machine is running on")
+        "`.Machine` is a variable holding information on the numerical characteristics of the machine \\*\\*R\\*\\* is running on")
 })


### PR DESCRIPTION
Since primitive functions do have `args()` output, we can provide their signature.