### PR TITLE
Use old behavior if formatting scope < indention

### DIFF
--- a/R/formatting.R
+++ b/R/formatting.R
@@ -48,7 +48,6 @@ style_text <- function(text, style, indentation = 0L) {
             }, error = function(e) e)
         }
     }
-    logger$info("style_text: ", list(text = text, new_text = new_text))
     if (inherits(new_text, "error")) {
         logger$info("formatting error:", new_text$message)
         return(NULL)


### PR DESCRIPTION
As suggested at https://github.com/r-lib/styler/issues/641#issuecomment-636771120, `style$indention` is checked so that #268 is only applied to `scope >= "indention"`.