### PR TITLE
Implement DocumentLinkProvider

### DIFF
--- a/R/capabilities.R
+++ b/R/capabilities.R
@@ -58,9 +58,9 @@ ServerCapabilities <- list(
     # codeLensProvider = CodeLensOptions,
     documentFormattingProvider = TRUE,
     documentRangeFormattingProvider = TRUE,
-    documentOnTypeFormattingProvider = DocumentOnTypeFormattingOptions
+    documentOnTypeFormattingProvider = DocumentOnTypeFormattingOptions,
     # renameProvider = FALSE,
-    # documentLinkProvider = DocumentLinkOptions,
+    documentLinkProvider = DocumentLinkOptions
     # colorProvider = FALSE,
     # foldingRangeProvider = FALSE,
     # executeCommandProvider = ExecuteCommandOptions,

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -134,32 +134,11 @@ code_lens_resolve  <- function(self, id, params) {
 #' Handler to the `textDocument/documentLink` [Request].
 #' @keywords internal
 text_document_document_link  <- function(self, id, params) {
-    xdoc <- self$workspace$get_xml_doc(params$textDocument$uri)
-    if (!is.null(xdoc)) {
-        str_tokens <- xml_find_all(xdoc, "//STR_CONST[@line1=@line2 and @col2 > @col1 + 1]")
-        str_texts <- xml_text(str_tokens)
-        str_texts <- substr(str_texts, 2, nchar(str_texts) - 1)
-        paths <- file.path(self$rootPath, str_texts)
-        sel <- file.exists(paths)
-        str_tokens <- str_tokens[sel]
-        str_texts <- str_texts[sel]
-        str_line1 <- as.integer(xml_attr(str_tokens, "line1"))
-        str_col1 <- as.integer(xml_attr(str_tokens, "col1"))
-        str_col2 <- as.integer(xml_attr(str_tokens, "col2"))
-        uris <- file.path(self$rootUri, str_texts)
-        links <- .mapply(function(line, col1, col2, uri) {
-            list(
-                range = range(
-                    start = position(line - 1, col1),
-                    end = position(line - 1, col2 - 1)
-                ),
-                target = uri
-            )
-        }, list(str_line1, str_col1, str_col2, uris), NULL)
-        self$deliver(Response$new(id, result = links))
-    } else {
-        self$deliver(Response$new(id))
-    }
+    textDocument <- params$textDocument
+    uri <- textDocument$uri
+    document <- self$documents[[uri]]
+    self$deliver(document_link_reply(id, uri, self$workspace,
+        document, self$rootPath, self$rootUri))
 }
 
 #' `documentLink/resolve` request handler

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -179,6 +179,7 @@ LanguageServer$set("public", "register_handlers", function() {
         `textDocument/onTypeFormatting` = text_document_on_type_formatting,
         `textDocument/documentSymbol` = text_document_document_symbol,
         `textDocument/documentHighlight` = text_document_document_highlight,
+        `textDocument/documentLink` = text_document_document_link,
         `workspace/symbol` = workspace_symbol
     )
 

--- a/R/link.R
+++ b/R/link.R
@@ -1,0 +1,36 @@
+#' The response to a textDocument/documentLink Request
+#'
+#' @keywords internal
+document_link_reply <- function(id, uri, workspace, document, rootPath, rootUri) {
+    result <- NULL
+
+    xdoc <- workspace$get_xml_doc(uri)
+    if (!is.null(xdoc)) {
+        str_tokens <- xml_find_all(xdoc, "//STR_CONST[@line1=@line2 and @col2 > @col1 + 1]")
+        str_texts <- xml_text(str_tokens)
+        str_texts <- substr(str_texts, 2, nchar(str_texts) - 1)
+        paths <- file.path(rootPath, str_texts)
+        sel <- file.exists(paths)
+        str_tokens <- str_tokens[sel]
+        str_texts <- str_texts[sel]
+        str_line1 <- as.integer(xml_attr(str_tokens, "line1"))
+        str_col1 <- as.integer(xml_attr(str_tokens, "col1"))
+        str_col2 <- as.integer(xml_attr(str_tokens, "col2"))
+        uris <- file.path(rootUri, str_texts)
+        result <- .mapply(function(line, col1, col2, uri) {
+            list(
+                range = range(
+                    start = document$to_lsp_position(line - 1, col1),
+                    end = document$to_lsp_position(line - 1, col2 - 1)
+                ),
+                target = uri
+            )
+        }, list(str_line1, str_col1, str_col2, uris), NULL)
+    }
+
+    if (is.null(result)) {
+      Response$new(id)
+    } else {
+      Response$new(id, result = result)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ These editors are supported by installing the corresponding package.
 - [x] documentRangeFormattingProvider
 - [x] documentOnTypeFormattingProvider
 - [ ] renameProvider
-- [ ] documentLinkProvider
+- [x] documentLinkProvider
 - [ ] executeCommandProvider
 
 ## Settings


### PR DESCRIPTION
This PR implements `documentLinkProvider` using `STR_CONST` tokens provided by XML parsed document.

<img width="444" alt="image" src="https://user-images.githubusercontent.com/4662568/73524149-7e446600-4447-11ea-84a8-9fe152df7562.png">

