### PR TITLE
A simple fix of highlight

### DIFF
--- a/R/definition.R
+++ b/R/definition.R
@@ -16,7 +16,6 @@ definition_reply <- function(id, uri, workspace, document, position) {
         line <- position$line + 1
         col <- position$character + 1
         token <- xdoc_find_token(xdoc, line, col)
-        logger$info("definition: ", token)
         if (length(token)) {
             token_name <- xml_name(token)
             token_text <- xml_text(token)

--- a/R/document.R
+++ b/R/document.R
@@ -317,7 +317,7 @@ document_highlight_reply <- function(id, uri, workspace, position) {
                 } else if (token_name %in% c("SYMBOL_SUB", "SLOT")) {
                     # ignore
                 } else {
-                    # highligh tokens with same name and text
+                    # highlight tokens with same name and text
                     xpath <- glue("//{token_name}[text()='{token_quote}']")
                     tokens <- xml_find_all(xdoc, xpath)
                 }


### PR DESCRIPTION
This PR is a simple fix of #129.

Highlight will not be provided for the following cases:

* Symbols following `$` or `@`, e.g. `zoo` in `foo$zoo` and `foo@zoo`.
* Function parameter names, e.g. `foo` in `list(foo = 0, bar = 1)`

I'll probably come back later to improve the semantics of highlight.