### PR TITLE
Respect client snippetSupport

### DIFF
--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -7,7 +7,8 @@ text_document_completion  <- function(self, id, params) {
     uri <- textDocument$uri
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
-    self$deliver(completion_reply(id, uri, self$workspace, document, point))
+    self$deliver(completion_reply(id, uri, self$workspace, document, point,
+        self$ClientCapabilities$textDocument$completion))
 }
 
 #' `completionItem/resolve` request handler

--- a/man/completion_reply.Rd
+++ b/man/completion_reply.Rd
@@ -4,7 +4,7 @@
 \alias{completion_reply}
 \title{The response to a textDocument/completion request}
 \usage{
-completion_reply(id, uri, workspace, document, point)
+completion_reply(id, uri, workspace, document, point, capabilities)
 }
 \description{
 The response to a textDocument/completion request

--- a/man/workspace_completion.Rd
+++ b/man/workspace_completion.Rd
@@ -5,7 +5,7 @@
 \title{Complete any object in the workspace}
 \usage{
 workspace_completion(workspace, token, package = NULL,
-  exported_only = TRUE)
+  exported_only = TRUE, capabilities = NULL)
 }
 \description{
 Complete any object in the workspace


### PR DESCRIPTION
Follows up #168 
Closes #231 

This PR respects `snippetSupport` client capability so that function completion snippet like `foo($0)` is only used when client `snippetSupport = true`.
