### PR TITLE
Code section support

### DIFF
--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -102,7 +102,8 @@ text_document_document_symbol  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
     document <- self$documents[[uri]]
-    self$deliver(document_symbol_reply(id, uri, self$workspace, document))
+    self$deliver(document_symbol_reply(id, uri, self$workspace, document,
+        self$ClientCapabilities$textDocument$documentSymbol))
 }
 
 #' `textDocument/codeAction` request handler

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -101,7 +101,8 @@ text_document_document_highlight  <- function(self, id, params) {
 text_document_document_symbol  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
-    self$deliver(document_symbol_reply(id, uri, self$workspace))
+    document <- self$documents[[uri]]
+    self$deliver(document_symbol_reply(id, uri, self$workspace, document))
 }
 
 #' `textDocument/codeAction` request handler

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -43,28 +43,31 @@ document_symbol_reply <- function(id, uri, workspace, document) {
             )
     })
 
+    section_symbols <- NULL
     section_lines <- seq_len(document$nline)
     section_lines <- section_lines[startsWith(document$content, "#")]
     section_lines <- section_lines[
         grep("^\\#+\\s*(.+)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
             document$content[section_lines])]
-    section_names <- trimws(gsub("^\\#+\\s*(.+)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
-        "\\1", document$content[section_lines]))
     logger$info("document sections found: ", length(section_lines))
-    section_end_lines <- c(section_lines[-1] - 1, document$nline)
-    section_symbols <- .mapply(function(name, start_line, end_line) {
-        symbol_information(
-            name = name,
-            kind = SymbolKind$String,
-            location = list(
-                uri = uri,
-                range = range(
-                    start = document$to_lsp_position(row = start_line - 1, col = 0),
-                    end = document$to_lsp_position(row = end_line - 1, col = nchar(document$line(end_line)))
+    if (length(section_lines)) {
+        section_names <- trimws(gsub("^\\#+\\s*(.+)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
+            "\\1", document$content[section_lines]))
+        section_end_lines <- c(section_lines[-1] - 1, document$nline)
+        section_symbols <- .mapply(function(name, start_line, end_line) {
+            symbol_information(
+                name = name,
+                kind = SymbolKind$String,
+                location = list(
+                    uri = uri,
+                    range = range(
+                        start = document$to_lsp_position(row = start_line - 1, col = 0),
+                        end = document$to_lsp_position(row = end_line - 1, col = nchar(document$line(end_line)))
+                    )
                 )
             )
-        )
-    }, list(section_names, section_lines, section_end_lines), NULL)
+        }, list(section_names, section_lines, section_end_lines), NULL)
+    }
 
     result <- c(definition_symbols, section_symbols)
 


### PR DESCRIPTION
Closes https://github.com/REditorSupport/languageserver/issues/160
Closes https://github.com/Ikuyadeu/vscode-R/issues/76
Closes https://github.com/Ikuyadeu/vscode-R/pull/193

This PR is a simple support of code section using DocumentSymbolProvider. It matches all commend lines that starts with # and ends with at least four #, +, -, = and show the string in-between as symbol.

This also addresses the comment at https://github.com/Ikuyadeu/vscode-R/issues/76#issuecomment-575969263 by using unified document symbol provider (all in languageserver), and the symbol information of each code section starts from the first line and ends before the next code section so that a hierarchy of code section containing symbol definitions can be presented.

Following is a screenshot in VSCode:

<img width="633" alt="image" src="https://user-images.githubusercontent.com/4662568/72678086-90381780-3add-11ea-9e93-0d7a4d1c1882.png">
