### PR TITLE
Separate resolve task from parse task

### DIFF
--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -114,7 +114,7 @@ diagnostics_task <- function(self, uri, document) {
     version <- document$version
     content <- document$content
     create_task(
-        diagnose_file,
+        package_call(diagnose_file),
         list(uri = uri, content = content),
         callback = function(result) diagnostics_callback(self, uri, version, result),
         error = function(e) logger$info("diagnostics_task:", e))

--- a/R/document.R
+++ b/R/document.R
@@ -325,7 +325,7 @@ parse_task <- function(self, uri, document) {
     version <- document$version
     content <- document$content
     create_task(
-        parse_document,
+        package_call(parse_document),
         list(uri = uri, content = content),
         callback = function(result) parse_callback(self, uri, version, result),
         error = function(e) logger$info("parse_task:", e))

--- a/R/document.R
+++ b/R/document.R
@@ -274,8 +274,7 @@ parse_document <- function(uri, content) {
         env <- parse_env()
         parse_expr(content, expr, env)
         env$packages <- basename(find.package(env$packages, quiet = TRUE))
-        xml_data <- xmlparsedata::xml_parse_data(expr)
-        env$xml_data <- xml_data
+        env$xml_data <- xmlparsedata::xml_parse_data(expr)
         env
     }
 }

--- a/R/document.R
+++ b/R/document.R
@@ -273,6 +273,7 @@ parse_document <- function(uri, content) {
         }
         env <- parse_env()
         parse_expr(content, expr, env)
+        env$packages <- basename(find.package(env$packages, quiet = TRUE))
         xml_data <- xmlparsedata::xml_parse_data(expr)
         env$xml_data <- xml_data
         env
@@ -291,10 +292,9 @@ parse_callback <- function(self, uri, version, parse_data) {
 
     if (!identical(old_parse_data$packages, parse_data$packages)) {
         if (length(parse_data$packages)) {
-            load_packages <- basename(find.package(parse_data$packages, quiet = TRUE))
             self$parse_task_manager$add_task(
                 uri,
-                resolve_task(self, uri, doc, load_packages)
+                resolve_task(self, uri, doc, parse_data$packages)
             )
             doc$loaded_packages <- load_packages
         } else {

--- a/R/document.R
+++ b/R/document.R
@@ -296,7 +296,7 @@ parse_callback <- function(self, uri, version, parse_data) {
                 uri,
                 resolve_task(self, uri, doc, parse_data$packages)
             )
-            doc$loaded_packages <- load_packages
+            doc$loaded_packages <- parse_data$packages
         } else {
             doc$loaded_packages <- character()
         }

--- a/R/document.R
+++ b/R/document.R
@@ -296,10 +296,11 @@ parse_callback <- function(self, uri, version, parse_data) {
                 uri,
                 resolve_task(self, uri, doc, load_packages)
             )
+            doc$loaded_packages <- load_packages
         } else {
             doc$loaded_packages <- character()
-            self$workspace$update_loaded_packages()
         }
+        self$workspace$update_loaded_packages()
     }
 
     pending_replies <- self$pending_replies$get(uri, NULL)

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -276,22 +276,11 @@ GlobalEnv <- R6::R6Class("GlobalEnv",
 
 
 resolve_attached_packages <- function(pkgs) {
-    if (length(pkgs)) {
-        pkgs <- tryCatch(
-            callr::r(
-                function(pkgs) {
-                    startup_packages <- .packages()
-                    for (pkg in pkgs) {
-                        tryCatch(library(pkg, character.only = TRUE),
-                            error = function(e) NULL
-                        )
-                    }
-                    rev(setdiff(.packages(), startup_packages))
-                },
-                list(pkgs = pkgs)
-            ),
+    startup_packages <- .packages()
+    for (pkg in pkgs) {
+        tryCatch(library(pkg, character.only = TRUE),
             error = function(e) NULL
         )
     }
-    pkgs
+    rev(setdiff(.packages(), startup_packages))
 }

--- a/R/task.R
+++ b/R/task.R
@@ -91,10 +91,13 @@ TaskManager <- R6::R6Class("TaskManager",
     )
 )
 
-
-create_task <- function(target, args, callback = NULL, error = NULL) {
+package_call <- function(target) {
     func <- call(":::", as.name("languageserver"), substitute(target))
     target <- eval(substitute(function(...) func(...), list(func = func)))
+    target
+}
+
+create_task <- function(target, args, callback = NULL, error = NULL) {
     Task$new(
         target = target,
         args = args,

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -173,7 +173,7 @@ Workspace <- R6::R6Class("Workspace",
         },
 
         get_parse_data = function(uri) {
-            self$documents$get(uri)$parse_data
+            self$documents$get(uri, NULL)$parse_data
         },
 
         update_loaded_packages = function() {
@@ -185,13 +185,11 @@ Workspace <- R6::R6Class("Workspace",
         },
 
         update_parse_data = function(uri, parse_data) {
-            self$load_packages(parse_data$load_packages)
             if (!is.null(parse_data$xml_data)) {
                 parse_data$xml_doc <- tryCatch(
                     xml2::read_xml(parse_data$xml_data), error = function(e) NULL)
             }
             self$documents$get(uri)$update_parse_data(parse_data)
-            self$update_loaded_packages()
         }
     )
 )

--- a/man/parse_document.Rd
+++ b/man/parse_document.Rd
@@ -4,7 +4,7 @@
 \alias{parse_document}
 \title{Parse a document}
 \usage{
-parse_document(uri, content, loaded_packages = character())
+parse_document(uri, content)
 }
 \description{
 Build the list of called packages, functions, variables, formals and


### PR DESCRIPTION
PR #204 tries to improve the performance of `parse_task` by avoiding unnecessary loading packages.

However, parsing is always fast while resolving packages with child R session is expensive. We should separate package resolving from parsing so that `parse_task` could callback quickly to provide necessary parse data for all other providers that need it and `resolve_task` should be created only when `parse_data$packages` is changed.

So the task flow looks like:

```
didOpen, didChange, didSave
* diagnostics_task -> diagnostics_callback
* parse_task -> parse_callback
  ? resolve_task -> resolve_callback
```

Another problem #204 has is that incremental resolving package could not handle reorder of package attaching, so the masking could be incorrect. The safe way to do is that whenever the library calls in the document are changed (i.e. original `parse_data$packages` changed), the resolve_task should be run. Since `resolve_task` is separated from `parse_task`, then the performance of `resolve_task` would not affect providers that use `parse_data`.