### PR TITLE
Remove dependency on stringr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     R6 (>= 2.4.1),
     readr (>= 1.3.1),
     repr (>= 1.1.0),
-    stringr (>= 1.4.0),
+    stringi (>= 1.1.7),
     styler (>= 1.2.0),
     tools,
     utils,

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -73,7 +73,7 @@ diagnose_file <- function(uri, content) {
 
     if (is_rmarkdown(uri)) {
         # make sure Rmarkdown file has at least one block
-        if (!any(stringr::str_detect(content, "```\\{r[ ,\\}]"))) {
+        if (!any(stringi::stri_detect_regex(content, "```\\{r[ ,\\}]"))) {
             return(list())
         }
     }

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -106,7 +106,7 @@ range_formatting_reply <- function(id, uri, document, range, options) {
     }
 
     selection <- document$content[(row1:row2) + 1]
-    indentation <- stringr::str_extract(selection[1], "^\\s*")
+    indentation <- stringi::stri_extract_first_regex(selection[1], "^\\s*")
     new_text <- style_text(selection, style, indentation = indentation)
     if (is.null(new_text)) {
         return(Response$new(id, list()))
@@ -195,7 +195,7 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
         # disable assignment operator fix since end_line could be function parameter
         style$token$force_assignment_op <- NULL
 
-        indentation <- stringr::str_extract(content[start_line], "^\\s*")
+        indentation <- stringi::stri_extract_first_regex(content[start_line], "^\\s*")
         new_text <- tryCatchTimeout(
             style_text(content[start_line:end_line], style, indentation = indentation),
             timeout = 1,

--- a/R/handlers-textsync.R
+++ b/R/handlers-textsync.R
@@ -10,7 +10,7 @@ text_document_did_open <- function(self, params) {
     logger$info("did open:", list(uri = uri, version = version))
     path <- path_from_uri(uri)
     if (!is.null(text)) {
-        content <- stringr::str_split(text, "\r\n|\n")[[1]]
+        content <- stringi::stri_split_lines1(text)
     } else if (file.exists(path)) {
         content <- readr::read_lines(path)
     } else {
@@ -37,7 +37,7 @@ text_document_did_change <- function(self, params) {
     version <- textDocument$version
     text <- contentChanges[[1]]$text
     logger$info("did change:", list(uri = uri, version = version))
-    content <- stringr::str_split(text, "\r\n|\n")[[1]]
+    content <- stringi::stri_split_lines1(text)
     if (self$workspace$documents$has(uri)) {
         doc <- self$workspace$documents$get(uri)
         doc$set_content(version, content)
@@ -67,7 +67,7 @@ text_document_did_save <- function(self, params) {
     logger$info("did save:", list(uri = uri))
     path <- path_from_uri(uri)
     if (!is.null(text)) {
-        content <- stringr::str_split(text, "\r\n|\n")[[1]]
+        content <- stringi::stri_split_lines1(text)
     } else if (file.exists(path)) {
         content <- readr::read_lines(path)
     } else {

--- a/R/hover.R
+++ b/R/hover.R
@@ -101,7 +101,7 @@ hover_reply <- function(id, uri, workspace, document, point) {
                         if (is.null(sig)) {
                             contents <- doc_string
                         } else {
-                            sig <- stringr::str_trunc(sig, 300)
+                            sig <- str_trunc(sig, 300)
                             contents <- c(
                                 sprintf("```r\n%s\n```", sig),
                                 sprintf("`%s` - %s", token_text, doc_string))

--- a/R/languagebase.R
+++ b/R/languagebase.R
@@ -67,7 +67,7 @@ LanguageBase <- R6::R6Class("LanguageBase",
                     if (!startsWith(header, "Content")) {
                         stop("Unexpected non-empty line")
                     }
-                    matches <- stringr::str_match(header, "Content-Length: ([0-9]+)")
+                    matches <- stringi::stri_match_first_regex(header, "Content-Length: ([0-9]+)")
                     if (!is.na(matches[2])) {
                         bytes <- as.integer(matches[2])
                     }

--- a/tests/testthat/test-hover.R
+++ b/tests/testthat/test-hover.R
@@ -17,12 +17,12 @@ test_that("Simple hover works", {
 
     result <- client %>% respond_hover(temp_file, c(0, 7))
     expect_length(result$contents, 1)
-    expect_true(stringr::str_detect(result$contents[1], "strsplit"))
+    expect_true(stringi::stri_detect_fixed(result$contents[1], "strsplit"))
     expect_equal(result$range$end$character, 12)
 
     result <- client %>% respond_hover(temp_file, c(1, 7))
     expect_length(result$contents, 1)
-    expect_true(stringr::str_detect(result$contents[1], "path_real"))
+    expect_true(stringi::stri_detect_fixed(result$contents[1], "path_real"))
     expect_equal(result$range$end$character, 13)
 })
 
@@ -149,12 +149,12 @@ test_that("Simple hover works in Rmarkdown", {
 
     result <- client %>% respond_hover(temp_file, c(5, 7))
     expect_length(result$contents, 1)
-    expect_true(stringr::str_detect(result$contents[1], "strsplit"))
+    expect_true(stringi::stri_detect_fixed(result$contents[1], "strsplit"))
     expect_equal(result$range$end$character, 12)
 
     result <- client %>% respond_hover(temp_file, c(6, 7))
     expect_length(result$contents, 1)
-    expect_true(stringr::str_detect(result$contents[1], "path_real"))
+    expect_true(stringi::stri_detect_fixed(result$contents[1], "path_real"))
     expect_equal(result$range$end$character, 13)
 })
 


### PR DESCRIPTION
Related to #125 
Follows up #229 

From https://github.com/REditorSupport/languageserver/pull/229#issuecomment-596041158.

>It seems that we could also remove dependency on stringr and use stringi regex functions directly since stringr uses stringi as backend but also imports glue which we have already removed the dependency, although this may not contribute much to reducing the installation size.

In this PR, most `stringr` calls are replaced with correponding `stringi` calls with less overhead.

Only `stringr::str_trunc` has not equivalent in `stringi` so I put a simplified version in `utils.R`.