### PR TITLE
Extend Namespace with more detailed categories

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,6 @@ Imports:
     callr (>= 3.0.0),
     collections (>= 0.2.0),
     desc,
-    glue,
     jsonlite,
     lintr (>= 2.0.0),
     R6,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,5 +3,4 @@
 export(run)
 import(xml2)
 importFrom(R6,R6Class)
-importFrom(glue,glue)
 useDynLib(languageserver)

--- a/R/completion.R
+++ b/R/completion.R
@@ -170,6 +170,20 @@ workspace_completion <- function(workspace, token, package = NULL, exported_only
     completions
 }
 
+scope_completion_symbols_xpath <- paste(
+    "FUNCTION/following-sibling::SYMBOL_FORMALS",
+    "forcond/SYMBOL",
+    "expr/LEFT_ASSIGN[not(following-sibling::expr/FUNCTION)]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    "expr/RIGHT_ASSIGN[not(preceding-sibling::expr/FUNCTION)]/following-sibling::expr[count(*)=1]/SYMBOL",
+    "equal_assign/EQ_ASSIGN[not(following-sibling::expr/FUNCTION)]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    sep = "|")
+
+scope_completion_functs_xpath <- paste(
+    "expr/LEFT_ASSIGN[following-sibling::expr/FUNCTION]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    "expr/RIGHT_ASSIGN[preceding-sibling::expr/FUNCTION]/following-sibling::expr[count(*)=1]/SYMBOL",
+    "equal_assign/EQ_ASSIGN[following-sibling::expr/FUNCTION]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    sep = "|")
+
 scope_completion <- function(uri, workspace, token, point) {
     xdoc <- workspace$get_xml_doc(uri)
     if (is.null(xdoc)) {
@@ -180,13 +194,7 @@ scope_completion <- function(uri, workspace, token, point) {
         point$row + 1, point$col + 1)
 
     completions <- list()
-    scope_symbols <- unique(xml_text(xml_find_all(enclosing_scopes, paste(
-        "FUNCTION/following-sibling::SYMBOL_FORMALS",
-        "forcond/SYMBOL",
-        "expr/LEFT_ASSIGN[not(following-sibling::expr/FUNCTION)]/preceding-sibling::expr[count(*)=1]/SYMBOL",
-        "expr/RIGHT_ASSIGN[not(preceding-sibling::expr/FUNCTION)]/following-sibling::expr[count(*)=1]/SYMBOL",
-        "equal_assign/EQ_ASSIGN[not(following-sibling::expr/FUNCTION)]/preceding-sibling::expr[count(*)=1]/SYMBOL",
-        sep = "|"))))
+    scope_symbols <- unique(xml_text(xml_find_all(enclosing_scopes, scope_completion_symbols_xpath)))
     scope_symbols <- scope_symbols[startsWith(scope_symbols, token)]
     completions <- c(completions, lapply(scope_symbols, function(symbol) {
         list(
@@ -196,11 +204,7 @@ scope_completion <- function(uri, workspace, token, point) {
         )
     }))
 
-    scope_functs <- unique(xml_text(xml_find_all(enclosing_scopes, paste(
-        "expr/LEFT_ASSIGN[following-sibling::expr/FUNCTION]/preceding-sibling::expr[count(*)=1]/SYMBOL",
-        "expr/RIGHT_ASSIGN[preceding-sibling::expr/FUNCTION]/following-sibling::expr[count(*)=1]/SYMBOL",
-        "equal_assign/EQ_ASSIGN[following-sibling::expr/FUNCTION]/preceding-sibling::expr[count(*)=1]/SYMBOL",
-        sep = "|"))))
+    scope_functs <- unique(xml_text(xml_find_all(enclosing_scopes, scope_completion_functs_xpath)))
     scope_functs <- scope_functs[startsWith(scope_functs, token)]
     completions <- c(completions, lapply(scope_functs, function(symbol) {
         list(

--- a/R/completion.R
+++ b/R/completion.R
@@ -57,12 +57,12 @@ package_completion <- function(token) {
 
 #' Complete a function argument
 #' @keywords internal
-arg_completion <- function(workspace, token, funct, package = NULL) {
+arg_completion <- function(workspace, token, funct, package = NULL, exported_only = TRUE) {
     if (is.null(package)) {
         package <- workspace$guess_namespace(funct, isf = TRUE)
     }
     if (!is.null(package)) {
-        args <- names(workspace$get_formals(funct, package))
+        args <- names(workspace$get_formals(funct, package, exported_only = exported_only))
         if (is.character(args)) {
             token_args <- args[startsWith(args, token)]
             completions <- lapply(token_args, function(arg) {
@@ -249,7 +249,9 @@ completion_reply <- function(id, uri, workspace, document, point) {
     if (nzchar(call_result$token)) {
         completions <- c(
             completions,
-            arg_completion(workspace, token, call_result$token, call_result$package))
+            arg_completion(workspace, token,
+                call_result$token, call_result$package,
+                exported_only = call_result$accessor != ":::"))
     }
 
     logger$info("completions: ", length(completions))

--- a/R/completion.R
+++ b/R/completion.R
@@ -141,7 +141,7 @@ workspace_completion <- function(workspace, token, package = NULL, exported_only
         ns <- workspace$get_namespace(package)
         if (!is.null(ns)) {
             tag <- paste0("{", package, "}")
-            functs <- ns$unexported_functs[startsWith(ns$unexported_functs, token)]
+            functs <- ns$functs[startsWith(ns$functs, token)]
             functs_completions <- lapply(functs, function(object) {
                 list(label = object,
                      kind = CompletionItemKind$Function,
@@ -151,7 +151,7 @@ workspace_completion <- function(workspace, token, package = NULL, exported_only
                          package = package
                      ))
             })
-            nonfuncts <- ns$unexported_nonfuncts[startsWith(ns$unexported_nonfuncts, token)]
+            nonfuncts <- ns$nonfuncts[startsWith(ns$nonfuncts, token)]
             nonfuncts_completions <- lapply(nonfuncts, function(object) {
                 list(label = object,
                      kind = CompletionItemKind$Field,

--- a/R/completion.R
+++ b/R/completion.R
@@ -97,12 +97,12 @@ workspace_completion <- function(workspace, token, package = NULL, exported_only
             if (is.null(ns)) {
                 next
             }
-            functs <- ns$functs[startsWith(ns$functs, token)]
             if (nsname == WORKSPACE) {
                 tag <- "[workspace]"
             } else {
                 tag <- paste0("{", nsname, "}")
             }
+            functs <- ns$exported_functs[startsWith(ns$exported_functs, token)]
             functs_completions <- lapply(functs, function(object) {
                 list(label = object,
                      kind = CompletionItemKind$Function,
@@ -112,7 +112,7 @@ workspace_completion <- function(workspace, token, package = NULL, exported_only
                          package = nsname
                      ))
             })
-            nonfuncts <- ns$nonfuncts[startsWith(ns$nonfuncts, token)]
+            nonfuncts <- ns$exported_nonfuncts[startsWith(ns$exported_nonfuncts, token)]
             nonfuncts_completions <- lapply(nonfuncts, function(object) {
                 list(label = object,
                      kind = CompletionItemKind$Field,
@@ -140,15 +140,30 @@ workspace_completion <- function(workspace, token, package = NULL, exported_only
     } else {
         ns <- workspace$get_namespace(package)
         if (!is.null(ns)) {
-            unexports <- ns$unexports[startsWith(ns$unexports, token)]
-            unexports_completion <- lapply(unexports, function(object) {
-                list(
-                    label = object,
-                    kind = CompletionItemKind$Field,
-                    detail = paste0("{", package, "}")
-                )
+            tag <- paste0("{", package, "}")
+            functs <- ns$unexported_functs[startsWith(ns$unexported_functs, token)]
+            functs_completions <- lapply(functs, function(object) {
+                list(label = object,
+                     kind = CompletionItemKind$Function,
+                     detail = tag,
+                     data = list(
+                         type = "function",
+                         package = package
+                     ))
             })
-            completions <- c(completions, unexports_completion)
+            nonfuncts <- ns$unexported_nonfuncts[startsWith(ns$unexported_nonfuncts, token)]
+            nonfuncts_completions <- lapply(nonfuncts, function(object) {
+                list(label = object,
+                     kind = CompletionItemKind$Field,
+                     detail = tag,
+                     data = list(
+                         type = "nonfunction",
+                         package = package
+                     ))
+            })
+            completions <- c(completions,
+                functs_completions,
+                nonfuncts_completions)
         }
     }
 

--- a/R/completion.R
+++ b/R/completion.R
@@ -290,14 +290,15 @@ completion_item_resolve_reply <- function(id, workspace, params) {
                 resolved <- TRUE
             }
         } else if (params$data$type == "parameter") {
-            doc <- workspace$get_documentation(params$data$funct, params$data$package)
+            doc <- workspace$get_documentation(params$data$funct, params$data$package, isf = TRUE)
             doc_string <- doc$arguments[[params$label]]
             if (!is.null(doc_string)) {
                 params$documentation <- list(kind = "markdown", value = doc_string)
                 resolved <- TRUE
             }
         } else if (params$data$type %in% c("constant", "function", "nonfunction", "lazydata")) {
-            doc <- workspace$get_documentation(params$label, params$data$package)
+            doc <- workspace$get_documentation(params$label, params$data$package,
+                isf = params$data$type == "function")
             doc_string <- doc$description
             if (!is.null(doc_string)) {
                 params$documentation <- list(kind = "markdown", value = doc_string)

--- a/R/definition.R
+++ b/R/definition.R
@@ -12,7 +12,7 @@ definition_reply <- function(id, uri, workspace, document, point) {
     result <- NULL
 
     xdoc <- workspace$get_xml_doc(uri)
-    if (!is.null(xdoc)) {
+    if (token_result$accessor == "" && !is.null(xdoc)) {
         row <- point$row + 1
         col <- point$col + 1
         token <- xdoc_find_token(xdoc, row, col)

--- a/R/definition.R
+++ b/R/definition.R
@@ -1,3 +1,11 @@
+definition_xpath <- paste(
+    "FUNCTION/following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]",
+    "expr[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
+    "expr[RIGHT_ASSIGN/following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
+    "equal_assign[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
+    "forcond/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]",
+    sep = "|")
+
 #' Get the location of a specified function definition
 #'
 #' If the function is not found in a file but is found in a loaded package,
@@ -27,13 +35,7 @@ definition_reply <- function(id, uri, workspace, document, point) {
                     enclosing_scopes <- xdoc_find_enclosing_scopes(xdoc,
                         row, col, top = TRUE)
                     token_quote <- xml_single_quote(token_text)
-                    xpath <- glue(paste(
-                        "FUNCTION/following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]",
-                        "expr[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
-                        "expr[RIGHT_ASSIGN/following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
-                        "equal_assign[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
-                        "forcond/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]",
-                        sep = "|"))
+                    xpath <- glue(definition_xpath)
                     all_defs <- xml_find_all(enclosing_scopes, xpath)
                     if (length(all_defs)) {
                         last_def <- all_defs[[length(all_defs)]]

--- a/R/definition.R
+++ b/R/definition.R
@@ -35,7 +35,7 @@ definition_reply <- function(id, uri, workspace, document, point) {
                     enclosing_scopes <- xdoc_find_enclosing_scopes(xdoc,
                         row, col, top = TRUE)
                     token_quote <- xml_single_quote(token_text)
-                    xpath <- glue(definition_xpath, token_quote = token_quote, row = row)
+                    xpath <- glue(definition_xpath, row = row, token_quote = token_quote)
                     all_defs <- xml_find_all(enclosing_scopes, xpath)
                     if (length(all_defs)) {
                         last_def <- all_defs[[length(all_defs)]]

--- a/R/definition.R
+++ b/R/definition.R
@@ -59,7 +59,8 @@ definition_reply <- function(id, uri, workspace, document, point) {
     }
 
     if (!resolved) {
-        result <- workspace$get_definition(token_result$token, token_result$package)
+        result <- workspace$get_definition(token_result$token, token_result$package,
+            exported_only = token_result$accessor != ":::")
     }
 
     if (is.null(result)) {

--- a/R/definition.R
+++ b/R/definition.R
@@ -35,7 +35,7 @@ definition_reply <- function(id, uri, workspace, document, point) {
                     enclosing_scopes <- xdoc_find_enclosing_scopes(xdoc,
                         row, col, top = TRUE)
                     token_quote <- xml_single_quote(token_text)
-                    xpath <- glue(definition_xpath)
+                    xpath <- glue(definition_xpath, token_quote = token_quote, row = row)
                     all_defs <- xml_find_all(enclosing_scopes, xpath)
                     if (length(all_defs)) {
                         last_def <- all_defs[[length(all_defs)]]

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -4,6 +4,8 @@ DocumentHighlightKind <- list(
     Write = 3
 )
 
+document_highlight_xpath <- "//*[(self::SYMBOL or self::SYMBOL_FUNCTION_CALL or self::SYMBOL_FORMALS) and not(preceding-sibling::OP-DOLLAR) and text() = '{token_quote}']"
+
 #' The response to a textDocument/documentHighlight Request
 #'
 #' @keywords internal
@@ -27,7 +29,7 @@ document_highlight_reply <- function(id, uri, workspace, document, point) {
                 if (token_name %in% c("SYMBOL", "SYMBOL_FUNCTION_CALL", "SYMBOL_FORMALS")) {
                     preceding_dollar <- xml_find_first(token, "preceding-sibling::OP-DOLLAR")
                     if (length(preceding_dollar) == 0) {
-                        xpath <- glue("//*[(self::SYMBOL or self::SYMBOL_FUNCTION_CALL or self::SYMBOL_FORMALS) and not(preceding-sibling::OP-DOLLAR) and text() = '{token_quote}']")
+                        xpath <- glue(document_highlight_xpath)
                         tokens <- xml_find_all(xdoc, xpath)
                     }
                 } else if (token_name %in% c("SYMBOL_SUB", "SLOT")) {

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -29,14 +29,15 @@ document_highlight_reply <- function(id, uri, workspace, document, point) {
                 if (token_name %in% c("SYMBOL", "SYMBOL_FUNCTION_CALL", "SYMBOL_FORMALS")) {
                     preceding_dollar <- xml_find_first(token, "preceding-sibling::OP-DOLLAR")
                     if (length(preceding_dollar) == 0) {
-                        xpath <- glue(document_highlight_xpath)
+                        xpath <- glue(document_highlight_xpath, token_quote = token_quote)
                         tokens <- xml_find_all(xdoc, xpath)
                     }
                 } else if (token_name %in% c("SYMBOL_SUB", "SLOT")) {
                     # ignore
                 } else {
                     # highlight tokens with same name and text
-                    xpath <- glue("//{token_name}[text()='{token_quote}']")
+                    xpath <- glue("//{token_name}[text()='{token_quote}']",
+                        token_name = token_name, token_quote = token_quote)
                     tokens <- xml_find_all(xdoc, xpath)
                 }
 

--- a/R/hover.R
+++ b/R/hover.R
@@ -81,7 +81,7 @@ hover_reply <- function(id, uri, workspace, document, point) {
                     if (is.na(package)) {
                         package <- NULL
                     }
-                    doc <- workspace$get_documentation(funct, package)
+                    doc <- workspace$get_documentation(funct, package, isf = TRUE)
                     doc_string <- doc$arguments[[token_text]]
                     if (is.null(doc_string)) {
                         doc_string <- doc$arguments$...

--- a/R/hover.R
+++ b/R/hover.R
@@ -1,3 +1,11 @@
+hover_xpath <- paste(
+    "FUNCTION[following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]]/parent::expr",
+    "expr[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
+    "expr[RIGHT_ASSIGN/following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
+    "equal_assign[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
+    "forcond/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]",
+    sep = "|")
+
 #' The response to a textDocument/hover Request
 #'
 #' When hovering on a symbol, if it is a function, return its help text
@@ -44,13 +52,7 @@ hover_reply <- function(id, uri, workspace, document, point) {
                     enclosing_scopes <- xdoc_find_enclosing_scopes(xdoc,
                         row, col, top = TRUE)
                     token_quote <- xml_single_quote(token_text)
-                    xpath <- glue(paste(
-                        "FUNCTION[following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]]/parent::expr",
-                        "expr[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
-                        "expr[RIGHT_ASSIGN/following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
-                        "equal_assign[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
-                        "forcond/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]",
-                        sep = "|"))
+                    xpath <- glue(hover_xpath)
                     all_defs <- xml_find_all(enclosing_scopes, xpath)
                     if (length(all_defs)) {
                         last_def <- all_defs[[length(all_defs)]]

--- a/R/hover.R
+++ b/R/hover.R
@@ -52,7 +52,7 @@ hover_reply <- function(id, uri, workspace, document, point) {
                     enclosing_scopes <- xdoc_find_enclosing_scopes(xdoc,
                         row, col, top = TRUE)
                     token_quote <- xml_single_quote(token_text)
-                    xpath <- glue(hover_xpath, token_quote = token_quote, row = row)
+                    xpath <- glue(hover_xpath, row = row, token_quote = token_quote)
                     all_defs <- xml_find_all(enclosing_scopes, xpath)
                     if (length(all_defs)) {
                         last_def <- all_defs[[length(all_defs)]]

--- a/R/hover.R
+++ b/R/hover.R
@@ -28,7 +28,7 @@ hover_reply <- function(id, uri, workspace, document, point) {
     resolved <- FALSE
     xdoc <- workspace$get_xml_doc(uri)
 
-    if (!is.null(xdoc)) {
+    if (token_result$accessor == "" && !is.null(xdoc)) {
         row <- point$row + 1
         col <- point$col + 1
         token <- xdoc_find_token(xdoc, row, col)
@@ -101,6 +101,9 @@ hover_reply <- function(id, uri, workspace, document, point) {
             } else if (token_name == "SYMBOL_FORMALS") {
                 # function formals
                 # contents <- "function parameter"
+                resolved <- TRUE
+            } else if (token_name == "SLOT") {
+                # S4 slot
                 resolved <- TRUE
             } else if (token_name == "NUM_CONST") {
                 # logical, integer, double

--- a/R/hover.R
+++ b/R/hover.R
@@ -17,7 +17,8 @@ hover_reply <- function(id, uri, workspace, document, point) {
         signs <- token_result$package
     }
 
-    sig <- workspace$get_signature(token_result$token, signs)
+    sig <- workspace$get_signature(token_result$token, signs,
+        exported_only = token_result$accessor != ":::")
     contents <- NULL
 
     if (!is.null(sig)) {

--- a/R/hover.R
+++ b/R/hover.R
@@ -52,14 +52,14 @@ hover_reply <- function(id, uri, workspace, document, point) {
                     enclosing_scopes <- xdoc_find_enclosing_scopes(xdoc,
                         row, col, top = TRUE)
                     token_quote <- xml_single_quote(token_text)
-                    xpath <- glue(hover_xpath)
+                    xpath <- glue(hover_xpath, token_quote = token_quote, row = row)
                     all_defs <- xml_find_all(enclosing_scopes, xpath)
                     if (length(all_defs)) {
                         last_def <- all_defs[[length(all_defs)]]
                         def_funct <- xml_find_first(last_def, "FUNCTION")
                         if (length(def_funct)) {
                             def_funct_end <- xml_find_first(last_def,
-                                glue("SYMBOL_FORMALS[text() = '{token_quote}']"))
+                                glue("SYMBOL_FORMALS[text() = '{token_quote}']", token_quote = token_quote))
                             def_line1 <- as.integer(xml_attr(def_funct, "line1"))
                             def_line2 <- as.integer(xml_attr(def_funct_end, "line2"))
                             def_lines <- seq.int(def_line1, def_line2)

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -1,6 +1,5 @@
 #' @useDynLib languageserver
 #' @importFrom R6 R6Class
-#' @importFrom glue glue
 #' @import xml2
 #' @details
 #' An implementation of the Language Server Protocol for R

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -81,7 +81,7 @@ Namespace <- R6::R6Class("Namespace",
                 uri = path_to_uri(temp_file),
                 range = range(
                     start = position(line = 0, character = 0),
-                    end = position(line = stringr::str_count(code, "\n") + 1, character = 0)
+                    end = position(line = length(code) + 1, character = 0)
                 )
             )
         },
@@ -93,12 +93,12 @@ Namespace <- R6::R6Class("Namespace",
             pkgname <- self$package_name
             ns <- asNamespace(pkgname)
             fn <- get(funct, envir = ns)
-            code <- repr::repr_text(fn)
-            # reorganize the code
-            code <- stringr::str_split(code, "\n")[[1]]
-            # we don't add  `<-` to avoid the parser pasrsing the file
-            # code[1] <- paste(funct, "<-", code[1])
-            paste0(code[!grepl("<bytecode|<environment", code)], collapse = "\n")
+            if (is.primitive(fn)) {
+                code <- utils::capture.output(print(fn))
+            } else {
+                code <- deparse(fn)
+            }
+            code
         },
 
         print = function() {

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -7,11 +7,8 @@ Namespace <- R6::R6Class("Namespace",
         functs = character(0),
         nonfuncts = character(0),
         exports = character(0),
-        unexports = character(0),
         exported_functs = character(0),
         exported_nonfuncts = character(0),
-        unexported_functs = character(0),
-        unexported_nonfuncts = character(0),
         lazydata = character(0),
 
         initialize = function(pkgname) {
@@ -24,11 +21,8 @@ Namespace <- R6::R6Class("Namespace",
             self$functs <- self$objects[is_function]
             self$nonfuncts <- self$objects[!is_function]
             self$exports <- self$objects[is_exported]
-            self$unexports <- self$objects[!is_exported]
             self$exported_functs <- self$objects[is_exported & is_function]
             self$exported_nonfuncts <- self$objects[is_exported & !is_function]
-            self$unexported_functs <- self$objects[!is_exported & is_function]
-            self$unexported_nonfuncts <- self$objects[!is_exported & !is_function]
             self$lazydata <- if (length(ns$.__NAMESPACE__.$lazydata))
                 objects(ns$.__NAMESPACE__.$lazydata) else character()
         },

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -49,8 +49,8 @@ Namespace <- R6::R6Class("Namespace",
             }
         },
 
-        get_signature = function(funct) {
-            if (!self$exists_funct(funct, exported_only = FALSE)) {
+        get_signature = function(funct, exported_only = TRUE) {
+            if (!self$exists_funct(funct, exported_only = exported_only)) {
                 return(NULL)
             }
             pkgname <- self$package_name
@@ -64,8 +64,8 @@ Namespace <- R6::R6Class("Namespace",
             }
         },
 
-        get_formals = function(funct) {
-            if (!self$exists_funct(funct, exported_only = FALSE)) {
+        get_formals = function(funct, exported_only = TRUE) {
+            if (!self$exists_funct(funct, exported_only = exported_only)) {
                 return(NULL)
             }
             pkgname <- self$package_name
@@ -74,8 +74,8 @@ Namespace <- R6::R6Class("Namespace",
             formals(fn)
         },
 
-        get_definition = function(symbol) {
-            code <- self$get_body(symbol)
+        get_definition = function(symbol, exported_only = TRUE) {
+            code <- self$get_body(symbol, exported_only = exported_only)
             if (is.null(code)) {
                 return(NULL)
             }
@@ -92,8 +92,8 @@ Namespace <- R6::R6Class("Namespace",
             )
         },
 
-        get_body = function(funct) {
-            if (!self$exists_funct(funct, exported_only = FALSE)) {
+        get_body = function(funct, exported_only = TRUE) {
+            if (!self$exists_funct(funct, exported_only = exported_only)) {
                 return(NULL)
             }
             pkgname <- self$package_name
@@ -128,19 +128,19 @@ GlobalNameSpace <- R6::R6Class("GlobalNameSpace",
             self$package_name <- WORKSPACE
         },
 
-        get_signature = function(funct) {
+        get_signature = function(funct, exported_only = TRUE) {
             self$signatures[[funct]]
         },
 
-        get_formals = function(funct) {
+        get_formals = function(funct, exported_only = TRUE) {
             self$formals[[funct]]
         },
 
-        get_definition = function(symbol) {
+        get_definition = function(symbol, exported_only = TRUE) {
             NULL
         },
 
-        get_body = function(funct) {
+        get_body = function(funct, exported_only = TRUE) {
             NULL
         },
 

--- a/R/signature.R
+++ b/R/signature.R
@@ -21,7 +21,7 @@ signature_reply <- function(id, uri, workspace, document, point) {
         logger$info("sig: ", sig)
         if (!is.null(sig)) {
             sig <- trimws(gsub("function\\s*", result$token, sig))
-            doc <- workspace$get_documentation(result$token, result$package)
+            doc <- workspace$get_documentation(result$token, result$package, isf = TRUE)
             if (is.null(doc$description)) {
                 documentation <- ""
             } else {

--- a/R/signature.R
+++ b/R/signature.R
@@ -16,7 +16,8 @@ signature_reply <- function(id, uri, workspace, document, point) {
     activeSignature <- -1
 
     if (nzchar(result$token)) {
-        sig <- workspace$get_signature(result$token, result$package)
+        sig <- workspace$get_signature(result$token, result$package,
+            exported_only = result$accessor != ":::")
         logger$info("sig: ", sig)
         if (!is.null(sig)) {
             sig <- trimws(gsub("function\\s*", result$token, sig))

--- a/R/utils.R
+++ b/R/utils.R
@@ -288,21 +288,29 @@ convert_doc_string <- function(doc) {
     paste0(convert_doc_to_markdown(doc), collapse = " ")
 }
 
+glue <- function(.x, ...) {
+    param <- list(...)
+    for (key in names(param)) {
+        .x <- gsub(paste0("{", key, "}"), param[[key]], .x, fixed = TRUE)
+    }
+    .x
+}
+
 xdoc_find_enclosing_scopes <- function(x, line, col, top = FALSE) {
     if (top) {
-        xpath <- glue("/exprlist | //expr[(@line1 < {line} or (@line1 = {line} and @col1 <= {col})) and
-                (@line2 > {line} or (@line2 = {line} and @col2 >= {col}))]")
+        xpath <- "/exprlist | //expr[(@line1 < {line} or (@line1 = {line} and @col1 <= {col})) and
+                (@line2 > {line} or (@line2 = {line} and @col2 >= {col}))]"
     } else {
-        xpath <- glue("//expr[(@line1 < {line} or (@line1 = {line} and @col1 <= {col})) and
-                (@line2 > {line} or (@line2 = {line} and @col2 >= {col}))]")
+        xpath <- "//expr[(@line1 < {line} or (@line1 = {line} and @col1 <= {col})) and
+                (@line2 > {line} or (@line2 = {line} and @col2 >= {col}))]"
     }
+    xpath <- glue(xpath, line = line, col = col)
     xml_find_all(x, xpath)
 }
 
 xdoc_find_token <- function(x, line, col) {
-    xpath <- glue("//*[not(*)]
-    [(@line1 < {line} or (@line1 = {line} and @col1 <= {col})) and
-                (@line2 > {line} or (@line2 = {line} and @col2 >= {col}))]")
+    xpath <- glue("//*[not(*)][(@line1 < {line} or (@line1 = {line} and @col1 <= {col})) and (@line2 > {line} or (@line2 = {line} and @col2 >= {col}))]",
+        line = line, col = col)
     xml_find_first(x, xpath)
 }
 

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -122,9 +122,9 @@ Workspace <- R6::R6Class("Workspace",
             }
         },
 
-        get_documentation = function(topic, pkgname = NULL) {
+        get_documentation = function(topic, pkgname = NULL, isf = FALSE) {
             if (is.null(pkgname)) {
-                pkgname <- self$guess_namespace(topic)
+                pkgname <- self$guess_namespace(topic, isf = isf)
             }
             if (!is.null(pkgname) && pkgname == WORKSPACE) {
                 # no documentation for workspace objects

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -74,7 +74,7 @@ Workspace <- R6::R6Class("Workspace",
             }
         },
 
-        get_signature = function(funct, pkgname = NULL) {
+        get_signature = function(funct, pkgname = NULL, exported_only = TRUE) {
             if (is.null(pkgname)) {
                 pkgname <- self$guess_namespace(funct, isf = TRUE)
                 if (is.null(pkgname)) {
@@ -83,11 +83,11 @@ Workspace <- R6::R6Class("Workspace",
             }
             ns <- self$get_namespace(pkgname)
             if (!is.null(ns)) {
-                ns$get_signature(funct)
+                ns$get_signature(funct, exported_only = exported_only)
             }
         },
 
-        get_formals = function(funct, pkgname = NULL) {
+        get_formals = function(funct, pkgname = NULL, exported_only = TRUE) {
             if (is.null(pkgname)) {
                 pkgname <- self$guess_namespace(funct, isf = TRUE)
                 if (is.null(pkgname)) {
@@ -96,7 +96,7 @@ Workspace <- R6::R6Class("Workspace",
             }
             ns <- self$get_namespace(pkgname)
             if (!is.null(ns)) {
-                ns$get_formals(funct)
+                ns$get_formals(funct, exported_only = exported_only)
             }
         },
 
@@ -169,7 +169,7 @@ Workspace <- R6::R6Class("Workspace",
         },
 
 
-        get_definition = function(symbol, pkgname = NULL) {
+        get_definition = function(symbol, pkgname = NULL, exported_only = TRUE) {
             if (is.null(pkgname)) {
                 # look in global_env
                 definition <- private$definition_cache$get(symbol)
@@ -183,7 +183,7 @@ Workspace <- R6::R6Class("Workspace",
             }
             ns <- self$get_namespace(pkgname)
             if (!is.null(ns)) {
-                ns$get_definition(symbol)
+                ns$get_definition(symbol, exported_only = exported_only)
             }
         },
 


### PR DESCRIPTION
Closes #148 
Closes #150 
Closes #151
Related #125 

This PR:

* Extends `Namespace` to distinguish exports, functions and non-functions to support signature and definition of all functions in packages.
* Extends `:::` to access all objects in a `Namespace` to be consistent with R (`:::` could access both exported and unexported objects except lazydata)
* Fixes definition and hover of `foo::bar` and `foo:::bar` when `bar` is also definied in `GlobalNameSpace`.
* Fixes all `::` and `:::` access in signature, hover, and definition so that `::` is not able to access unexports, and `:::` is able to access all objects.
* Remove `glue` dependency and use a much simplified version with 15x performance.
* Fixes `workspace$get_documentation` to be able to handle name collision.