### PR TITLE
Support textDocument/documentColor and textDocument/colorPresentation

### DIFF
--- a/R/capabilities.R
+++ b/R/capabilities.R
@@ -60,8 +60,8 @@ ServerCapabilities <- list(
     documentRangeFormattingProvider = TRUE,
     documentOnTypeFormattingProvider = DocumentOnTypeFormattingOptions,
     # renameProvider = FALSE,
-    documentLinkProvider = DocumentLinkOptions
-    # colorProvider = FALSE,
+    documentLinkProvider = DocumentLinkOptions,
+    colorProvider = TRUE
     # foldingRangeProvider = FALSE,
     # executeCommandProvider = ExecuteCommandOptions,
     # workspace = list()

--- a/R/color.R
+++ b/R/color.R
@@ -47,3 +47,18 @@ document_color_reply <- function(id, uri, workspace, document) {
     Response$new(id, result = result)
   }
 }
+
+#' The response to a textDocument/colorPresentation Request
+#'
+#' @keywords internal
+color_presentation_reply <- function(id, uri, workspace, document, color) {
+  if (color$alpha == 1) {
+    hex_color <- grDevices::rgb(color$red, color$green, color$blue)
+  } else {
+    hex_color <- grDevices::rgb(color$red, color$green, color$blue, color$alpha)
+  }
+  result <- list(
+    list(label = hex_color)
+  )
+  Response$new(id, result = result)
+}

--- a/R/color.R
+++ b/R/color.R
@@ -1,0 +1,49 @@
+#' The response to a textDocument/documentColor Request
+#'
+#' @keywords internal
+document_color_reply <- function(id, uri, workspace, document) {
+  result <- NULL
+
+  parse_data <- workspace$get_parse_data(uri)
+  if (is.null(parse_data) ||
+    (!is.null(parse_data$version) && parse_data$version != document$version)) {
+    return(NULL)
+  }
+
+  xdoc <- parse_data$xml_doc
+  if (!is.null(xdoc)) {
+    str_tokens <- xml_find_all(xdoc, "//STR_CONST[@line1=@line2 and @col2 > @col1 + 1]")
+    str_texts <- xml_text(str_tokens)
+    str_texts <- substr(str_texts, 2, nchar(str_texts) - 1)
+
+    is_color <- grepl("^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$", str_texts) | str_texts %in% grDevices::colors()
+    str_tokens <- str_tokens[is_color]
+    str_texts <- str_texts[is_color]
+    str_colors <- grDevices::col2rgb(str_texts, alpha = TRUE) / 255
+
+    str_line1 <- as.integer(xml_attr(str_tokens, "line1"))
+    str_col1 <- as.integer(xml_attr(str_tokens, "col1"))
+    str_col2 <- as.integer(xml_attr(str_tokens, "col2"))
+    result <- .mapply(function(line, col1, col2, i) {
+      list(
+        range = range(
+          start = document$to_lsp_position(line - 1, col1),
+          end = document$to_lsp_position(line - 1, col2 - 1)
+        ),
+        color = list(
+          red = str_colors["red", i],
+          green = str_colors["green", i],
+          blue = str_colors["blue", i],
+          alpha = str_colors["alpha", i]
+        )
+      )
+    }, list(str_line1, str_col1, str_col2, seq_along(str_texts)), NULL)
+    logger$info(result)
+  }
+
+  if (is.null(result)) {
+    Response$new(id)
+  } else {
+    Response$new(id, result = result)
+  }
+}

--- a/R/color.R
+++ b/R/color.R
@@ -57,6 +57,7 @@ color_presentation_reply <- function(id, uri, workspace, document, color) {
     hex_color <- grDevices::rgb(color$red, color$green, color$blue, color$alpha)
   }
   result <- list(
+    list(label = tolower(hex_color)),
     list(label = hex_color)
   )
   Response$new(id, result = result)

--- a/R/color.R
+++ b/R/color.R
@@ -38,7 +38,6 @@ document_color_reply <- function(id, uri, workspace, document) {
         )
       )
     }, list(str_line1, str_col1, str_col2, seq_along(str_texts)), NULL)
-    logger$info(result)
   }
 
   if (is.null(result)) {

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -196,7 +196,6 @@ text_document_document_color  <- function(self, id, params) {
 #' Handler to the `textDocument/colorPresentation` [Request].
 #' @keywords internal
 text_document_color_presentation  <- function(self, id, params) {
-    logger$info("text_document_color_presentation:", id, params)
     textDocument <- params$textDocument
     uri <- textDocument$uri
     document <- self$documents$get(uri)

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -175,7 +175,20 @@ document_link_resolve  <- function(self, id, params) {
 #' Handler to the `textDocument/documentColor` [Request].
 #' @keywords internal
 text_document_document_color  <- function(self, id, params) {
-
+    textDocument <- params$textDocument
+    uri <- textDocument$uri
+    document <- self$documents$get(uri)
+    reply <- document_color_reply(id, uri, self$workspace, document)
+    if (is.null(reply)) {
+        queue <- self$pending_replies$get(uri)[["textDocument/documentColor"]]
+        queue$push(list(
+            id = id,
+            version = document$version,
+            params = params
+        ))
+    } else {
+        self$deliver(reply)
+    }
 }
 
 #' `textDocument/colorPresentation` request handler
@@ -183,7 +196,7 @@ text_document_document_color  <- function(self, id, params) {
 #' Handler to the `textDocument/colorPresentation` [Request].
 #' @keywords internal
 text_document_color_presentation  <- function(self, id, params) {
-
+    logger$info("text_document_color_presentation:", id, params)
 }
 
 #' `textDocument/formatting` request handler

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -197,6 +197,11 @@ text_document_document_color  <- function(self, id, params) {
 #' @keywords internal
 text_document_color_presentation  <- function(self, id, params) {
     logger$info("text_document_color_presentation:", id, params)
+    textDocument <- params$textDocument
+    uri <- textDocument$uri
+    document <- self$documents$get(uri)
+    color <- params$color
+    self$deliver(color_presentation_reply(id, uri, self$workspace, document, color))
 }
 
 #' `textDocument/formatting` request handler

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -84,7 +84,8 @@ LanguageServer <- R6::R6Class("LanguageServer",
             if (!self$pending_replies$has(uri)) {
                 self$pending_replies$set(uri, list(
                     `textDocument/documentSymbol` = collections::Queue(),
-                    `textDocument/documentLink` = collections::Queue()
+                    `textDocument/documentLink` = collections::Queue(),
+                    `textDocument/documentColor` = collections::Queue()
                 ))
             }
 
@@ -190,6 +191,8 @@ LanguageServer$set("public", "register_handlers", function() {
         `textDocument/documentSymbol` = text_document_document_symbol,
         `textDocument/documentHighlight` = text_document_document_highlight,
         `textDocument/documentLink` = text_document_document_link,
+        `textDocument/documentColor` = text_document_document_color,
+        `textDocument/colorPresentation` = text_document_color_presentation,
         `workspace/symbol` = workspace_symbol
     )
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ These editors are supported by installing the corresponding package.
 - [x] documentOnTypeFormattingProvider
 - [ ] renameProvider
 - [x] documentLinkProvider
+- [x] colorProvider
 - [ ] executeCommandProvider
 
 ## Settings


### PR DESCRIPTION
This PR adds support for `textDocument/documentColor` and `textDocument/colorPresentation`.

<img width="465" alt="image" src="https://user-images.githubusercontent.com/4662568/73992222-5f832980-4989-11ea-9593-a58e97df47b5.png">
