### PR TITLE
Always use content in diagnose_file

### DIFF
--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -67,11 +67,8 @@ find_config <- function(filename) {
 #' Lint and diagnose problems in a file.
 #' @keywords internal
 diagnose_file <- function(uri, content) {
-    path <- path_from_uri(uri)
-    if (is.null(find_config(path))) {
-        linters <- getOption("languageserver.default_linters", NULL)
-    } else {
-        linters <- NULL
+    if (length(content) == 0) {
+        return(list())
     }
 
     if (is_rmarkdown(uri)) {
@@ -81,7 +78,14 @@ diagnose_file <- function(uri, content) {
         }
     }
 
-    if (length(content) <= 1) {
+    path <- path_from_uri(uri)
+    if (is.null(find_config(path))) {
+        linters <- getOption("languageserver.default_linters", NULL)
+    } else {
+        linters <- NULL
+    }
+
+    if (length(content) == 1) {
         content <- c(content, "")
     }
 

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -74,24 +74,20 @@ diagnose_file <- function(uri, content) {
         linters <- NULL
     }
 
-    if (length(content) <= 1 && file.exists(path)) {
-        # lintr::lint doesn't work with one line text
-        content <- readr::read_lines(path)
-        diagnostics <- lapply(
-            lintr::lint(path, linters = linters), diagnostic_from_lint, content = content)
-    } else {
-        if (is_rmarkdown(path)) {
-            # make sure Rmarkdown file has at least one block
-            if (!any(stringr::str_detect(content, "```\\{r[ ,\\}]"))) {
-                return(list())
-            }
+    if (is_rmarkdown(uri)) {
+        # make sure Rmarkdown file has at least one block
+        if (!any(stringr::str_detect(content, "```\\{r[ ,\\}]"))) {
+            return(list())
         }
-        # use inline data
-        text <- paste0(content, collapse = "\n")
-        diagnostics <- lapply(
-            lintr::lint(text, linters = linters), diagnostic_from_lint, content = content)
-
     }
+
+    if (length(content) <= 1) {
+        content <- c(content, "")
+    }
+
+    text <- paste0(content, collapse = "\n")
+    diagnostics <- lapply(
+        lintr::lint(text, linters = linters), diagnostic_from_lint, content = content)
     names(diagnostics) <- NULL
     diagnostics
 }


### PR DESCRIPTION
Closes #222 

This PR always uses `content` in `diagnose_file` and fixes one-line content so that it could correctly handle one-line content and untitled document.

We should avoid reading the file from the path of URI as long as we could get the content, or otherwise the unsaved or untitled document cannot be handled correctly.
