### PR TITLE
Preserve parsed data when document parsing fails

### DIFF
--- a/R/document.R
+++ b/R/document.R
@@ -230,28 +230,28 @@ parse_document <- function(path, content = NULL, resolve = FALSE) {
     }
     text <- paste0(content, collapse = "\n")
     expr <- tryCatch(parse(text = text, keep.source = TRUE), error = function(e) NULL)
-    parse_env <- function() {
-        env <- new.env(parent = .GlobalEnv)
-        env$packages <- character()
-        env$nonfuncts <- character()
-        env$functs <- character()
-        env$formals <- list()
-        env$signatures <- list()
-        env$definition_ranges <- list()
-        env$xml_data <- NULL
-        env$xml_doc <- NULL
-        env
-    }
-    env <- parse_env()
-    parse_expr(expr, env)
     if (!is.null(expr)) {
+        parse_env <- function() {
+            env <- new.env(parent = .GlobalEnv)
+            env$packages <- character()
+            env$nonfuncts <- character()
+            env$functs <- character()
+            env$formals <- list()
+            env$signatures <- list()
+            env$definition_ranges <- list()
+            env$xml_data <- NULL
+            env$xml_doc <- NULL
+            env
+        }
+        env <- parse_env()
+        parse_expr(expr, env)
         xml_data <- xmlparsedata::xml_parse_data(expr)
         env$xml_data <- xml_data
+        if (resolve) {
+            env$packages <- resolve_attached_packages(env$packages)
+        }
+        env
     }
-    if (resolve) {
-        env$packages <- resolve_attached_packages(env$packages)
-    }
-    env
 }
 
 

--- a/R/document.R
+++ b/R/document.R
@@ -228,8 +228,7 @@ parse_document <- function(path, content = NULL, resolve = FALSE) {
     if (is_rmarkdown(path)) {
         content <- purl(content)
     }
-    text <- paste0(content, collapse = "\n")
-    expr <- tryCatch(parse(text = text, keep.source = TRUE), error = function(e) NULL)
+    expr <- tryCatch(parse(text = content, keep.source = TRUE), error = function(e) NULL)
     if (!is.null(expr)) {
         parse_env <- function() {
             env <- new.env(parent = .GlobalEnv)


### PR DESCRIPTION
Closes #132.

Now `parse_document` only returns `env` when the document is successfully parsed, or otherwise `NULL` is returned. Then in `parse_callback`, if it receives `NULL` then it wouldn't call `update_parse_data` so that the existing parse data is preserved to provide functionality for the syntactically incorrect document at the moment.