### PR TITLE
break find_unbalanced_bracket when a multiline string is encountered

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -86,6 +86,11 @@ SEXP find_unbalanced_bracket(SEXP content, SEXP _row, SEXP _col, SEXP _skip_el) 
             brac[0] = c[j];
             break;
         }
+        if (i < row && (state.single_quoted || state.double_quoted)) {
+            // do not search further if an unmatched quote is detected
+            i = k = -1;
+            break;
+        }
     }
     SEXP out = PROTECT(Rf_allocVector(VECSXP, 2));
     SEXP loc = PROTECT(Rf_allocVector(INTSXP, 2));


### PR DESCRIPTION
The current implementation will give a false alarm if there is an unbalanced open parenthesis in a multiline string.

```r
"
system.time(
"
|
```
We are being conservation here to prevent false alarm in the case of multiline strings. I reckon that it doesn't affect any daily use because multiline strings are not common, especially inside a function call. Secondly, there is always a better presentation of code.

Instead of
```
foo("
some
multiline
string
")
```
The code should be refactored as
```
SOME="
some
multiline
string
"
foo(SOME)
```