### PR TITLE
Reply documentSymbol and documentLink when document parsed

### DIFF
--- a/R/document.R
+++ b/R/document.R
@@ -283,6 +283,24 @@ parse_callback <- function(self, uri, version, parse_data) {
     logger$info("parse_callback called:", list(uri = uri, version = version))
     parse_data$version <- version
     self$workspace$update_parse_data(uri, parse_data)
+
+    pending_replies <- self$pending_replies[[uri]]
+    for (name in names(pending_replies)) {
+        queue <- pending_replies[[name]]
+        handler <- self$request_handlers[[name]]
+        while (queue$size()) {
+            item <- queue$peek()
+            if (item$version < version) {
+                self$deliver(Response$new(item$id))
+                queue$pop()
+            } else if (item$version == version) {
+                handler(self, item$id, item$params)
+                queue$pop()
+            } else {
+                break
+            }
+        }
+    }
 }
 
 parse_task <- function(self, uri, version, document, resolve = FALSE) {

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -102,8 +102,18 @@ text_document_document_symbol  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
     document <- self$documents[[uri]]
-    self$deliver(document_symbol_reply(id, uri, self$workspace, document,
-        self$ClientCapabilities$textDocument$documentSymbol))
+    reply <- document_symbol_reply(id, uri, self$workspace, document,
+        self$ClientCapabilities$textDocument$documentSymbol)
+    if (is.null(reply)) {
+        queue <- self$pending_replies[[uri]][["textDocument/documentSymbol"]]
+        queue$push(list(
+            id = id,
+            version = document$version,
+            params = params
+        ))
+    } else {
+        self$deliver(reply)
+    }
 }
 
 #' `textDocument/codeAction` request handler
@@ -139,7 +149,17 @@ text_document_document_link  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
     document <- self$documents[[uri]]
-    self$deliver(document_link_reply(id, uri, self$workspace, document, self$rootUri))
+    reply <- document_link_reply(id, uri, self$workspace, document, self$rootUri)
+    if (is.null(reply)) {
+        queue <- self$pending_replies[[uri]][["textDocument/documentLink"]]
+        queue$push(list(
+            id = id,
+            version = document$version,
+            params = params
+        ))
+    } else {
+        self$deliver(reply)
+    }
 }
 
 #' `documentLink/resolve` request handler

--- a/R/handlers-textsync.R
+++ b/R/handlers-textsync.R
@@ -13,6 +13,10 @@ text_document_did_open <- function(self, params) {
     } else {
         self$documents[[uri]]$set(version, content)
     }
+    self$pending_replies[[uri]] <- list(
+        `textDocument/documentSymbol` = collections::Queue(),
+        `textDocument/documentLink` = collections::Queue()
+    )
     self$text_sync(uri, version = version, document = NULL, run_lintr = TRUE, parse = TRUE, resolve = TRUE)
 }
 
@@ -68,6 +72,7 @@ text_document_did_close <- function(self, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
     rm(list = uri, envir = self$documents)
+    rm(list = uri, envir = self$pending_replies)
 }
 
 #' `textDocument/willSaveWaitUntil` notification handler

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -32,7 +32,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
         parse_task_manager = NULL,
         resolve_task_manager = NULL,
 
-        reply_queue = NULL,
+        pending_replies = new.env(parent = .GlobalEnv),
 
         initialize = function(host, port) {
             if (is.null(port)) {

--- a/R/link.R
+++ b/R/link.R
@@ -4,7 +4,12 @@
 document_link_reply <- function(id, uri, workspace, document, rootUri) {
     result <- NULL
 
-    xdoc <- workspace$get_parse_data(uri)$xml_doc
+    parse_data <- workspace$get_parse_data(uri)
+    if (is.null(parse_data) || parse_data$version != document$version) {
+        return(NULL)
+    }
+
+    xdoc <- parse_data$xml_doc
     if (!is.null(xdoc)) {
         str_tokens <- xml_find_all(xdoc, "//STR_CONST[@line1=@line2 and @col2 > @col1 + 1]")
         str_texts <- xml_text(str_tokens)

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -32,6 +32,11 @@ SymbolKind <- list(
 #' Get all the symbols in the document
 #' @keywords internal
 document_symbol_reply <- function(id, uri, workspace, document, capabilities) {
+    parse_data <- workspace$get_parse_data(uri)
+    if (is.null(parse_data) || parse_data$version != document$version) {
+        return(NULL)
+    }
+
     defns <- workspace$get_definitions_for_uri(uri)
     logger$info("document definitions found: ", length(defns))
     definition_symbols <- lapply(names(defns),


### PR DESCRIPTION
Closes #173 

This PR implements a simple mechanism that delays `textDocument/documentSymbol` and `textDocument/documentLink` to the time when document `parse_data` is updated in `parse_callback`.

`document_symbol_reply` and `document_link_reply` are refined so that it returns `NULL` if `parse_data$version` does not match `document$version` in the first place. Then the request handler will push the request id, document version, and params to the corresponding reply queue, waiting for `parse_callback` for that `document$version` is done. When `parse_callback` is called, it will handle all queued replies by replying empty response to outdated requests and recall the request handler with stored `id` and `params` for the queued reply that matches the document version.

Under such mechanism, document symbols and links are computed when the same document is parsed, and both requests will be handled timely with updated `parse_data`.