### PR TITLE
Provide textDocument/onTypeFormatting

### DIFF
--- a/R/capabilities.R
+++ b/R/capabilities.R
@@ -30,8 +30,8 @@ CodeLensOptions <- list(
 )
 
 DocumentOnTypeFormattingOptions <- list(
-    firstTriggerCharacter = NULL,
-    moreTriggerCharacter = NULL
+    firstTriggerCharacter = "\n",
+    moreTriggerCharacter = list(")", "]", "}")
 )
 
 DocumentLinkOptions <- list(
@@ -57,8 +57,8 @@ ServerCapabilities <- list(
     # codeActionProvider = FALSE,
     # codeLensProvider = CodeLensOptions,
     documentFormattingProvider = TRUE,
-    documentRangeFormattingProvider = TRUE
-    # documentOnTypeFormattingProvider = DocumentOnTypeFormattingOptions,
+    documentRangeFormattingProvider = TRUE,
+    documentOnTypeFormattingProvider = DocumentOnTypeFormattingOptions
     # renameProvider = FALSE,
     # documentLinkProvider = DocumentLinkOptions,
     # colorProvider = FALSE,

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -119,3 +119,27 @@ range_formatting_reply <- function(id, uri, document, range, options) {
     TextEditList <- list(TextEdit)
     Response$new(id, TextEditList)
 }
+
+#' Format on type
+#' @keywords internal
+on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
+    if (ch == "\n") {
+        row <- point$row - 1
+    } else {
+        row <- point$row
+    }
+    style <- get_style(options)
+    selection <- document$line0(row)
+    indentation <- stringr::str_extract(selection, "^\\s*")
+    new_text <- style_text(selection, style, indentation = indentation)
+    if (is.null(new_text)) {
+        return(Response$new(id, list()))
+    }
+    range <- range(
+        start = document$to_lsp_position(row = row, col = 0),
+        end = document$to_lsp_position(row = row, col = nchar(document$line0(row)))
+    )
+    TextEdit <- text_edit(range = range, new_text = new_text)
+    TextEditList <- list(TextEdit)
+    Response$new(id, TextEditList)
+}

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -194,7 +194,13 @@ text_document_range_formatting  <- function(self, id, params) {
 #' Handler to the `textDocument/onTypeFormatting` [Request].
 #' @keywords internal
 text_document_on_type_formatting  <- function(self, id, params) {
-
+    textDocument <- params$textDocument
+    uri <- textDocument$uri
+    document <- self$documents[[uri]]
+    point <- document$from_lsp_position(params$position)
+    ch <- params$ch
+    options <- params$options
+    self$deliver(on_type_formatting_reply(id, uri, document, point, ch, options))
 }
 
 

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -172,6 +172,7 @@ LanguageServer$set("public", "register_handlers", function() {
         `textDocument/signatureHelp` = text_document_signature_help,
         `textDocument/formatting` = text_document_formatting,
         `textDocument/rangeFormatting` = text_document_range_formatting,
+        `textDocument/onTypeFormatting` = text_document_on_type_formatting,
         `textDocument/documentSymbol` = text_document_document_symbol,
         `textDocument/documentHighlight` = text_document_document_highlight,
         `workspace/symbol` = workspace_symbol

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ These editors are supported by installing the corresponding package.
 - [ ] codeLensProvider
 - [x] documentFormattingProvider
 - [x] documentRangeFormattingProvider
-- [ ] documentOnTypeFormattingProvider
+- [x] documentOnTypeFormattingProvider
 - [ ] renameProvider
 - [ ] documentLinkProvider
 - [ ] executeCommandProvider


### PR DESCRIPTION
This PR is an initial attempt to handling `textDocument/onTypeFormatting` as suggested in #152.

As a starting point, only single line of code is formatted at the moment.

I test this while I'm editing large scripts and the performance is good.
