### PR TITLE
Fix section symbols

### DIFF
--- a/R/symbol.R
+++ b/R/symbol.R
@@ -36,8 +36,8 @@ get_r_document_section_symbols <- function(uri, document) {
             document$content[section_lines], perl = TRUE)]
     logger$info("document sections found: ", length(section_lines))
     if (length(section_lines)) {
-        section_names <- trimws(gsub("^\\#+\\s*(.+?)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
-            "\\1", document$content[section_lines], perl = TRUE))
+        section_names <- gsub("^\\#+\\s*(.+?)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
+            "\\1", document$content[section_lines], perl = TRUE)
         section_end_lines <- c(section_lines[-1] - 1, document$nline)
         section_symbols <- .mapply(function(name, start_line, end_line) {
             symbol_information(

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -61,8 +61,8 @@ get_r_document_section_symbols <- function(uri, document) {
             document$content[subsection_lines], perl = TRUE)]
     logger$info("document subsections found: ", length(subsection_lines))
     if (length(subsection_lines)) {
-        subsection_names <- trimws(gsub("^\\s+\\#+\\s*(.+?)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
-            "\\1", document$content[subsection_lines], perl = TRUE))
+        subsection_names <- gsub("^\\s+\\#+\\s*(.+?)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
+            "\\1", document$content[subsection_lines], perl = TRUE)
         subsection_symbols <- .mapply(function(name, line) {
             symbol_information(
                 name = name,

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -32,12 +32,12 @@ get_r_document_section_symbols <- function(uri, document) {
     section_symbols <- NULL
     section_lines <- seq_len(document$nline)
     section_lines <- section_lines[
-        grep("^\\#+\\s*(.+)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
-            document$content[section_lines])]
+        grep("^\\#+\\s*(.+?)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
+            document$content[section_lines], perl = TRUE)]
     logger$info("document sections found: ", length(section_lines))
     if (length(section_lines)) {
-        section_names <- trimws(gsub("^\\#+\\s*(.+)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
-            "\\1", document$content[section_lines]))
+        section_names <- trimws(gsub("^\\#+\\s*(.+?)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
+            "\\1", document$content[section_lines], perl = TRUE))
         section_end_lines <- c(section_lines[-1] - 1, document$nline)
         section_symbols <- .mapply(function(name, start_line, end_line) {
             symbol_information(
@@ -57,12 +57,12 @@ get_r_document_section_symbols <- function(uri, document) {
     subsection_symbols <- NULL
     subsection_lines <- seq_len(document$nline)
     subsection_lines <- subsection_lines[
-        grep("^\\s+\\#+\\s*(.+)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
-            document$content[subsection_lines])]
+        grep("^\\s+\\#+\\s*(.+?)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
+            document$content[subsection_lines], perl = TRUE)]
     logger$info("document subsections found: ", length(subsection_lines))
     if (length(subsection_lines)) {
-        subsection_names <- trimws(gsub("^\\s+\\#+\\s*(.+)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
-            "\\1", document$content[subsection_lines]))
+        subsection_names <- trimws(gsub("^\\s+\\#+\\s*(.+?)\\s*(\\#{4,}|\\+{4,}|\\-{4,}|\\={4,})\\s*$",
+            "\\1", document$content[subsection_lines], perl = TRUE))
         subsection_symbols <- .mapply(function(name, line) {
             symbol_information(
                 name = name,
@@ -114,7 +114,7 @@ get_rmd_document_section_symbols <- function(uri, document) {
     section_texts <- content[section_lines]
     section_hashes <- gsub("^(#+)\\s+.+$", "\\1", section_texts)
     section_levels <- nchar(section_hashes)
-    section_names <- gsub("^#+\\s+(.+)$", "\\1", section_texts)
+    section_names <- gsub("^#+\\s+(.+?)(\\s+#+)?\\s*$", "\\1", section_texts, perl = TRUE)
 
     section_symbols <- lapply(seq_len(section_num), function(i) {
         start_line <- section_lines[[i]]


### PR DESCRIPTION
Closes #188 

This PR uses lazy matching (which requires `perl = TRUE`) in the regex that extract code section symbols from both R document and Rmd document.
