### PR TITLE
Fix handling raw string in link and color

### DIFF
--- a/R/color.R
+++ b/R/color.R
@@ -22,7 +22,6 @@ document_color_reply <- function(id, uri, workspace, document) {
         is_color <- !grepl("^[rR]", str_expr) &
             (grepl("^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$", str_texts) |
                 str_texts %in% grDevices::colors())
-        color_tokens <- str_tokens[is_color]
         color_texts <- str_texts[is_color]
         color_line1 <- str_line1[is_color]
         color_col1 <- str_col1[is_color]

--- a/R/link.R
+++ b/R/link.R
@@ -22,20 +22,19 @@ document_link_reply <- function(id, uri, workspace, document, rootPath) {
         paths <- fs::path_abs(str_texts, rootPath)
 
         is_link <- file.exists(paths) & !dir.exists(paths)
-        link_tokens <- str_tokens[is_link]
         link_paths <- path.expand(paths[is_link])
         link_expr <- str_expr[is_link]
         is_raw_string <- grepl("^[rR]", link_expr)
         link_line1 <- str_line1[is_link]
         link_col1 <- str_col1[is_link] + is_raw_string
-        link_col2 <- str_col2[is_link] - 1
+        link_col2 <- str_col2[is_link]
         uris <- vapply(link_paths, path_to_uri, character(1))
 
         result <- .mapply(function(line, col1, col2, uri) {
             list(
                 range = range(
                     start = document$to_lsp_position(line - 1, col1),
-                    end = document$to_lsp_position(line - 1, col2)
+                    end = document$to_lsp_position(line - 1, col2 - 1)
                 ),
                 target = uri
             )

--- a/R/link.R
+++ b/R/link.R
@@ -13,28 +13,33 @@ document_link_reply <- function(id, uri, workspace, document, rootPath) {
     xdoc <- parse_data$xml_doc
     if (!is.null(xdoc)) {
         str_tokens <- xml_find_all(xdoc, "//STR_CONST[@line1=@line2 and @col2 > @col1 + 1]")
-        str_texts <- xml_text(str_tokens)
-        str_texts <- substr(str_texts, 2, nchar(str_texts) - 1)
-
-        paths <- fs::path_abs(str_texts, rootPath)
-
-        sel <- file.exists(paths) & !dir.exists(paths)
-        str_tokens <- str_tokens[sel]
-        paths <- path.expand(paths[sel])
-        uris <- vapply(paths, path_to_uri, character(1))
-
         str_line1 <- as.integer(xml_attr(str_tokens, "line1"))
         str_col1 <- as.integer(xml_attr(str_tokens, "col1"))
         str_col2 <- as.integer(xml_attr(str_tokens, "col2"))
+        str_expr <- substr(document$content[str_line1], str_col1, str_col2)
+        str_texts <- as.character(parse(text = str_expr, keep.source = FALSE))
+
+        paths <- fs::path_abs(str_texts, rootPath)
+
+        is_link <- file.exists(paths) & !dir.exists(paths)
+        link_tokens <- str_tokens[is_link]
+        link_paths <- path.expand(paths[is_link])
+        link_expr <- str_expr[is_link]
+        is_raw_string <- grepl("^[rR]", link_expr)
+        link_line1 <- str_line1[is_link]
+        link_col1 <- str_col1[is_link] + is_raw_string
+        link_col2 <- str_col2[is_link] - 1
+        uris <- vapply(link_paths, path_to_uri, character(1))
+
         result <- .mapply(function(line, col1, col2, uri) {
             list(
                 range = range(
                     start = document$to_lsp_position(line - 1, col1),
-                    end = document$to_lsp_position(line - 1, col2 - 1)
+                    end = document$to_lsp_position(line - 1, col2)
                 ),
                 target = uri
             )
-        }, list(str_line1, str_col1, str_col2, uris), NULL)
+        }, list(link_line1, link_col1, link_col2, uris), NULL)
     }
 
     if (is.null(result)) {

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -57,7 +57,7 @@ test_that("Document link works", {
     expect_equal(result[[4]]$target, path_to_uri(src_file2))
 })
 
-test_that("Document link works work raw strings", {
+test_that("Document link works with raw strings", {
     skip_on_cran()
     skip_if(getRversion() < "4.0.0")
 

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -57,6 +57,64 @@ test_that("Document link works", {
     expect_equal(result[[4]]$target, path_to_uri(src_file2))
 })
 
+test_that("Document link works work raw strings", {
+    skip_on_cran()
+    skip_if(getRversion() < "4.0.0")
+
+    dir <- tempdir()
+    client <- language_client(dir)
+
+    withr::local_tempfile(c("src_file1", "src_file2", "temp_file"), tmpdir = dir, fileext = ".R")
+    src_file1 <- fs::path(src_file1)
+    src_file2 <- fs::path(src_file2)
+
+    writeLines(
+        c(
+            "x <- 1"
+        ),
+        src_file1
+    )
+
+    writeLines(
+        c(
+            "x <- 2"
+        ),
+        src_file2
+    )
+
+    writeLines(
+        c(
+            sprintf("source(r'(%s)')", src_file1),
+            sprintf("source(R'{%s}')", basename(src_file1)),
+            sprintf("source(r'-(%s)-')", src_file2),
+            sprintf("source(R'--{%s}--')", basename(src_file2)),
+            "source(r'(non_exist_file.R)')"
+        ),
+        temp_file
+    )
+
+    client %>% did_save(temp_file)
+
+    result <- client %>% respond_document_link(temp_file)
+
+    expect_length(result, 4)
+    expect_equal(result[[1]]$range$start, list(line = 0, character = 9))
+    expect_equal(result[[1]]$range$end, list(line = 0, character = 9 + nchar(src_file1) + 2))
+    expect_equal(result[[1]]$target, path_to_uri(src_file1))
+
+    expect_equal(result[[2]]$range$start, list(line = 1, character = 9))
+    expect_equal(result[[2]]$range$end, list(line = 1, character = 9 + nchar(basename(src_file1)) + 2))
+    expect_equal(result[[2]]$target, path_to_uri(src_file1))
+
+    expect_equal(result[[3]]$range$start, list(line = 2, character = 9))
+    expect_equal(result[[3]]$range$end, list(line = 2, character = 9 + nchar(src_file2) + 4))
+    expect_equal(result[[3]]$target, path_to_uri(src_file2))
+
+    expect_equal(result[[4]]$range$start, list(line = 3, character = 9))
+    expect_equal(result[[4]]$range$end, list(line = 3, character = 9 + nchar(basename(src_file2)) + 6))
+    expect_equal(result[[4]]$target, path_to_uri(src_file2))
+})
+
 test_that("Document link works in Rmarkdown", {
     skip_on_cran()
 


### PR DESCRIPTION
Related #242 

This PR

* Fixes raw string handling in document link using `col1` and `col2` attributes of  `STR_CONST` (which are correct) and `parse()` to extract the right text.
* Ignores raw string in color provider to avoid incorrect replacement of color from color picker.
* Adds test cases of handling raw strings in document link.