### PR TITLE
Expression-level on-type-formatting

### DIFF
--- a/R/document.R
+++ b/R/document.R
@@ -19,13 +19,7 @@ Document <- R6::R6Class(
 
         set_content = function(version, content) {
             self$version <- version
-            # remove last empty line
-            nline <- length(content)
-            if (nline > 0L && !nzchar(content[nline])) {
-                content <- content[-nline]
-                nline <- nline - 1
-            }
-            self$nline <- nline
+            self$nline <- length(content)
             self$content <- content
         },
 

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -161,7 +161,7 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
             start_line <- start_line - 1
         }
         TRUE
-    }, timeout = 0.1, error = function(e) logger$info("on_type_formatting_reply:", e))
+    }, timeout = 0.1, error = function(e) logger$info("on_type_formatting_reply:parser:", e))
 
     if (is.null(res)) {
         # timeout
@@ -192,7 +192,8 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
         new_text <- tryCatchTimeout(
             style_text(content[start_line:end_line], style, indentation = indentation),
             timeout = 1,
-            error = function(e) logger$info("on_type_formatting_reply:", e))
+            error <- function(e) logger$info("on_type_formatting_reply:styler:", e)
+        )
         if (!is.null(new_text)) {
             if (use_zero) {
                 new_text <- substr(new_text, 1, nchar(new_text) - 1)

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -181,11 +181,11 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
             start_line <- start_line + 1
         }
 
-        logger$info("on_type_formatting_reply:", list(
-            start_line = start_line,
-            end_line = end_line,
-            chunk = content[start_line:end_line]
-        ))
+        # logger$info("on_type_formatting_reply:", list(
+        #     start_line = start_line,
+        #     end_line = end_line,
+        #     chunk = content[start_line:end_line]
+        # ))
 
         style <- get_style(options)
         indentation <- stringr::str_extract(content[start_line], "^\\s*")

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -127,13 +127,16 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
     end_line <- point$row + 1
     use_zero <- FALSE
     if (ch == "\n") {
+        start_line <- end_line - 1
+        if (grepl("^\\s*$", content[[start_line]])) {
+            return(Response$new(id))
+        }
         if (grepl("^\\s*(#.+)?$", content[[end_line]])) {
             # use "0" to complete the potentially incomplete expression
             last_line <- content[end_line]
             content[end_line] <- "0"
             use_zero <- TRUE
         }
-        start_line <- end_line - 1
     } else {
         start_line <- end_line
     }

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -127,9 +127,9 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
     end_line <- point$row + 1
     use_dot <- FALSE
     if (ch == "\n") {
-        if (grepl("^\\s*$", content[[end_line]])) {
+        if (grepl("^\\s*(#.+)?$", content[[end_line]])) {
             # use "." to complete the potentially incomplete expression
-            content[end_line] <- "."
+            content[end_line] <- paste0("...()", content[end_line])
             use_dot <- TRUE
         }
         start_line <- end_line - 1
@@ -194,7 +194,7 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
             error = function(e) logger$info("on_type_formatting_reply:", e))
         if (!is.null(new_text)) {
             if (use_dot) {
-                new_text <- substr(new_text, 1, nchar(new_text) - 1)
+                new_text <- gsub("...()", "", new_text, fixed = TRUE)
             }
             range <- range(
                 start = document$to_lsp_position(row = start_line - 1, col = 0),

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -192,7 +192,7 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
         new_text <- tryCatchTimeout(
             style_text(content[start_line:end_line], style, indentation = indentation),
             timeout = 1,
-            error <- function(e) logger$info("on_type_formatting_reply:styler:", e)
+            error = function(e) logger$info("on_type_formatting_reply:styler:", e)
         )
         if (!is.null(new_text)) {
             if (use_zero) {

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -191,6 +191,10 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
         # ))
 
         style <- get_style(options)
+        
+        # disable assignment operator fix since end_line could be function parameter
+        style$token$force_assignment_op <- NULL
+
         indentation <- stringr::str_extract(content[start_line], "^\\s*")
         new_text <- tryCatchTimeout(
             style_text(content[start_line:end_line], style, indentation = indentation),

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -125,12 +125,13 @@ range_formatting_reply <- function(id, uri, document, range, options) {
 on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
     content <- document$content
     end_line <- point$row + 1
-    use_dot <- FALSE
+    use_zero <- FALSE
     if (ch == "\n") {
         if (grepl("^\\s*(#.+)?$", content[[end_line]])) {
-            # use "." to complete the potentially incomplete expression
-            content[end_line] <- paste0("...()", content[end_line])
-            use_dot <- TRUE
+            # use "0" to complete the potentially incomplete expression
+            last_line <- content[end_line]
+            content[end_line] <- "0"
+            use_zero <- TRUE
         }
         start_line <- end_line - 1
     } else {
@@ -193,8 +194,9 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
             timeout = 1,
             error = function(e) logger$info("on_type_formatting_reply:", e))
         if (!is.null(new_text)) {
-            if (use_dot) {
-                new_text <- gsub("...()", "", new_text, fixed = TRUE)
+            if (use_zero) {
+                new_text <- substr(new_text, 1, nchar(new_text) - 1)
+                new_text <- paste0(new_text, trimws(last_line, whitespace = "\\s"))
             }
             range <- range(
                 start = document$to_lsp_position(row = start_line - 1, col = 0),

--- a/R/utils.R
+++ b/R/utils.R
@@ -43,6 +43,14 @@ print.errorWithStack <- function(x, ...) {
     invisible(x)
 }
 
+tryCatchTimeout <- function(expr, timeout = Inf, ...) {
+    expr <- substitute(expr)
+    envir <- parent.frame()
+    setTimeLimit(timeout, transient = TRUE)
+    on.exit(setTimeLimit())
+    tryCatch(eval(expr, envir), ...)
+}
+
 capture_print <- function(x) {
     paste0(utils::capture.output(print(x)), collapse = "\n")
 }


### PR DESCRIPTION
Closes #208 

This PR enhances the current implementation of on-type-formatting handler which only tries to format the single-line under editing.

Parsing a short chunk of code without generating source reference is super fast, which allows us to use `parse(text = ., keep.source = FALSE)` repeatedly to find the parse-able expression before current line to perform formatting.

Currently, only `)`, `]`, `}` and `\n` are used to trigger on type formatting. The closing brackets are usually with complete expressions before cursor, while the line break can be in the end of either a complete expression (a single line call like `foo()`) or an incomplete expression to be continued in the next line (typical use case is pipelines ending with ggplot's `+` or magrittr's `%>%`)

To handle the case of `\n` in the end of an incomplete expression, we use a zero strategy, i.e. if the end line is empty or only whitespace, then we replace that line with `0` to make the expression a complete one.

```r
mtcars %>% # hit enter
```

internally becomes

```
mtcars %>%
  0
```

Then we use a backward parsing strategy, i.e., we expand the code chunk backward line by line from the end line on request and try to parse the code. We stop backward parsing when 

* We have at least one expression parsed and 
* We are entering the previous expression.
  - If it is one-line expression, then we got 1 more expression.
  - If it is multi-line expression, then we got no expression

When we find the start line of the expression, and we format the code in the range and cut the zero if used.

Both backward parsing and formatting are called in `tryCatchTimeout()` which uses `setTimeout()` to limit the number of seconds to evaluate an expression. We set the timeout of backward parsing to 0.1s and formatting to 1s at the moment.

Now the on-type-formatting works nicely with the following use cases:

```r
1+1 # hit enter to format this line

f(a,b,c) # hit enter to format this line

mtcars %>% # hit enter and we get an indentation

mtcars %>%
  select(a,b, c) %>%
  mutate(x=a + b, y = b - c) %>%
  select(a, b,c) # close the bracket or hit enter

mtcars %>% select(a, b, c) # hit enter anywhere in the middle of the expression to get correct indention

if(x+1){
  y+1
}else{
  z+1
} # hit enter or close this bracket to format the whole if else expression

fun2 <- function(x,y, z) {
  x+y + z # hit enter to format this line
  x+ y +z
  local({
  local({
    x+y+z
    }) # hit enter or close bracket to format this inner local call
  }) # hit enter or close bracket to format both inner and outer local calls
} # hit enter or close bracket to format the entire function
```

![Kapture 2020-02-13 at 21 02 46](https://user-images.githubusercontent.com/4662568/74438354-f0379900-4ea4-11ea-9743-99e8a8950d40.gif)

