### PR TITLE
Add version to Document and parse_data

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -197,7 +197,7 @@ scope_completion_functs_xpath <- paste(
     sep = "|")
 
 scope_completion <- function(uri, workspace, token, point) {
-    xdoc <- workspace$get_xml_doc(uri)
+    xdoc <- workspace$get_parse_data(uri)$xml_doc
     if (is.null(xdoc)) {
         return(list())
     }

--- a/R/definition.R
+++ b/R/definition.R
@@ -19,7 +19,7 @@ definition_reply <- function(id, uri, workspace, document, point) {
     resolved <- FALSE
     result <- NULL
 
-    xdoc <- workspace$get_xml_doc(uri)
+    xdoc <- workspace$get_parse_data(uri)$xml_doc
     if (token_result$accessor == "" && !is.null(xdoc)) {
         row <- point$row + 1
         col <- point$col + 1

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -91,9 +91,9 @@ diagnose_file <- function(path, content = NULL) {
 }
 
 
-diagnostics_callback <- function(self, uri, diagnostics) {
+diagnostics_callback <- function(self, uri, version, diagnostics) {
     if (is.null(diagnostics)) return(NULL)
-    logger$info("diagnostics_callback called")
+    logger$info("diagnostics_callback called:", list(uri = uri, version = version))
     self$deliver(
         Notification$new(
             method = "textDocument/publishDiagnostics",
@@ -106,7 +106,7 @@ diagnostics_callback <- function(self, uri, diagnostics) {
 }
 
 
-diagnostics_task <- function(self, uri, document) {
+diagnostics_task <- function(self, uri, version, document) {
     if (is.null(document)) {
         content <- NULL
     } else {
@@ -115,5 +115,5 @@ diagnostics_task <- function(self, uri, document) {
     create_task(
         diagnose_file,
         list(path = path_from_uri(uri), content = content),
-        callback = function(result) diagnostics_callback(self, uri, result))
+        callback = function(result) diagnostics_callback(self, uri, version, result))
 }

--- a/R/document.R
+++ b/R/document.R
@@ -2,19 +2,22 @@ Document <- R6::R6Class(
     "Document",
     public = list(
         uri = NULL,
+        version = 0,
         nline = 0,
         content = NULL,
         is_rmarkdown = NULL,
 
-        initialize = function(uri, content = NULL) {
+        initialize = function(uri, version, content = NULL) {
             self$uri <- uri
+            self$version <- version
             self$is_rmarkdown <- is_rmarkdown(self$uri)
             if (!is.null(content)) {
-                self$set(content)
+                self$set(version, content)
             }
         },
 
-        set = function(content) {
+        set = function(version, content) {
+            self$version <- version
             # remove last empty line
             nline <- length(content)
             if (nline > 0L && !nzchar(content[nline])) {
@@ -275,14 +278,14 @@ parse_document <- function(path, content = NULL, resolve = FALSE) {
 }
 
 
-parse_callback <- function(self, uri, parse_data) {
+parse_callback <- function(self, uri, version, parse_data) {
     if (is.null(parse_data)) return(NULL)
-    logger$info("parse_callback called")
+    logger$info("parse_callback called:", list(uri = uri, version = version))
+    parse_data$version <- version
     self$workspace$update_parse_data(uri, parse_data)
 }
 
-
-parse_task <- function(self, uri, document, resolve = FALSE) {
+parse_task <- function(self, uri, version, document, resolve = FALSE) {
     if (is.null(document)) {
         content <- NULL
     } else {
@@ -291,5 +294,5 @@ parse_task <- function(self, uri, document, resolve = FALSE) {
     create_task(
         parse_document,
         list(path = path_from_uri(uri), content = content, resolve = resolve),
-        callback = function(result) parse_callback(self, uri, result))
+        callback = function(result) parse_callback(self, uri, version, result))
 }

--- a/R/handlers-textsync.R
+++ b/R/handlers-textsync.R
@@ -5,13 +5,15 @@
 text_document_did_open <- function(self, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
+    version <- textDocument$version
+    logger$info("did open:", list(uri = uri, version = version))
     content <- readr::read_lines(path_from_uri(uri))
     if (is.null(self$documents[[uri]])) {
-        self$documents[[uri]] <- Document$new(uri, content)
+        self$documents[[uri]] <- Document$new(uri, version, content)
     } else {
-        self$documents[[uri]]$set(content)
+        self$documents[[uri]]$set(version, content)
     }
-    self$text_sync(uri, document = NULL, run_lintr = TRUE, parse = TRUE, resolve = TRUE)
+    self$text_sync(uri, version = version, document = NULL, run_lintr = TRUE, parse = TRUE, resolve = TRUE)
 }
 
 #' `textDocument/didChange` notification handler
@@ -23,16 +25,17 @@ text_document_did_change <- function(self, params) {
     contentChanges <- params$contentChanges
     text <- contentChanges[[1]]$text
     uri <- textDocument$uri
-    logger$info("did change: ", uri)
+    version <- textDocument$version
+    logger$info("did change:", list(uri = uri, version = version))
     content <- stringr::str_split(text, "\r\n|\n")[[1]]
     if (is.null(self$documents[[uri]])) {
-        doc <- Document$new(uri, content)
+        doc <- Document$new(uri, version, content)
         self$documents[[uri]] <- doc
     } else {
-        self$documents[[uri]]$set(content)
+        self$documents[[uri]]$set(version, content)
         doc <- self$documents[[uri]]
     }
-    self$text_sync(uri, document = doc, run_lintr = TRUE, parse = TRUE, resolve = FALSE)
+    self$text_sync(uri, version = version, document = doc, run_lintr = TRUE, parse = TRUE, resolve = FALSE)
 }
 
 #' `textDocument/willSave` notification handler
@@ -50,10 +53,11 @@ text_document_will_save <- function(self, params) {
 text_document_did_save <- function(self, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
-    logger$info("did save:", uri)
+    version <- textDocument$version
+    logger$info("did save:", list(uri = uri, version = version))
     content <- readr::read_lines(path_from_uri(uri))
-    self$documents[[uri]] <- Document$new(uri, content)
-    self$text_sync(uri, document = NULL, run_lintr = TRUE, parse = TRUE, resolve = TRUE)
+    self$documents[[uri]] <- Document$new(uri, version, content)
+    self$text_sync(uri, version = version, document = NULL, run_lintr = TRUE, parse = TRUE, resolve = TRUE)
 }
 
 #' `textDocument/didClose` notification handler

--- a/R/highlight.R
+++ b/R/highlight.R
@@ -11,7 +11,7 @@ document_highlight_xpath <- "//*[(self::SYMBOL or self::SYMBOL_FUNCTION_CALL or 
 #' @keywords internal
 document_highlight_reply <- function(id, uri, workspace, document, point) {
     result <- NULL
-    xdoc <- workspace$get_xml_doc(uri)
+    xdoc <- workspace$get_parse_data(uri)$xml_doc
     if (!is.null(xdoc)) {
         row <- point$row + 1
         col <- point$col + 1

--- a/R/hover.R
+++ b/R/hover.R
@@ -29,7 +29,11 @@ hover_reply <- function(id, uri, workspace, document, point) {
         exported_only = token_result$accessor != ":::")
     contents <- NULL
     resolved <- FALSE
-    xdoc <- workspace$get_xml_doc(uri)
+
+    version <- workspace$get_parse_data(uri)$version
+    logger$info("hover:", list(uri = uri, version = version))
+
+    xdoc <- workspace$get_parse_data(uri)$xml_doc
 
     if (token_result$accessor == "" && !is.null(xdoc)) {
         row <- point$row + 1

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -76,22 +76,22 @@ LanguageServer <- R6::R6Class("LanguageServer",
         },
 
         text_sync = function(
-                uri, document = NULL, run_lintr = FALSE, parse = FALSE, resolve = FALSE) {
+                uri, version, document = NULL, run_lintr = FALSE, parse = FALSE, resolve = FALSE) {
             if (run_lintr && self$run_lintr) {
                 self$diagnostics_task_manager$add_task(
                     uri,
-                    diagnostics_task(self, uri, document)
+                    diagnostics_task(self, uri, version, document)
                 )
             }
             if (resolve) {
                 self$resolve_task_manager$add_task(
                     uri,
-                    parse_task(self, uri, document, resolve = TRUE)
+                    parse_task(self, uri, version, document, resolve = TRUE)
                 )
             } else if (parse) {
                 self$parse_task_manager$add_task(
                     uri,
-                    parse_task(self, uri, document, resolve = FALSE)
+                    parse_task(self, uri, version, document, resolve = FALSE)
                 )
             }
         },

--- a/R/link.R
+++ b/R/link.R
@@ -4,7 +4,7 @@
 document_link_reply <- function(id, uri, workspace, document, rootPath, rootUri) {
     result <- NULL
 
-    xdoc <- workspace$get_xml_doc(uri)
+    xdoc <- workspace$get_parse_data(uri)$xml_doc
     if (!is.null(xdoc)) {
         str_tokens <- xml_find_all(xdoc, "//STR_CONST[@line1=@line2 and @col2 > @col1 + 1]")
         str_texts <- xml_text(str_tokens)

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -194,8 +194,8 @@ Workspace <- R6::R6Class("Workspace",
             private$definition_cache$filter(query)
         },
 
-        get_xml_doc = function(uri) {
-            private$parse_data[[uri]]$xml_doc
+        get_parse_data = function(uri) {
+            private$parse_data[[uri]]
         },
 
         update_parse_data = function(uri, parse_data) {


### PR DESCRIPTION
Related to #173 

`Document` and `parse_data` now got `version` so that the sync state (or consistency) could be checked.

When document is open (`textDocument/didOpen`) or modified (`text_document_did_change`), `Document$version` will be updated. A while later when parse task is finished, `parse_data$version` will be updated to `Document$version`. Before parse callback, there would be `Document$version > parse_data$version` so that providers could know that `parse_data` is out-of-sync.