### PR TITLE
Fix handling untitled document

### DIFF
--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -64,7 +64,8 @@ find_config <- function(filename) {
 #'
 #' Lint and diagnose problems in a file.
 #' @keywords internal
-diagnose_file <- function(path, content = NULL) {
+diagnose_file <- function(uri, content = NULL) {
+    path <- path_from_uri(uri)
     if (is.null(find_config(path))) {
         linters <- getOption("languageserver.default_linters", NULL)
     } else {
@@ -114,7 +115,7 @@ diagnostics_task <- function(self, uri, version, document) {
     }
     create_task(
         diagnose_file,
-        list(path = path_from_uri(uri), content = content),
+        list(uri = uri, content = content),
         callback = function(result) diagnostics_callback(self, uri, version, result),
         error = function(e) logger$info("diagnostics_task:", e))
 }

--- a/R/document.R
+++ b/R/document.R
@@ -244,14 +244,15 @@ parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcr
 #' signatures in the document in order to add them to the current [Workspace].
 #'
 #' @keywords internal
-parse_document <- function(path, content = NULL, resolve = FALSE) {
+parse_document <- function(uri, content = NULL, resolve = FALSE) {
     if (is.null(content)) {
+        path <- path_from_uri(uri)
         content <- readr::read_lines(path)
     }
     if (length(content) == 0) {
         content <- ""
     }
-    if (is_rmarkdown(path)) {
+    if (is_rmarkdown(uri)) {
         content <- purl(content)
     }
     expr <- tryCatch(parse(text = content, keep.source = TRUE), error = function(e) NULL)
@@ -314,7 +315,7 @@ parse_task <- function(self, uri, version, document, resolve = FALSE) {
     }
     create_task(
         parse_document,
-        list(path = path_from_uri(uri), content = content, resolve = resolve),
+        list(uri = uri, content = content, resolve = resolve),
         callback = function(result) parse_callback(self, uri, version, result),
         error = function(e) logger$info("parse_task:", e))
 }


### PR DESCRIPTION
Closes #196 

This PR fixes `text_document_did_open` so that it gets file text from `textDocument$text` when file path does not exist (typically due to untitled document).
