### PR TITLE
Update README.md: add JupyterLab client

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ These editors are supported by installing the corresponding package.
             :server-id 'lsp-R))
     ```
 
+- JupyterLab: [jupyterlab-lsp](https://github.com/krassowski/jupyterlab-lsp)
+
 ## Services Implemented
 
 `languageserver` is still under active development, the following services have been implemented:


### PR DESCRIPTION
Thank you for this precious language server (it became a necessity)! Please consider this update to readme which adds a link to our jupterlab-lsp extension so that they can start using this server with JupyterLab smoothly (or disregard if you think that it does not fit here - I understand that this might be a list of editors that you intend to support, rather than of all clients which support this language server).

Note: we provide automatic configuration, so no config is required.