### PR TITLE
Check args in get_signature

### DIFF
--- a/R/document.R
+++ b/R/document.R
@@ -192,7 +192,7 @@ parse_expr <- function(expr, env, level = 0L, srcref = attr(expr, "srcref")) {
                 env$formals[[funct]] <- func[[2L]]
 
                 signature <- func
-                signature <- utils::capture.output(print(signature[1:2]))
+                signature <- format(signature[1:2])
                 signature <- paste0(trimws(signature, which = "left"), collapse = "\n")
                 signature <- trimws(gsub("NULL\\s*$", "", signature))
                 env$signatures[[funct]] <- signature

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -38,9 +38,12 @@ Namespace <- R6::R6Class("Namespace",
             pkgname <- self$package_name
             ns <- asNamespace(pkgname)
             fn <- get(funct, envir = ns)
-            sig <- utils::capture.output(print(args(fn)))
-            sig <- sig[-length(sig)]
-            paste0(trimws(sig, which = "left"), collapse = "\n")
+            args <- args(fn)
+            if (!is.null(args)) {
+                sig <- utils::capture.output(print(args))
+                sig <- sig[-length(sig)]
+                paste0(trimws(sig, which = "left"), collapse = "\n")
+            }
         },
 
         get_formals = function(funct) {

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -40,7 +40,7 @@ Namespace <- R6::R6Class("Namespace",
             fn <- get(funct, envir = ns)
             args <- args(fn)
             if (!is.null(args)) {
-                sig <- utils::capture.output(print(args))
+                sig <- format(args)
                 sig <- sig[-length(sig)]
                 paste0(trimws(sig, which = "left"), collapse = "\n")
             }


### PR DESCRIPTION
Primitive functions like `function` itself has `NULL` args. No need to provide signature for such functions.