### PR TITLE
Fix handling empty input of path_from_uri and path_to_uri

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -10,8 +10,8 @@ merge_list <- function(x, y) {
 #' Paths and uris
 #' @keywords internal
 path_from_uri <- function(uri) {
-    if (is.null(uri)) {
-        return(NULL)
+    if (length(uri) == 0) {
+        return(character())
     }
     start_char <- if (.Platform$OS.type == "windows") 9 else 8
     utils::URLdecode(substr(uri, start_char, nchar(uri)))
@@ -21,8 +21,8 @@ path_from_uri <- function(uri) {
 #' @keywords internal
 #' @rdname path_from_uri
 path_to_uri <- function(path) {
-    if (is.null(path)) {
-        return(NULL)
+    if (length(path) == 0) {
+        return(character())
     }
     prefix <- if (.Platform$OS.type == "windows") "file:///" else "file://"
     paste0(prefix, utils::URLencode(path))


### PR DESCRIPTION
Closes #178 

The error is caused by `path_from_uri` and `path_to_uri` not working with `character(0)` input.
Both functions are fixed by checking if input `path` or `uri` has zero length. If so, an empty character vector is returned, which is consistent with the behavior of `file.path`:

```r
file.path(NULL)
file.path(character(0))
```

both return `character(0)`.