### PR TITLE
Run tasks with delay to reduce CPU usage on input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Imports:
     fs (>= 1.3.1),
     jsonlite (>= 1.6),
     lintr (>= 2.0.0),
+    parallel,
     R6 (>= 2.4.1),
     repr (>= 1.1.0),
     stringi (>= 1.1.7),

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -116,7 +116,7 @@ diagnostics_callback <- function(self, uri, version, diagnostics) {
 }
 
 
-diagnostics_task <- function(self, uri, document, ...) {
+diagnostics_task <- function(self, uri, document, delay = 0) {
     version <- document$version
     content <- document$content
     create_task(
@@ -134,5 +134,7 @@ diagnostics_task <- function(self, uri, document, ...) {
                 source = "lintr",
                 message = paste0("Failed to run diagnostics: ", conditionMessage(e))
             )))
-        }, ...)
+        },
+        delay = delay
+    )
 }

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -116,12 +116,12 @@ diagnostics_callback <- function(self, uri, version, diagnostics) {
 }
 
 
-diagnostics_task <- function(self, uri, document) {
+diagnostics_task <- function(self, uri, document, ...) {
     version <- document$version
     content <- document$content
     create_task(
-        package_call(diagnose_file),
-        list(uri = uri, content = content),
+        target = package_call(diagnose_file),
+        args = list(uri = uri, content = content),
         callback = function(result) diagnostics_callback(self, uri, version, result),
         error = function(e) {
             logger$info("diagnostics_task:", e)
@@ -134,5 +134,5 @@ diagnostics_task <- function(self, uri, document) {
                 source = "lintr",
                 message = paste0("Failed to run diagnostics: ", conditionMessage(e))
             )))
-        })
+        }, ...)
 }

--- a/R/document.R
+++ b/R/document.R
@@ -315,14 +315,15 @@ parse_callback <- function(self, uri, version, parse_data) {
     }
 }
 
-parse_task <- function(self, uri, document) {
+parse_task <- function(self, uri, document, ...) {
     version <- document$version
     content <- document$content
     create_task(
-        package_call(parse_document),
-        list(uri = uri, content = content),
+        target = package_call(parse_document),
+        args = list(uri = uri, content = content),
         callback = function(result) parse_callback(self, uri, version, result),
-        error = function(e) logger$info("parse_task:", e))
+        error = function(e) logger$info("parse_task:", e),
+        ...)
 }
 
 resolve_callback <- function(self, uri, version, packages) {
@@ -334,11 +335,12 @@ resolve_callback <- function(self, uri, version, packages) {
     self$workspace$update_loaded_packages()
 }
 
-resolve_task <- function(self, uri, document, packages) {
+resolve_task <- function(self, uri, document, packages, ...) {
     version <- document$version
     create_task(
-        resolve_attached_packages,
-        list(pkgs = packages),
+        target = resolve_attached_packages,
+        args = list(pkgs = packages),
         callback = function(result) resolve_callback(self, uri, version, result),
-        error = function(e) logger$info("resolve_task:", e))
+        error = function(e) logger$info("resolve_task:", e),
+        ...)
 }

--- a/R/document.R
+++ b/R/document.R
@@ -315,7 +315,7 @@ parse_callback <- function(self, uri, version, parse_data) {
     }
 }
 
-parse_task <- function(self, uri, document, ...) {
+parse_task <- function(self, uri, document, delay = 0) {
     version <- document$version
     content <- document$content
     create_task(
@@ -323,7 +323,8 @@ parse_task <- function(self, uri, document, ...) {
         args = list(uri = uri, content = content),
         callback = function(result) parse_callback(self, uri, version, result),
         error = function(e) logger$info("parse_task:", e),
-        ...)
+        delay = delay
+    )
 }
 
 resolve_callback <- function(self, uri, version, packages) {
@@ -335,12 +336,13 @@ resolve_callback <- function(self, uri, version, packages) {
     self$workspace$update_loaded_packages()
 }
 
-resolve_task <- function(self, uri, document, packages, ...) {
+resolve_task <- function(self, uri, document, packages, delay = 0) {
     version <- document$version
     create_task(
         target = resolve_attached_packages,
         args = list(pkgs = packages),
         callback = function(result) resolve_callback(self, uri, version, result),
         error = function(e) logger$info("resolve_task:", e),
-        ...)
+        delay = 0
+    )
 }

--- a/R/handlers-textsync.R
+++ b/R/handlers-textsync.R
@@ -45,7 +45,7 @@ text_document_did_change <- function(self, params) {
         doc <- Document$new(uri, version, content)
         self$workspace$documents$set(uri, doc)
     }
-    self$text_sync(uri, document = doc, run_lintr = TRUE, parse = TRUE)
+    self$text_sync(uri, document = doc, run_lintr = TRUE, parse = TRUE, delay = 0.5)
 }
 
 #' `textDocument/willSave` notification handler

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -73,12 +73,12 @@ LanguageServer <- R6::R6Class("LanguageServer",
             self$diagnostics_task_manager$check_tasks()
             self$parse_task_manager$run_tasks()
             self$parse_task_manager$check_tasks()
-            self$resolve_task_manager$run_tasks(delay = 0)
+            self$resolve_task_manager$run_tasks()
             self$resolve_task_manager$check_tasks()
         },
 
         text_sync = function(
-                uri, document, run_lintr = FALSE, parse = FALSE) {
+                uri, document, run_lintr = FALSE, parse = FALSE, delay = 0) {
 
             if (!self$pending_replies$has(uri)) {
                 self$pending_replies$set(uri, list(
@@ -94,7 +94,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
                     !fs::path_has_parent(path_from_uri(uri), temp_root)) {
                     self$diagnostics_task_manager$add_task(
                         uri,
-                        diagnostics_task(self, uri, document)
+                        diagnostics_task(self, uri, document, delay = delay)
                     )
                 }
             }
@@ -102,7 +102,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
             if (parse) {
                 self$parse_task_manager$add_task(
                     uri,
-                    parse_task(self, uri, document)
+                    parse_task(self, uri, document, delay = delay)
                 )
             }
         },

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -73,7 +73,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
             self$diagnostics_task_manager$check_tasks()
             self$parse_task_manager$run_tasks()
             self$parse_task_manager$check_tasks()
-            self$resolve_task_manager$run_tasks()
+            self$resolve_task_manager$run_tasks(delay = 0)
             self$resolve_task_manager$check_tasks()
         },
 

--- a/R/task.R
+++ b/R/task.R
@@ -49,19 +49,21 @@ Task <- R6::R6Class("Task",
 
 TaskManager <- R6::R6Class("TaskManager",
     private = list(
+        cpus = NULL,
         pending_tasks = NULL,
         running_tasks = NULL
     ),
     public = list(
         initialize = function() {
+            private$cpus <- parallel::detectCores()
             private$pending_tasks <- collections::ordered_dict()
             private$running_tasks <- collections::ordered_dict()
         },
         add_task = function(id, task) {
             private$pending_tasks$set(id, task)
         },
-        run_tasks = function(n = 8, delay = 0.5) {
-            n <- max(n - private$running_tasks$size(), 0)
+        run_tasks = function(cpu_load = 0.5, delay = 0.5) {
+            n <- max(max(private$cpus * cpu_load, 1) - private$running_tasks$size(), 0)
             ids <- private$pending_tasks$keys()
             if (length(ids) > n) {
                 ids <- ids[seq_len(n)]

--- a/R/task.R
+++ b/R/task.R
@@ -67,12 +67,12 @@ TaskManager <- R6::R6Class("TaskManager",
                 ids <- ids[seq_len(n)]
             }
             for (id in ids) {
-                if (private$running_tasks$has(id)) {
-                    task <- private$running_tasks$pop(id)
-                    task$kill()
-                }
                 task <- private$pending_tasks$get(id)
                 if (Sys.time() - task$time >= delay) {
+                    if (private$running_tasks$has(id)) {
+                        task <- private$running_tasks$pop(id)
+                        task$kill()
+                    }
                     task <- private$pending_tasks$pop(id)
                     private$running_tasks$set(id, task)
                     task$start()


### PR DESCRIPTION
Closes #245.

Originally, `throttle` is used to ensure that `run_tasks` is not called too frequently. However, if user input multiple characters in a short span of time (less than `t`) after some idle time, then only the first input triggers `run_tasks`, resulting in out-of-sync results. If user no longer changes the document, then the results will be out-of-sync forever.

This PR changes the throttle behavior of `TaskManager` so that each task gets a `time` at creation and the task manager only runs tasks older than `delay` seconds. Therefore, within `delay` seconds, the tasks are only replaced on user input. If any task is older than `delay`, then it will be executed. This ensures that the outcome is always sync when user stops changing the document.

Since diagnostics task, parse task are directly triggered by didChange, and resolve task is only created when parse task is finished, only diagnostics and parse need a delay to reduce unnecessary CPU usage while resolve does not need a delay.

With some trying, `delay = 0.5` seems a reasonable value for most cases which effectively drops unnecessary tasks while keeps me feeling that the lsp is responsive enough.