### PR TITLE
Move data from environment to Dict

### DIFF
--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -5,7 +5,7 @@
 text_document_completion  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
-    document <- self$documents[[uri]]
+    document <- self$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(completion_reply(id, uri, self$workspace, document, point))
 }
@@ -27,7 +27,7 @@ completion_item_resolve  <- function(self, id, params) {
 text_document_hover  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
-    document <- self$documents[[uri]]
+    document <- self$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(hover_reply(id, uri, self$workspace, document, point))
 }
@@ -40,7 +40,7 @@ text_document_hover  <- function(self, id, params) {
 text_document_signature_help  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
-    document <- self$documents[[uri]]
+    document <- self$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(signature_reply(id, uri, self$workspace, document, point))
 }
@@ -52,7 +52,7 @@ text_document_signature_help  <- function(self, id, params) {
 text_document_definition  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
-    document <- self$documents[[uri]]
+    document <- self$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(definition_reply(id, uri, self$workspace, document, point))
 }
@@ -89,7 +89,7 @@ text_document_references  <- function(self, id, params) {
 text_document_document_highlight  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
-    document <- self$documents[[uri]]
+    document <- self$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(document_highlight_reply(id, uri, self$workspace, document, point))
 }
@@ -101,7 +101,7 @@ text_document_document_highlight  <- function(self, id, params) {
 text_document_document_symbol  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
-    document <- self$documents[[uri]]
+    document <- self$documents$get(uri)
     reply <- document_symbol_reply(id, uri, self$workspace, document,
         self$ClientCapabilities$textDocument$documentSymbol)
     if (is.null(reply)) {
@@ -148,7 +148,7 @@ code_lens_resolve  <- function(self, id, params) {
 text_document_document_link  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
-    document <- self$documents[[uri]]
+    document <- self$documents$get(uri)
     reply <- document_link_reply(id, uri, self$workspace, document, self$rootUri)
     if (is.null(reply)) {
         queue <- self$pending_replies$get(uri)[["textDocument/documentLink"]]
@@ -194,7 +194,7 @@ text_document_formatting  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
     options <- params$options
-    self$deliver(formatting_reply(id, uri, self$documents[[uri]], options))
+    self$deliver(formatting_reply(id, uri, self$documents$get(uri), options))
 }
 
 #' `textDocument/rangeFormatting` request handler
@@ -204,7 +204,7 @@ text_document_formatting  <- function(self, id, params) {
 text_document_range_formatting  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
-    document <- self$documents[[uri]]
+    document <- self$documents$get(uri)
     range <- list(
         start = document$from_lsp_position(params$range$start),
         end = document$from_lsp_position(params$range$end)
@@ -221,7 +221,7 @@ text_document_range_formatting  <- function(self, id, params) {
 text_document_on_type_formatting  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
-    document <- self$documents[[uri]]
+    document <- self$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     ch <- params$ch
     options <- params$options

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -52,7 +52,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
             self$inputcon <- inputcon
             self$outputcon <- outputcon
 
-            self$documents <- new.env(parent = .GlobalEnv)
+            self$documents <- collections::Dict()
             self$workspace <- Workspace$new()
 
             self$diagnostics_task_manager <- TaskManager$new()

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -142,6 +142,7 @@ GlobalNameSpace <- R6::R6Class("GlobalNameSpace",
         },
 
         update = function(parse_data) {
+            parse_data <- parse_data$as_list()
             self$nonfuncts <- unique(unlist(lapply(parse_data, "[[", "nonfuncts"), use.names = FALSE))
             self$exported_nonfuncts <- self$nonfuncts
             self$functs <- unique(unlist(lapply(parse_data, "[[", "functs"), use.names = FALSE))


### PR DESCRIPTION
Inspired by https://github.com/REditorSupport/languageserver/pull/187#discussion_r375604801 as `environment` has memory leaks as described at https://github.com/r-lib/fastmap#memory-leak-examples, this PR moves the following data from `environment` or `list` to `collections::Dict`

* `LanguageServer$documents(uri)`
* `Workspace$namespaces(pkgname)`
* `Workspace$documentation(name)`
* `Workspace$parse_data(uri)`
