### PR TITLE
Add a test case for null workspace root

### DIFF
--- a/tests/testthat/test-null-root.R
+++ b/tests/testthat/test-null-root.R
@@ -1,0 +1,19 @@
+context("Test Null-root Workspace")
+
+test_that("Null-root workspace works", {
+  skip_on_cran()
+  client <- language_client(NULL)
+
+  withr::local_tempfile(c("temp_file"), fileext = ".R")
+  writeLines(
+    c(
+      "file.path("
+    ),
+    temp_file)
+
+  client %>% did_save(temp_file)
+
+  result <- client %>% respond_signature(temp_file, c(0, 10))
+  expect_length(result$signatures, 1)
+  expect_match(result$signatures[[1]]$label, "file\\.path\\(.*")
+})


### PR DESCRIPTION
This PR adds a test case for  6fff92f that closes #249.