### PR TITLE
Store parse_data separately and combine them in GlobalNameSpace

### DIFF
--- a/R/namespace.R
+++ b/R/namespace.R
@@ -126,12 +126,16 @@ GlobalNameSpace <- R6::R6Class("GlobalNameSpace",
             NULL
         },
 
-        update = function(nonfuncts, functs, signatures, formals) {
-            self$nonfuncts <- unique(c(self$nonfuncts, nonfuncts))
-            self$functs <- unique(c(self$functs, functs))
+        update = function(parse_data) {
+            self$nonfuncts <- unique(unlist(lapply(parse_data, "[[", "nonfuncts"), use.names = FALSE))
+            self$functs <- unique(unlist(lapply(parse_data, "[[", "functs"), use.names = FALSE))
             self$exports <- unique(c(self$nonfuncts, self$functs))
-            self$signatures <- merge_list(self$signatures, signatures)
-            self$formals <- merge_list(self$formals, formals)
+            self$signatures <- list()
+            self$formals <- list()
+            for (item in parse_data) {
+                self$signatures <- merge_list(self$signatures, item$signatures)
+                self$formals <- merge_list(self$formals, item$formals)
+            }
         }
     )
 )

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -10,7 +10,7 @@ Workspace <- R6::R6Class("Workspace",
         namespaces = list(),
         definition_cache = NULL,
         documentation = list(),
-        xml_docs = list()
+        parse_data = list()
     ),
     public = list(
         loaded_packages = c(
@@ -196,24 +196,18 @@ Workspace <- R6::R6Class("Workspace",
         },
 
         get_xml_doc = function(uri) {
-            private$xml_docs[[uri]]
+            private$parse_data[[uri]]$xml_doc
         },
 
         update_parse_data = function(uri, parse_data) {
             self$load_packages(parse_data$packages)
-
-            private$global_env$update(
-                parse_data$nonfuncts,
-                parse_data$functs,
-                parse_data$signatures,
-                parse_data$formals
-            )
-            private$definition_cache$update(uri, parse_data$definition_ranges)
-
             if (!is.null(parse_data$xml_data)) {
-                private$xml_docs[[uri]] <- tryCatch(
+                parse_data$xml_doc <- tryCatch(
                     xml2::read_xml(parse_data$xml_data), error = function(e) NULL)
             }
+            private$parse_data[[uri]] <- parse_data
+            private$global_env$update(private$parse_data)
+            private$definition_cache$update(uri, parse_data$definition_ranges)
         }
     )
 )


### PR DESCRIPTION
This PR addresses #58 by modifying the mechanism of populating the global namespace. One extreme is to infinitely expand global namespace (current approach), the other extreme is to provide completion per document. This PR is an attempt to strike a balance so that global namespace is not infinitely expanding but still shares symbols between multiple documents.

The current mechanism merges objects from parse data on each workspace update. Even if a symbol is removed from all documents, the symbol still lives in the global namespace.

Storing `parse_data` of each `uri` separately and combine them on each update will remove symbols that are removed in documents, making global namespace consistent with documents.