### PR TITLE
Fix handling null rootUri

### DIFF
--- a/R/handlers-general.R
+++ b/R/handlers-general.R
@@ -24,7 +24,7 @@ on_initialize <- function(self, id, params) {
 on_initialized <- function(self, params) {
     logger$info("on_initialized")
     project_root <- self$rootPath
-    if (is_package(project_root)) {
+    if (length(project_root) && is_package(project_root)) {
         source_dir <- file.path(project_root, "R")
         files <- list.files(source_dir)
         for (f in files) {

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -149,7 +149,8 @@ text_document_document_link  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- textDocument$uri
     document <- self$workspace$documents$get(uri)
-    reply <- document_link_reply(id, uri, self$workspace, document, self$rootPath)
+    rootPath <- if (length(self$rootPath)) self$rootPath else dirname(path_from_uri(uri))
+    reply <- document_link_reply(id, uri, self$workspace, document, rootPath)
     if (is.null(reply)) {
         queue <- self$pending_replies$get(uri)[["textDocument/documentLink"]]
         queue$push(list(


### PR DESCRIPTION
Closes #219 

This PR checks `self$rootPath` on initialization and in `document_link_reply` so that it could handle the case where `rootPath` is `null`. `document_link_reply` is also fixed so that it could handle it when `rootPath` is `null` and document is untitled (`uri = "untitled:untitled-n"`).