### PR TITLE
Change separator between param and doc string in hover

### DIFF
--- a/R/hover.R
+++ b/R/hover.R
@@ -100,7 +100,7 @@ hover_reply <- function(id, uri, workspace, document, point) {
                             sig <- stringr::str_trunc(sig, 300)
                             contents <- c(
                                 sprintf("```r\n%s\n```", sig),
-                                sprintf("`%s`: %s", token_text, doc_string))
+                                sprintf("`%s` — %s", token_text, doc_string))
                         }
                     }
                     resolved <- TRUE


### PR DESCRIPTION
Originally, we use the following format in the hover of a function parameter.

```
`param`: doc string
```

It seems to look better if we change `:` to `—` which is used by TypeScript LSP in VSCode in function parameter hover:

```
`param` — doc string
```

Before

<img width="670" alt="image" src="https://user-images.githubusercontent.com/4662568/73195605-1fda6780-4169-11ea-90d2-41aca8af3d43.png">

After

<img width="670" alt="image" src="https://user-images.githubusercontent.com/4662568/73195520-f4577d00-4168-11ea-8c99-fe28df4a386e.png">

