### PR TITLE
Generalize rmd chunk pattern

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -106,7 +106,7 @@ check_scope <- function(uri, document, point) {
             document$content[1:(row + 1)], startsWith, logical(1), "```", USE.NAMES = FALSE)
         if (any(flags)) {
             last_match <- document$content[max(which(flags))]
-            stringi::stri_detect_regex(last_match, "```\\{r[ ,\\}]") &&
+            stringi::stri_detect_regex(last_match, "`{3,}\\s*\\{r[ ,\\}]") &&
                 !identical(sum(flags) %% 2, 0) &&
                 !enclosed_by_quotes(document, point)
         } else {
@@ -135,7 +135,7 @@ seq_safe <- function(a, b) {
 #' @keywords internal
 extract_blocks <- function(content) {
     begins_or_ends <- which(stringi::stri_detect_fixed(content, "```"))
-    begins <- which(stringi::stri_detect_regex(content, "```\\{r[ ,\\}]"))
+    begins <- which(stringi::stri_detect_regex(content, "`{3,}\\s*\\{r[ ,\\}]"))
     ends <- setdiff(begins_or_ends, begins)
     blocks <- list()
     for (begin in begins) {


### PR DESCRIPTION
Closes #255 

This PR generalizes the Rmd code chunk pattern.

The following are valid Rmd code chunks supported by both RStudio and knitr.

* Spaces between backticks and `{r}`:

````r
``` {r}
x <- rnorm(100)
```
````

* More than 3 backticks:

`````r
````{r}
x <- rnorm(100)
````
`````