### PR TITLE
Use more conservative pool_size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,9 +92,7 @@ jobs:
     - name: Running Tests
       run: |
         New-Item -ItemType directory -Path C:/tmp/languageserver
-        # rcmdcheck is not working very well with the task session
-        # Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), error_on = 'error')"
-        Rscript -e "devtools::test()"
+        Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), error_on = 'error')"
     - uses: actions/upload-artifact@v1
       if: failure()
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       NOT_CRAN: true
       R_LANGSVR_LOG: /tmp/languageserver/log
+      R_LANGSVR_POOL_SIZE: 1
     steps:
     - uses: actions/checkout@v1
     - name: Install apt-get dependencies
@@ -51,6 +52,7 @@ jobs:
     env:
       NOT_CRAN: true
       R_LANGSVR_LOG: /tmp/languageserver/log
+      R_LANGSVR_POOL_SIZE: 1
     steps:
     - uses: actions/checkout@v1
     - uses: r-lib/actions/setup-r@v1
@@ -81,6 +83,7 @@ jobs:
     env:
       NOT_CRAN: true
       R_LANGSVR_LOG: C:/tmp/languageserver/log
+      R_LANGSVR_POOL_SIZE: 1
     steps:
     - uses: actions/checkout@v1
     - uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,9 @@ jobs:
         Rscript -e "install.packages(c('remotes', 'rcmdcheck'), repos = 'https://cloud.r-project.org')"
         Rscript -e "remotes::install_deps(dependencies = TRUE)"
     - name: Running Tests
+      timeout-minutes: 10
       run: |
-        Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), timeout = 600, error_on = 'error')"
+        Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), error_on = 'error')"
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
@@ -61,9 +62,10 @@ jobs:
         Rscript -e "install.packages(c('remotes', 'rcmdcheck'), repos = 'https://cloud.r-project.org', type = 'mac.binary.el-capitan')"
         Rscript -e "remotes::install_deps(dependencies = TRUE, type = 'mac.binary.el-capitan')"
     - name: Running Tests
+      timeout-minutes: 10
       run: |
         mkdir -p /tmp/languageserver
-        Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), timeout = 600, error_on = 'error')"
+        Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), error_on = 'error')"
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
@@ -93,9 +95,10 @@ jobs:
         # in Windows, we need to install a seperate copy for spawning server in the tests
         Rscript -e "devtools::install(type = 'win.binary')"
     - name: Running Tests
+      timeout-minutes: 10
       run: |
         New-Item -ItemType directory -Path C:/tmp/languageserver
-        Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), timeout = 600, error_on = 'error')"
+        Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), error_on = 'error')"
     - uses: actions/upload-artifact@v1
       if: failure()
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ on: [push, pull_request]
 jobs:
   linux:
     if: contains(github.event.head_commit.message, '[ci skip]') == false
-    timeout-minutes: 15
     strategy:
       matrix:
         r: [latest]
@@ -30,7 +29,7 @@ jobs:
         Rscript -e "remotes::install_deps(dependencies = TRUE)"
     - name: Running Tests
       run: |
-        Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), error_on = 'error')"
+        Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), timeout = 600, error_on = 'error')"
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
@@ -43,7 +42,6 @@ jobs:
 
   macos:
     if: contains(github.event.head_commit.message, '[ci skip]') == false
-    timeout-minutes: 15
     strategy:
       matrix:
         r: [latest]
@@ -65,7 +63,7 @@ jobs:
     - name: Running Tests
       run: |
         mkdir -p /tmp/languageserver
-        Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), error_on = 'error')"
+        Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), timeout = 600, error_on = 'error')"
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
@@ -74,7 +72,6 @@ jobs:
 
   windows:
     if: contains(github.event.head_commit.message, '[ci skip]') == false
-    timeout-minutes: 15
     strategy:
       matrix:
         r: [latest]
@@ -98,7 +95,7 @@ jobs:
     - name: Running Tests
       run: |
         New-Item -ItemType directory -Path C:/tmp/languageserver
-        Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), error_on = 'error')"
+        Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), timeout = 600, error_on = 'error')"
     - uses: actions/upload-artifact@v1
       if: failure()
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
       NOT_CRAN: true
       R_LANGSVR_LOG: /tmp/languageserver/log
       R_LANGSVR_POOL_SIZE: 1
+      R_LANGSVR_TEST_FAST: NO
     steps:
     - uses: actions/checkout@v1
     - name: Install apt-get dependencies
@@ -51,6 +52,7 @@ jobs:
       NOT_CRAN: true
       R_LANGSVR_LOG: /tmp/languageserver/log
       R_LANGSVR_POOL_SIZE: 1
+      R_LANGSVR_TEST_FAST: NO
     steps:
     - uses: actions/checkout@v1
     - uses: r-lib/actions/setup-r@v1
@@ -81,6 +83,7 @@ jobs:
       NOT_CRAN: true
       R_LANGSVR_LOG: C:/tmp/languageserver/log
       R_LANGSVR_POOL_SIZE: 1
+      R_LANGSVR_TEST_FAST: NO
     steps:
     - uses: actions/checkout@v1
     - uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,6 @@ jobs:
         Rscript -e "install.packages(c('remotes', 'rcmdcheck'), repos = 'https://cloud.r-project.org')"
         Rscript -e "remotes::install_deps(dependencies = TRUE)"
     - name: Running Tests
-      timeout-minutes: 10
       run: |
         Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), error_on = 'error')"
     - uses: actions/upload-artifact@v1
@@ -62,7 +61,6 @@ jobs:
         Rscript -e "install.packages(c('remotes', 'rcmdcheck'), repos = 'https://cloud.r-project.org', type = 'mac.binary.el-capitan')"
         Rscript -e "remotes::install_deps(dependencies = TRUE, type = 'mac.binary.el-capitan')"
     - name: Running Tests
-      timeout-minutes: 10
       run: |
         mkdir -p /tmp/languageserver
         Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), error_on = 'error')"
@@ -95,7 +93,6 @@ jobs:
         # in Windows, we need to install a seperate copy for spawning server in the tests
         Rscript -e "devtools::install(type = 'win.binary')"
     - name: Running Tests
-      timeout-minutes: 10
       run: |
         New-Item -ItemType directory -Path C:/tmp/languageserver
         Rscript -e "rcmdcheck::rcmdcheck(args = c('--as-cran', '--no-manual', '--timings'), error_on = 'error')"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   linux:
     if: contains(github.event.head_commit.message, '[ci skip]') == false
+    timeout-minutes: 15
     strategy:
       matrix:
         r: [latest]
@@ -41,6 +42,7 @@ jobs:
 
   macos:
     if: contains(github.event.head_commit.message, '[ci skip]') == false
+    timeout-minutes: 15
     strategy:
       matrix:
         r: [latest]
@@ -70,6 +72,7 @@ jobs:
 
   windows:
     if: contains(github.event.head_commit.message, '[ci skip]') == false
+    timeout-minutes: 15
     strategy:
       matrix:
         r: [latest]

--- a/R/languageclient.R
+++ b/R/languageclient.R
@@ -23,7 +23,7 @@ LanguageClient <- R6::R6Class("LanguageClient",
 
         finalize = function() {
             if (!is.null(self$process)) {
-                self$process$kill()
+                self$process$kill_tree()
             }
             super$finalize()
         },

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -53,7 +53,8 @@ LanguageServer <- R6::R6Class("LanguageServer",
             self$outputcon <- outputcon
 
             cpus <- parallel::detectCores()
-            pool_size <- min(max(floor(cpus / 2), 1), 3)
+            pool_size <- as.integer(
+                Sys.getenv("R_LANGSVR_POOL_SIZE", min(max(floor(cpus / 2), 1), 3)))
             # parse pool
             parse_pool <- SessionPool$new(pool_size, "parse")
             # diagnostics is slower, so use a seperated pool

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -53,7 +53,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
             self$outputcon <- outputcon
 
             cpus <- parallel::detectCores()
-            pool_size <- min(max(cpus, 2), 3)
+            pool_size <- min(max(floor(cpus / 2), 1), 3)
             # parse pool
             parse_pool <- SessionPool$new(pool_size, "parse")
             # diagnostics is slower, so use a seperated pool

--- a/R/session.R
+++ b/R/session.R
@@ -73,7 +73,8 @@ Session <- R6::R6Class("Session",
             private$id <- id
 
             private$session <- callr::r_session$new(
-                callr::r_session_options(system_profile = TRUE, user_profile = TRUE),
+                callr::r_session_options(
+                    system_profile = TRUE, user_profile = TRUE, supervise = TRUE),
                 # skip waiting
                 wait = FALSE
             )

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -44,11 +44,11 @@ language_client <- function(working_dir = getwd(), diagnostics = FALSE, capabili
             client %>% respond("shutdown", NULL, retry = FALSE)
             client$process$wait(30)
             if (client$process$is_alive()) {
-                client$stop()
+                client$process$kill_tree()
                 fail("server did not shutdown peacefully")
             }
         } else {
-            client$stop()
+            client$process$kill_tree()
         }
     })
     client

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -38,13 +38,13 @@ language_client <- function(working_dir = getwd(), diagnostics = FALSE, capabili
     client %>% notify(
         "workspace/didChangeConfiguration", list(settings = list(diagnostics = diagnostics)))
     withr::defer_parent({
-        if (Sys.getenv("R_COVR", "") == "true") {
-            # it is necessary to shutdown the server in covr
-            # we skip this for other times for speed
-            client %>% respond("shutdown", NULL, retry = FALSE)
-            client$process$wait()
-        } else {
+        # it is necessary to shutdown the server in covr
+        # we skip this for other times for speed
+        client %>% respond("shutdown", NULL, retry = FALSE)
+        client$process$wait(30)
+        if (client$process$is_alive()) {
             client$stop()
+            fail("server did not shutdown peacefully")
         }
     })
     client


### PR DESCRIPTION
Follows up #265.

The `pool_size` is altered to be more conservative for machines with fewer CPUs.

```
cpus<=3, pool_size=1
4<=cpus<=5, pool_size=2
cpus>=6, pool_size=3
```