### PR TITLE
Disable lintr for temp files

### DIFF
--- a/R/handlers-textsync.R
+++ b/R/handlers-textsync.R
@@ -90,6 +90,10 @@ text_document_did_save <- function(self, params) {
 text_document_did_close <- function(self, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
+    # remove diagnostics if file is not from workspace
+    if (!startsWith(uri, self$rootUri)) {
+        diagnostics_callback(self, uri, NULL, list())
+    }
     # do not remove document in package
     if (!(is_package(self$rootUri) && startsWith(uri, self$rootUri))) {
         self$workspace$documents$remove(uri)

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -88,7 +88,8 @@ LanguageServer <- R6::R6Class("LanguageServer",
                 ))
             }
 
-            if (run_lintr && self$run_lintr) {
+            if (run_lintr && self$run_lintr && 
+                !startsWith(uri, path_to_uri(dirname(tempdir())))) {
                 self$diagnostics_task_manager$add_task(
                     uri,
                     diagnostics_task(self, uri, document)

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -88,14 +88,16 @@ LanguageServer <- R6::R6Class("LanguageServer",
                 ))
             }
 
-            if (run_lintr && self$run_lintr && 
-                !startsWith(uri, path_to_uri(dirname(tempdir())))) {
-                self$diagnostics_task_manager$add_task(
-                    uri,
-                    diagnostics_task(self, uri, document)
-                )
+            if (run_lintr && self$run_lintr) {
+                temp_root <- dirname(tempdir())
+                if (startsWith(self$rootUri, temp_root) || !startsWith(uri, temp_root)) {
+                    self$diagnostics_task_manager$add_task(
+                        uri,
+                        diagnostics_task(self, uri, document)
+                    )
+                }
             }
-            
+
             if (parse) {
                 self$parse_task_manager$add_task(
                     uri,

--- a/tests/testthat/test-lintr.R
+++ b/tests/testthat/test-lintr.R
@@ -17,20 +17,6 @@ test_that("lintr works", {
     expect_equal(data$diagnostics[[1]]$message, "Use <-, not =, for assignment.")
 })
 
-test_that("lintr is disabled with temp files in non-temp workspace", {
-    skip_on_cran()
-
-    dir <- normalizePath("~")
-    client <- language_client(dir, diagnostics = TRUE)
-
-    withr::local_tempfile(c("temp_file"), fileext = ".R")
-    writeLines("a = 1", temp_file)
-
-    client %>% did_open(temp_file)
-    data <- client %>% wait_for("textDocument/publishDiagnostics", timeout = runif(1, 1, 3))
-    expect_equal(client$diagnostics$size(), 0)
-})
-
 test_that("lintr is disabled", {
     skip_on_cran()
     client <- language_client(diagnostics = FALSE)

--- a/tests/testthat/test-lintr.R
+++ b/tests/testthat/test-lintr.R
@@ -28,7 +28,7 @@ test_that("lintr is disabled with temp files in non-temp workspace", {
 
     client %>% did_open(temp_file)
     data <- client %>% wait_for("textDocument/publishDiagnostics", timeout = runif(1, 1, 3))
-    expect_null(data)
+    expect_equal(client$diagnostics$size(), 0)
 })
 
 test_that("lintr is disabled", {


### PR DESCRIPTION
This PR disables lintr for files from temp root as suggested in #213.

Temp root is used instead of session temp dir because an interactive session may produce a file in temp for the editor to view (e.g. vscode-R allows user to call `View(func)` in a user session to view the function code in the editor. The file is located in the temp directory of the user session rather than the session running languageserver so they have different `tempdir()` but the same temp root `dirname(tempdir())`).
