### PR TITLE
Fix resolving paths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     callr (>= 3.0.0),
     collections (>= 0.2.3),
     desc (>= 1.2.0),
+    fs (>= 1.3.1),
     jsonlite (>= 1.6),
     lintr (>= 2.0.0),
     R6 (>= 2.4.1),
@@ -37,7 +38,6 @@ Imports:
     xmlparsedata (>= 1.0.3)
 Suggests:
     covr (>= 3.4.0),
-    fs (>= 1.3.1),
     magrittr (>= 1.5),
     mockery (>= 0.4.2),
     processx (>= 3.4.1),

--- a/R/handlers-general.R
+++ b/R/handlers-general.R
@@ -23,9 +23,8 @@ on_initialize <- function(self, id, params) {
 #' @keywords internal
 on_initialized <- function(self, params) {
     logger$info("on_initialized")
-    if (is_package(self$rootUri)) {
-
-        project_root <- path_from_uri(self$rootUri)
+    project_root <- self$rootPath
+    if (is_package(project_root)) {
         source_dir <- file.path(project_root, "R")
         files <- list.files(source_dir)
         for (f in files) {

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -149,7 +149,7 @@ text_document_document_link  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
     document <- self$workspace$documents$get(uri)
-    reply <- document_link_reply(id, uri, self$workspace, document, self$rootUri)
+    reply <- document_link_reply(id, uri, self$workspace, document, self$rootPath)
     if (is.null(reply)) {
         queue <- self$pending_replies$get(uri)[["textDocument/documentLink"]]
         queue$push(list(

--- a/R/handlers-textsync.R
+++ b/R/handlers-textsync.R
@@ -90,15 +90,20 @@ text_document_did_save <- function(self, params) {
 text_document_did_close <- function(self, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
+    path <- path_from_uri(uri)
+    is_from_workspace <- fs::path_has_parent(path, self$rootPath)
+
     # remove diagnostics if file is not from workspace
-    if (!startsWith(uri, self$rootUri)) {
+    if (!is_from_workspace) {
         diagnostics_callback(self, uri, NULL, list())
     }
+
     # do not remove document in package
-    if (!(is_package(self$rootUri) && startsWith(uri, self$rootUri))) {
+    if (!(is_package(self$rootPath) && is_from_workspace)) {
         self$workspace$documents$remove(uri)
         self$workspace$update_loaded_packages()
     }
+
     self$pending_replies$remove(uri)
 }
 

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -89,9 +89,9 @@ LanguageServer <- R6::R6Class("LanguageServer",
             }
 
             if (run_lintr && self$run_lintr) {
-                temp_root <- paste0(path_to_uri(dirname(tempdir())), "/")
-                if (startsWith(self$rootUri, temp_root) ||
-                    !startsWith(uri, temp_root)) {
+                temp_root <- dirname(tempdir())
+                if (fs::path_has_parent(self$rootPath, temp_root) ||
+                    !fs::path_has_parent(path_from_uri(uri), temp_root)) {
                     self$diagnostics_task_manager$add_task(
                         uri,
                         diagnostics_task(self, uri, document)

--- a/R/link.R
+++ b/R/link.R
@@ -21,7 +21,7 @@ document_link_reply <- function(id, uri, workspace, document, rootUri) {
 
         sel <- file.exists(paths) & !dir.exists(paths)
         str_tokens <- str_tokens[sel]
-        paths <- fs::path_expand(paths[sel])
+        paths <- path.expand(paths[sel])
         uris <- vapply(paths, path_to_uri, character(1))
 
         str_line1 <- as.integer(xml_attr(str_tokens, "line1"))

--- a/R/link.R
+++ b/R/link.R
@@ -1,7 +1,7 @@
 #' The response to a textDocument/documentLink Request
 #'
 #' @keywords internal
-document_link_reply <- function(id, uri, workspace, document, rootUri) {
+document_link_reply <- function(id, uri, workspace, document, rootPath) {
     result <- NULL
 
     parse_data <- workspace$get_parse_data(uri)
@@ -16,8 +16,7 @@ document_link_reply <- function(id, uri, workspace, document, rootUri) {
         str_texts <- xml_text(str_tokens)
         str_texts <- substr(str_texts, 2, nchar(str_texts) - 1)
 
-        root_path <- path_from_uri(rootUri)
-        paths <- fs::path_abs(str_texts, root_path)
+        paths <- fs::path_abs(str_texts, rootPath)
 
         sel <- file.exists(paths) & !dir.exists(paths)
         str_tokens <- str_tokens[sel]

--- a/R/link.R
+++ b/R/link.R
@@ -15,20 +15,14 @@ document_link_reply <- function(id, uri, workspace, document, rootUri) {
         str_tokens <- xml_find_all(xdoc, "//STR_CONST[@line1=@line2 and @col2 > @col1 + 1]")
         str_texts <- xml_text(str_tokens)
         str_texts <- substr(str_texts, 2, nchar(str_texts) - 1)
-        is_abs_path <- grepl("^(~|/+|[A-Za-z]:)", str_texts)
 
         root_path <- path_from_uri(rootUri)
-        paths <- str_texts
-        paths[!is_abs_path] <- file.path(root_path, str_texts[!is_abs_path])
-        paths <- normalizePath(paths, "/", mustWork = FALSE)
+        paths <- fs::path_abs(str_texts, root_path)
 
         sel <- file.exists(paths) & !dir.exists(paths)
         str_tokens <- str_tokens[sel]
-        str_texts <- str_texts[sel]
-        paths <- paths[sel]
-        is_abs_path <- is_abs_path[sel]
-
-        uris <- path_to_uri(paths)
+        paths <- fs::path_expand(paths[sel])
+        uris <- vapply(paths, path_to_uri, character(1))
 
         str_line1 <- as.integer(xml_attr(str_tokens, "line1"))
         str_col1 <- as.integer(xml_attr(str_tokens, "col1"))

--- a/R/utils.R
+++ b/R/utils.R
@@ -231,13 +231,14 @@ find_package <- function(path = getwd()) {
     normalizePath(prev_path)
 }
 
-#' check if an URI is a package folder
+#' check if a path is a package folder
 #'
-#' @param rootUri a character representing a URI
+#' @param rootPath a character representing a path
 #'
 #' @keywords internal
-is_package <- function(rootUri) {
-    file.exists(file.path(path_from_uri(rootUri), "DESCRIPTION"))
+is_package <- function(rootPath) {
+    file <- file.path(rootPath, "DESCRIPTION")
+    file.exists(file) && !dir.exists(file)
 }
 
 #' read a character from stdin

--- a/R/utils.R
+++ b/R/utils.R
@@ -61,6 +61,9 @@ path_from_uri <- function(uri) {
     if (length(uri) == 0) {
         return(character())
     }
+    if (!startsWith(uri, "file:///")) {
+        return("")
+    }
     start_char <- if (.Platform$OS.type == "windows") 9 else 8
     utils::URLdecode(substr(uri, start_char, nchar(uri)))
 }

--- a/man/document_link_reply.Rd
+++ b/man/document_link_reply.Rd
@@ -4,7 +4,7 @@
 \alias{document_link_reply}
 \title{The response to a textDocument/documentLink Request}
 \usage{
-document_link_reply(id, uri, workspace, document, rootUri)
+document_link_reply(id, uri, workspace, document, rootPath)
 }
 \description{
 The response to a textDocument/documentLink Request

--- a/man/is_package.Rd
+++ b/man/is_package.Rd
@@ -2,14 +2,14 @@
 % Please edit documentation in R/utils.R
 \name{is_package}
 \alias{is_package}
-\title{check if an URI is a package folder}
+\title{check if a path is a package folder}
 \usage{
-is_package(rootUri)
+is_package(rootPath)
 }
 \arguments{
-\item{rootUri}{a character representing a URI}
+\item{rootPath}{a character representing a path}
 }
 \description{
-check if an URI is a package folder
+check if a path is a package folder
 }
 \keyword{internal}

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -6,38 +6,55 @@ test_that("Document link works", {
     dir <- tempdir()
     client <- language_client(dir)
 
-    withr::local_tempfile(c("src_file", "temp_file"), tmpdir = dir, fileext = ".R")
-    src_file <- normalizePath(src_file, "/", mustWork = FALSE)
+    withr::local_tempfile(c("src_file1", "src_file2", "temp_file"), tmpdir = dir, fileext = ".R")
+    src_file1 <- fs::path(src_file1)
+    src_file2 <- fs::path(src_file2)
 
     writeLines(
         c(
             "x <- 1"
         ),
-        src_file
+        src_file1
     )
 
     writeLines(
         c(
-            sprintf("source('%s')", src_file),
-            sprintf("source('%s')", basename(src_file)),
+            "x <- 2"
+        ),
+        src_file2
+    )
+
+    writeLines(
+        c(
+            sprintf("source('%s')", src_file1),
+            sprintf("source('%s')", basename(src_file1)),
+            sprintf("source('%s')", src_file2),
+            sprintf("source('%s')", basename(src_file2)),
             "source('non_exist_file.R')"
         ),
         temp_file
     )
 
-    client %>% did_save(src_file)
     client %>% did_save(temp_file)
 
     result <- client %>% respond_document_link(temp_file)
 
-    expect_length(result, 2)
+    expect_length(result, 4)
     expect_equal(result[[1]]$range$start, list(line = 0, character = 8))
-    expect_equal(result[[1]]$range$end, list(line = 0, character = 8 + nchar(src_file)))
-    expect_equal(result[[1]]$target, path_to_uri(src_file))
+    expect_equal(result[[1]]$range$end, list(line = 0, character = 8 + nchar(src_file1)))
+    expect_equal(result[[1]]$target, path_to_uri(src_file1))
 
     expect_equal(result[[2]]$range$start, list(line = 1, character = 8))
-    expect_equal(result[[2]]$range$end, list(line = 1, character = 8 + nchar(basename(src_file))))
-    expect_equal(result[[2]]$target, path_to_uri(src_file))
+    expect_equal(result[[2]]$range$end, list(line = 1, character = 8 + nchar(basename(src_file1))))
+    expect_equal(result[[2]]$target, path_to_uri(src_file1))
+
+    expect_equal(result[[3]]$range$start, list(line = 2, character = 8))
+    expect_equal(result[[3]]$range$end, list(line = 2, character = 8 + nchar(src_file2)))
+    expect_equal(result[[3]]$target, path_to_uri(src_file2))
+    
+    expect_equal(result[[4]]$range$start, list(line = 3, character = 8))
+    expect_equal(result[[4]]$range$end, list(line = 3, character = 8 + nchar(basename(src_file2))))
+    expect_equal(result[[4]]$target, path_to_uri(src_file2))
 })
 
 test_that("Document link works in Rmarkdown", {
@@ -46,15 +63,23 @@ test_that("Document link works in Rmarkdown", {
     dir <- tempdir()
     client <- language_client(working_dir = dir)
 
-    withr::local_tempfile("src_file", tmpdir = dir, fileext = ".R")
+    withr::local_tempfile(c("src_file1", "src_file2"), tmpdir = dir, fileext = ".R")
     withr::local_tempfile("temp_file", tmpdir = dir, fileext = ".Rmd")
-    src_file <- normalizePath(src_file, "/", mustWork = FALSE)
+    src_file1 <- fs::path(src_file1)
+    src_file2 <- fs::path(src_file2)
 
     writeLines(
         c(
             "x <- 1"
         ),
-        src_file
+        src_file1
+    )
+    
+    writeLines(
+        c(
+            "x <- 2"
+        ),
+        src_file2
     )
 
     writeLines(
@@ -62,27 +87,36 @@ test_that("Document link works in Rmarkdown", {
             "---",
             "title: r markdown",
             "---",
-            sprintf("will source file '%s'", src_file),
+            sprintf("will source file '%s' and '%s'", src_file1, src_file2),
             "```{r}",
-            sprintf("source('%s')", src_file),
-            sprintf("source('%s')", basename(src_file)),
+            sprintf("source('%s')", src_file1),
+            sprintf("source('%s')", basename(src_file1)),
+            sprintf("source('%s')", src_file2),
+            sprintf("source('%s')", basename(src_file2)),
             "source('non_exist_file.R')",
             "```"
         ),
         temp_file
     )
 
-    client %>% did_save(src_file)
     client %>% did_save(temp_file)
 
     result <- client %>% respond_document_link(temp_file)
 
-    expect_length(result, 2)
+    expect_length(result, 4)
     expect_equal(result[[1]]$range$start, list(line = 5, character = 8))
-    expect_equal(result[[1]]$range$end, list(line = 5, character = 8 + nchar(src_file)))
-    expect_equal(result[[1]]$target, path_to_uri(src_file))
+    expect_equal(result[[1]]$range$end, list(line = 5, character = 8 + nchar(src_file1)))
+    expect_equal(result[[1]]$target, path_to_uri(src_file1))
 
     expect_equal(result[[2]]$range$start, list(line = 6, character = 8))
-    expect_equal(result[[2]]$range$end, list(line = 6, character = 8 + nchar(basename(src_file))))
-    expect_equal(result[[2]]$target, path_to_uri(src_file))
+    expect_equal(result[[2]]$range$end, list(line = 6, character = 8 + nchar(basename(src_file1))))
+    expect_equal(result[[2]]$target, path_to_uri(src_file1))
+
+    expect_equal(result[[3]]$range$start, list(line = 7, character = 8))
+    expect_equal(result[[3]]$range$end, list(line = 7, character = 8 + nchar(src_file2)))
+    expect_equal(result[[3]]$target, path_to_uri(src_file2))
+    
+    expect_equal(result[[4]]$range$start, list(line = 8, character = 8))
+    expect_equal(result[[4]]$range$end, list(line = 8, character = 8 + nchar(basename(src_file2))))
+    expect_equal(result[[4]]$target, path_to_uri(src_file2))
 })

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -51,7 +51,7 @@ test_that("Document link works", {
     expect_equal(result[[3]]$range$start, list(line = 2, character = 8))
     expect_equal(result[[3]]$range$end, list(line = 2, character = 8 + nchar(src_file2)))
     expect_equal(result[[3]]$target, path_to_uri(src_file2))
-    
+
     expect_equal(result[[4]]$range$start, list(line = 3, character = 8))
     expect_equal(result[[4]]$range$end, list(line = 3, character = 8 + nchar(basename(src_file2))))
     expect_equal(result[[4]]$target, path_to_uri(src_file2))
@@ -74,7 +74,7 @@ test_that("Document link works in Rmarkdown", {
         ),
         src_file1
     )
-    
+
     writeLines(
         c(
             "x <- 2"
@@ -115,7 +115,7 @@ test_that("Document link works in Rmarkdown", {
     expect_equal(result[[3]]$range$start, list(line = 7, character = 8))
     expect_equal(result[[3]]$range$end, list(line = 7, character = 8 + nchar(src_file2)))
     expect_equal(result[[3]]$target, path_to_uri(src_file2))
-    
+
     expect_equal(result[[4]]$range$start, list(line = 8, character = 8))
     expect_equal(result[[4]]$range$end, list(line = 8, character = 8 + nchar(basename(src_file2))))
     expect_equal(result[[4]]$target, path_to_uri(src_file2))


### PR DESCRIPTION
Closes #215 
Closes #216 

This PR imports `fs` to handle path-related issues.

* Replace `normalizePath()` with `fs::path_abs()` and `path.expand()` in `document_link_reply` so that symlinks are not resolved. If the link is a symlink, its target will be the symlink rather than the resolved real path.
* Add checking of `file:///` in `path_from_uri` to handle untitled document case where URI is `untitled:untitled-n`.
* Use `fs::path_has_parent` to correctly handle directory parent check since 
  * Document URI and R `tempdir()` have different cases of disk drive in Windows.
  * Document URI and rootPath may clash using `startsWith` (e.g. URI: `/home/user/project.R` and rootPath: `/home/user/project`)
* Fix document link since `path_to_uri` does not handle multiple paths.
* Add test cases for multiple document links.

Note that `path_to_uri` must respect the cases of letters or it would be inconsistent with editor generated URIs of documents.
