### PR TITLE
Use tryCatchStack to caputure stack on error

### DIFF
--- a/R/languagebase.R
+++ b/R/languagebase.R
@@ -114,7 +114,8 @@ LanguageBase <- R6::R6Class("LanguageBase",
 
         handle_raw = function(data) {
             payload <- tryCatchStack(
-                jsonlite::fromJSON(data, simplifyVector = FALSE)
+                jsonlite::fromJSON(data, simplifyVector = FALSE),
+                error = function(e) e
             )
             if (inherits(payload, "error")) {
                 logger$error("error handling json: ", payload)

--- a/R/languagebase.R
+++ b/R/languagebase.R
@@ -113,13 +113,11 @@ LanguageBase <- R6::R6Class("LanguageBase",
         },
 
         handle_raw = function(data) {
-            payload <- tryCatch(
-                jsonlite::fromJSON(data, simplifyVector = FALSE),
-                error = function(e) e
+            payload <- tryCatchStack(
+                jsonlite::fromJSON(data, simplifyVector = FALSE)
             )
             if (inherits(payload, "error")) {
                 logger$error("error handling json: ", payload)
-                logger$error("traceback:", as.list(traceback()))
                 return(NULL)
             }
             pl_names <- names(payload)
@@ -141,13 +139,12 @@ LanguageBase <- R6::R6Class("LanguageBase",
             params <- request$params
             if (method %in% names(self$request_handlers)) {
                 logger$info("handling request: ", method)
-                tryCatch({
+                tryCatchStack({
                     dispatch <- self$request_handlers[[method]]
                     dispatch(self, id, params)
                 },
                 error = function(e) {
                     logger$info("internal error:", e)
-                    logger$info("traceback:", as.list(traceback()))
                     self$deliver(ResponseErrorMessage$new(id, "InternalError", to_string(e)))
                 }
                 )
@@ -164,13 +161,12 @@ LanguageBase <- R6::R6Class("LanguageBase",
             params <- notification$params
             if (method %in% names(self$notification_handlers)) {
                 logger$info("handling notification: ", method)
-                tryCatch({
+                tryCatchStack({
                     dispatch <- self$notification_handlers[[method]]
                     dispatch(self, params)
                 },
                 error = function(e) {
                     logger$info("internal error:", e)
-                    logger$info("traceback:", as.list(traceback()))
                 }
                 )
             } else {
@@ -186,11 +182,10 @@ LanguageBase <- R6::R6Class("LanguageBase",
             )
             if ("error" %in% names(response)) {
                 logger$info("internal error:", response$error)
-                logger$info("traceback:", as.list(traceback()))
             } else if (!is.null(callback)) {
                 logger$info("calling callback")
                 if (self$catch_callback_error) {
-                    tryCatch(
+                    tryCatchStack(
                         callback(self, response$result),
                         error = function(e) logger$info("callback error: ", e)
                     )

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -151,7 +151,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
                         next
                     }
                     self$handle_raw(data)
-                }, error = identity)
+                }, error = function(e) e)
                 if (inherits(ret, "error")) {
                     logger$error(ret)
                     logger$error("exiting")

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -137,7 +137,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
 
         run = function() {
             while (TRUE) {
-                ret <- try({
+                ret <- tryCatchStack({
                     if (isTRUE(self$exit_flag)) {
                         logger$info("exiting")
                         break
@@ -151,12 +151,9 @@ LanguageServer <- R6::R6Class("LanguageServer",
                         next
                     }
                     self$handle_raw(data)
-                },
-                silent = TRUE
-                )
-                if (inherits(ret, "try-error")) {
+                }, error = identity)
+                if (inherits(ret, "error")) {
                     logger$error(ret)
-                    logger$error(as.list(traceback()))
                     logger$error("exiting")
                     break
                 }

--- a/R/log.R
+++ b/R/log.R
@@ -8,20 +8,18 @@ to_string <- function(...) {
     if (length(dots) > 0) {
         str <- vapply(
             dots, function(x) {
-                if (is.atomic(x) || is.list(x)) {
+                if (inherits(x, "error")) {
+                    capture_print(x)
+                } else if (is.atomic(x) || is.list(x)) {
                     if (is.list(x) || length(x) > 1) {
-                        tryCatch(jsonlite::toJSON(x, auto_unbox = TRUE, force = TRUE),
-                            error = function(e) {
-                                paste0(e$message, utils::capture.output(print(x)), collapse = "\n")
-                            }
-                        )
+                        jsonlite::toJSON(x, auto_unbox = TRUE, force = TRUE, pretty = TRUE)
                     } else if (length(x) == 1) {
                         as.character(x)
                     } else {
                         ""
                     }
                 } else {
-                    paste0(utils::capture.output(print(x)), collapse = "\n")
+                    capture_print(x)
                 }
             }, character(1L), USE.NAMES = FALSE
         )

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,6 +6,22 @@ merge_list <- function(x, y) {
   x
 }
 
+#' tryCatch with stack captured
+#'
+#' @keywords internal
+tryCatchStack <- function(expr, ...) {
+  expr <- substitute(expr)
+  env <- parent.frame()
+  capture_calls <- function(e) {
+    calls <- sys.calls()
+    ncalls <- length(calls)
+    e$calls <- c(calls[-c(seq_len(frame + 7), ncalls - 1, ncalls)], e$call)
+    e$calls <- lapply(e$calls, deparse)
+    signalCondition(e)
+  }
+  frame <- sys.nframe()
+  tryCatch(withCallingHandlers(eval(expr, env), error = capture_calls), ...)
+}
 
 #' Paths and uris
 #' @keywords internal

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,11 +16,25 @@ tryCatchStack <- function(expr, ...) {
     calls <- sys.calls()
     ncalls <- length(calls)
     e$calls <- c(calls[-c(seq_len(frame + 7), ncalls - 1, ncalls)], e$call)
-    e$calls <- lapply(e$calls, deparse)
+    class(e) <- c("errorWithStack", class(e))
     signalCondition(e)
   }
   frame <- sys.nframe()
   tryCatch(withCallingHandlers(eval(expr, env), error = capture_calls), ...)
+}
+
+print.errorWithStack <- function(x, ...) {
+  cat("Error: ", conditionMessage(x), "\n", sep = "")
+  cat("Stack trace:\n")
+  rev_calls <- rev(x$calls)
+  for (i in seq_along(rev_calls)) {
+    cat(i, ": ", sep = "")
+    print(rev_calls[[i]])
+  }
+}
+
+capture_print <- function(x) {
+    paste0(utils::capture.output(print(x)), collapse = "\n")
 }
 
 #' Paths and uris


### PR DESCRIPTION
Closes #180 

This PR:

* Implements `tryCatchStack(expr, ...)` which is an enhanced version of `tryCatch(expr, ...)` to also capture stack trace on error.
* Replace all `traceback()` calls (which do not work with caught error) with `tryCatchStack` so that the logging could properly show the calling stack on error.

Now the error logging includes a stack trace like the following:

<img width="517" alt="image" src="https://user-images.githubusercontent.com/4662568/73609331-7a5f4200-4607-11ea-8c0c-71bb448dc689.png">

It makes it much easier to track down the error.