### PR TITLE
Fix XPaths to detect assignments

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -168,9 +168,9 @@ scope_completion <- function(uri, workspace, token, position) {
     scope_symbols <- unique(xml_text(xml_find_all(enclosing_scopes, paste(
         "expr[FUNCTION]/SYMBOL_FORMALS",
         "forcond/SYMBOL",
-        "expr/LEFT_ASSIGN[not(following-sibling::expr/FUNCTION)]/preceding-sibling::expr/SYMBOL",
-        "expr/RIGHT_ASSIGN[not(preceding-sibling::expr/FUNCTION)]/following-sibling::expr/SYMBOL",
-        "equal_assign/EQ_ASSIGN[not(following-sibling::expr/FUNCTION)]/preceding-sibling::expr/SYMBOL",
+        "expr/LEFT_ASSIGN[not(following-sibling::expr/FUNCTION)]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+        "expr/RIGHT_ASSIGN[not(preceding-sibling::expr/FUNCTION)]/following-sibling::expr[count(*)=1]/SYMBOL",
+        "equal_assign/EQ_ASSIGN[not(following-sibling::expr/FUNCTION)]/preceding-sibling::expr[count(*)=1]/SYMBOL",
         sep = "|"))))
     scope_symbols <- scope_symbols[startsWith(scope_symbols, token)]
     completions <- c(completions, lapply(scope_symbols, function(symbol) {
@@ -182,9 +182,9 @@ scope_completion <- function(uri, workspace, token, position) {
     }))
 
     scope_functs <- unique(xml_text(xml_find_all(enclosing_scopes, paste(
-        "expr/LEFT_ASSIGN[following-sibling::expr/FUNCTION]/preceding-sibling::expr/SYMBOL",
-        "expr/RIGHT_ASSIGN[preceding-sibling::expr/FUNCTION]/following-sibling::expr/SYMBOL",
-        "equal_assign/EQ_ASSIGN[following-sibling::expr/FUNCTION]/preceding-sibling::expr/SYMBOL",
+        "expr/LEFT_ASSIGN[following-sibling::expr/FUNCTION]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+        "expr/RIGHT_ASSIGN[preceding-sibling::expr/FUNCTION]/following-sibling::expr[count(*)=1]/SYMBOL",
+        "equal_assign/EQ_ASSIGN[following-sibling::expr/FUNCTION]/preceding-sibling::expr[count(*)=1]/SYMBOL",
         sep = "|"))))
     scope_functs <- scope_functs[startsWith(scope_functs, token)]
     completions <- c(completions, lapply(scope_functs, function(symbol) {

--- a/R/definition.R
+++ b/R/definition.R
@@ -38,9 +38,9 @@ definition_reply <- function(id, uri, workspace, document, position) {
                     token_quote <- xml_single_quote(token_text)
                     xpath <- glue(paste(
                         "expr[FUNCTION]/SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {line}]",
-                        "expr[LEFT_ASSIGN/preceding-sibling::expr/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]]",
-                        "expr[RIGHT_ASSIGN/following-sibling::expr/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]]",
-                        "equal_assign[expr[1]/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]]",
+                        "expr[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]]",
+                        "expr[RIGHT_ASSIGN/following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]]",
+                        "equal_assign[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]]",
                         "forcond/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]",
                         sep = "|"))
                     all_defs <- xml_find_all(enclosing_scopes, xpath)

--- a/R/hover.R
+++ b/R/hover.R
@@ -53,9 +53,9 @@ hover_reply <- function(id, uri, workspace, document, position) {
                     token_quote <- xml_single_quote(token_text)
                     xpath <- glue(paste(
                         "expr[FUNCTION and SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {line}]]",
-                        "expr[LEFT_ASSIGN/preceding-sibling::expr/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]]",
-                        "expr[RIGHT_ASSIGN/following-sibling::expr/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]]",
-                        "equal_assign[expr[1]/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]]",
+                        "expr[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]]",
+                        "expr[RIGHT_ASSIGN/following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]]",
+                        "equal_assign[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]]",
                         "forcond/SYMBOL[text() = '{token_quote}' and @line1 <= {line}]",
                         sep = "|"))
                     all_defs <- xml_find_all(enclosing_scopes, xpath)


### PR DESCRIPTION
This PR fixes the issue found at https://github.com/REditorSupport/languageserver/issues/129#issuecomment-565307510.

Now `bar` in the following code can be correctly identified in hover, definition and completion.

```r
bar <- 0
foo$bar <- 1
foo$bar = 1
bar
```
