### PR TITLE
set O_BINARY for stdin/stdout

### DIFF
--- a/src/languageserver.c
+++ b/src/languageserver.c
@@ -1,6 +1,11 @@
 #include "search.h"
 #include "reader.h"
 
+#ifdef _WIN32
+# include <fcntl.h>
+# include <io.h>
+# include <stdio.h>
+#endif
 
 #if !defined(_WIN32)
 
@@ -29,6 +34,10 @@ static const R_CallMethodDef CallEntries[] = {
 };
 
 void R_init_languageserver(DllInfo *dll) {
+#ifdef _WIN32
+    _setmode(_fileno(stdin), _O_BINARY);
+    _setmode(_fileno(stdout), _O_BINARY);
+#endif
     R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
     R_useDynamicSymbols(dll, FALSE);
 }


### PR DESCRIPTION
On Windows, R does not read/write bytes content correctly for stdin/stdout. So content-length header is not handled for many Language Server Clients. This change set O_BINARY to stdin/stdout.

![screenshot2](https://user-images.githubusercontent.com/10111/74085177-ac661d80-4ab9-11ea-9cc5-590877c834d1.gif)
