### PR TITLE
make sure the path is UTF-8

### DIFF
--- a/R/handlers-general.R
+++ b/R/handlers-general.R
@@ -6,7 +6,7 @@
 on_initialize <- function(self, id, params) {
     logger$info("initialization config: ", params)
     self$processId <- params$processId
-    self$rootUri <- params$rootUri
+    self$rootUri <- utils::URLencode(params$rootUri)
     self$rootPath <- path_from_uri(self$rootUri)
     self$workspace <- Workspace$new(self$rootPath)
     self$initializationOptions <- params$initializationOptions

--- a/R/handlers-general.R
+++ b/R/handlers-general.R
@@ -6,7 +6,7 @@
 on_initialize <- function(self, id, params) {
     logger$info("initialization config: ", params)
     self$processId <- params$processId
-    self$rootUri <- utils::URLencode(params$rootUri)
+    self$rootUri <- uri_escape_unicode(params$rootUri)
     self$rootPath <- path_from_uri(self$rootUri)
     self$workspace <- Workspace$new(self$rootPath)
     self$initializationOptions <- params$initializationOptions

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -4,7 +4,7 @@
 #' @keywords internal
 text_document_completion  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(completion_reply(id, uri, self$workspace, document, point,
@@ -27,7 +27,7 @@ completion_item_resolve  <- function(self, id, params) {
 #' @keywords internal
 text_document_hover  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(hover_reply(id, uri, self$workspace, document, point))
@@ -40,7 +40,7 @@ text_document_hover  <- function(self, id, params) {
 #' @keywords internal
 text_document_signature_help  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(signature_reply(id, uri, self$workspace, document, point))
@@ -52,7 +52,7 @@ text_document_signature_help  <- function(self, id, params) {
 #' @keywords internal
 text_document_definition  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(definition_reply(id, uri, self$workspace, document, point))
@@ -89,7 +89,7 @@ text_document_references  <- function(self, id, params) {
 #' @keywords internal
 text_document_document_highlight  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(document_highlight_reply(id, uri, self$workspace, document, point))
@@ -101,7 +101,7 @@ text_document_document_highlight  <- function(self, id, params) {
 #' @keywords internal
 text_document_document_symbol  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     reply <- document_symbol_reply(id, uri, self$workspace, document,
         self$ClientCapabilities$textDocument$documentSymbol)
@@ -148,7 +148,7 @@ code_lens_resolve  <- function(self, id, params) {
 #' @keywords internal
 text_document_document_link  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     rootPath <- if (length(self$rootPath)) self$rootPath else dirname(path_from_uri(uri))
     reply <- document_link_reply(id, uri, self$workspace, document, rootPath)
@@ -178,7 +178,7 @@ document_link_resolve  <- function(self, id, params) {
 #' @keywords internal
 text_document_document_color  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     reply <- document_color_reply(id, uri, self$workspace, document)
     if (is.null(reply)) {
@@ -199,7 +199,7 @@ text_document_document_color  <- function(self, id, params) {
 #' @keywords internal
 text_document_color_presentation  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     color <- params$color
     self$deliver(color_presentation_reply(id, uri, self$workspace, document, color))
@@ -211,7 +211,7 @@ text_document_color_presentation  <- function(self, id, params) {
 #' @keywords internal
 text_document_formatting  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     options <- params$options
     self$deliver(formatting_reply(id, uri, self$workspace$documents$get(uri), options))
 }
@@ -222,7 +222,7 @@ text_document_formatting  <- function(self, id, params) {
 #' @keywords internal
 text_document_range_formatting  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     range <- list(
         start = document$from_lsp_position(params$range$start),
@@ -239,7 +239,7 @@ text_document_range_formatting  <- function(self, id, params) {
 #' @keywords internal
 text_document_on_type_formatting  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     ch <- params$ch

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -4,7 +4,7 @@
 #' @keywords internal
 text_document_completion  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(completion_reply(id, uri, self$workspace, document, point,
@@ -27,7 +27,7 @@ completion_item_resolve  <- function(self, id, params) {
 #' @keywords internal
 text_document_hover  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(hover_reply(id, uri, self$workspace, document, point))
@@ -40,7 +40,7 @@ text_document_hover  <- function(self, id, params) {
 #' @keywords internal
 text_document_signature_help  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(signature_reply(id, uri, self$workspace, document, point))
@@ -52,7 +52,7 @@ text_document_signature_help  <- function(self, id, params) {
 #' @keywords internal
 text_document_definition  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(definition_reply(id, uri, self$workspace, document, point))
@@ -89,7 +89,7 @@ text_document_references  <- function(self, id, params) {
 #' @keywords internal
 text_document_document_highlight  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     self$deliver(document_highlight_reply(id, uri, self$workspace, document, point))
@@ -101,7 +101,7 @@ text_document_document_highlight  <- function(self, id, params) {
 #' @keywords internal
 text_document_document_symbol  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     reply <- document_symbol_reply(id, uri, self$workspace, document,
         self$ClientCapabilities$textDocument$documentSymbol)
@@ -148,7 +148,7 @@ code_lens_resolve  <- function(self, id, params) {
 #' @keywords internal
 text_document_document_link  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     rootPath <- if (length(self$rootPath)) self$rootPath else dirname(path_from_uri(uri))
     reply <- document_link_reply(id, uri, self$workspace, document, rootPath)
@@ -178,7 +178,7 @@ document_link_resolve  <- function(self, id, params) {
 #' @keywords internal
 text_document_document_color  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     reply <- document_color_reply(id, uri, self$workspace, document)
     if (is.null(reply)) {
@@ -199,7 +199,7 @@ text_document_document_color  <- function(self, id, params) {
 #' @keywords internal
 text_document_color_presentation  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     color <- params$color
     self$deliver(color_presentation_reply(id, uri, self$workspace, document, color))
@@ -211,7 +211,7 @@ text_document_color_presentation  <- function(self, id, params) {
 #' @keywords internal
 text_document_formatting  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     options <- params$options
     self$deliver(formatting_reply(id, uri, self$workspace$documents$get(uri), options))
 }
@@ -222,7 +222,7 @@ text_document_formatting  <- function(self, id, params) {
 #' @keywords internal
 text_document_range_formatting  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     range <- list(
         start = document$from_lsp_position(params$range$start),
@@ -239,7 +239,7 @@ text_document_range_formatting  <- function(self, id, params) {
 #' @keywords internal
 text_document_on_type_formatting  <- function(self, id, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
     ch <- params$ch

--- a/R/handlers-textsync.R
+++ b/R/handlers-textsync.R
@@ -91,7 +91,7 @@ text_document_did_close <- function(self, params) {
     textDocument <- params$textDocument
     uri <- uri_escape_unicode(textDocument$uri)
     path <- path_from_uri(uri)
-    is_from_workspace <- fs::path_has_parent(path, self$rootPath)
+    is_from_workspace <- path_has_parent(path, self$rootPath)
 
     # remove diagnostics if file is not from workspace
     if (!is_from_workspace) {

--- a/R/handlers-textsync.R
+++ b/R/handlers-textsync.R
@@ -4,7 +4,7 @@
 #' @keywords internal
 text_document_did_open <- function(self, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     version <- textDocument$version
     text <- textDocument$text
     logger$info("did open:", list(uri = uri, version = version))
@@ -33,7 +33,7 @@ text_document_did_open <- function(self, params) {
 text_document_did_change <- function(self, params) {
     textDocument <- params$textDocument
     contentChanges <- params$contentChanges
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     version <- textDocument$version
     text <- contentChanges[[1]]$text
     logger$info("did change:", list(uri = uri, version = version))
@@ -63,7 +63,7 @@ text_document_will_save <- function(self, params) {
 text_document_did_save <- function(self, params) {
     textDocument <- params$textDocument
     text <- params$text
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     logger$info("did save:", list(uri = uri))
     path <- path_from_uri(uri)
     if (!is.null(text)) {
@@ -89,7 +89,7 @@ text_document_did_save <- function(self, params) {
 #' @keywords internal
 text_document_did_close <- function(self, params) {
     textDocument <- params$textDocument
-    uri <- utils::URLencode(textDocument$uri)
+    uri <- uri_escape_unicode(textDocument$uri)
     path <- path_from_uri(uri)
     is_from_workspace <- fs::path_has_parent(path, self$rootPath)
 

--- a/R/handlers-textsync.R
+++ b/R/handlers-textsync.R
@@ -4,7 +4,7 @@
 #' @keywords internal
 text_document_did_open <- function(self, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     version <- textDocument$version
     text <- textDocument$text
     logger$info("did open:", list(uri = uri, version = version))
@@ -33,7 +33,7 @@ text_document_did_open <- function(self, params) {
 text_document_did_change <- function(self, params) {
     textDocument <- params$textDocument
     contentChanges <- params$contentChanges
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     version <- textDocument$version
     text <- contentChanges[[1]]$text
     logger$info("did change:", list(uri = uri, version = version))
@@ -63,7 +63,7 @@ text_document_will_save <- function(self, params) {
 text_document_did_save <- function(self, params) {
     textDocument <- params$textDocument
     text <- params$text
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     logger$info("did save:", list(uri = uri))
     path <- path_from_uri(uri)
     if (!is.null(text)) {
@@ -89,7 +89,7 @@ text_document_did_save <- function(self, params) {
 #' @keywords internal
 text_document_did_close <- function(self, params) {
     textDocument <- params$textDocument
-    uri <- textDocument$uri
+    uri <- utils::URLencode(textDocument$uri)
     path <- path_from_uri(uri)
     is_from_workspace <- fs::path_has_parent(path, self$rootPath)
 

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -103,8 +103,8 @@ LanguageServer <- R6::R6Class("LanguageServer",
 
             if (run_lintr && self$run_lintr) {
                 temp_root <- dirname(tempdir())
-                if (fs::path_has_parent(self$rootPath, temp_root) ||
-                    !fs::path_has_parent(path_from_uri(uri), temp_root)) {
+                if (path_has_parent(self$rootPath, temp_root) ||
+                    !path_has_parent(path_from_uri(uri), temp_root)) {
                     self$diagnostics_task_manager$add_task(
                         uri,
                         diagnostics_task(self, uri, document, delay = delay)

--- a/R/utils.R
+++ b/R/utils.R
@@ -64,8 +64,6 @@ path_from_uri <- function(uri) {
     if (!startsWith(uri, "file:///")) {
         return("")
     }
-    # escape unicodes first
-    uri <- utils::URLencode(uri)
     # URLdecode gives unknown encoding, we need to mark them as UTF-8
     start_char <- if (.Platform$OS.type == "windows") 9 else 8
     enc2utf8(utils::URLdecode(substr(uri, start_char, nchar(uri))))

--- a/R/utils.R
+++ b/R/utils.R
@@ -64,11 +64,11 @@ path_from_uri <- function(uri) {
     if (!startsWith(uri, "file:///")) {
         return("")
     }
-    start_char <- if (.Platform$OS.type == "windows") 9 else 8
+    # escape unicodes first
     uri <- utils::URLencode(uri)
-    path <- utils::URLdecode(substr(uri, start_char, nchar(uri)))
-    Encoding(path) <- "UTF-8"
-    path
+    # URLdecode gives unknown encoding, we need to mark them as UTF-8
+    start_char <- if (.Platform$OS.type == "windows") 9 else 8
+    enc2utf8(utils::URLdecode(substr(uri, start_char, nchar(uri))))
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -65,7 +65,10 @@ path_from_uri <- function(uri) {
         return("")
     }
     start_char <- if (.Platform$OS.type == "windows") 9 else 8
-    utils::URLdecode(substr(uri, start_char, nchar(uri)))
+    uri <- utils::URLencode(uri)
+    path <- utils::URLdecode(substr(uri, start_char, nchar(uri)))
+    Encoding(path) <- "UTF-8"
+    path
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -55,6 +55,14 @@ capture_print <- function(x) {
     paste0(utils::capture.output(print(x)), collapse = "\n")
 }
 
+
+uri_escape_unicode <- function(uri) {
+    if (length(uri) == 0) {
+        return(character())
+    }
+    utils::URLencode(uri)
+}
+
 #' Paths and uris
 #' @keywords internal
 path_from_uri <- function(uri) {

--- a/tests/testthat/test-unicode-path.R
+++ b/tests/testthat/test-unicode-path.R
@@ -1,0 +1,44 @@
+context("Test Unicode path")
+
+test_that("Works with unicode path", {
+    skip_on_cran()
+
+    dir <- file.path(tempdir(), "中文 にほんご 한국어")
+    dir.create(dir, showWarnings = FALSE, recursive = TRUE)
+    client <- language_client(dir)
+
+    withr::local_tempfile("defn_file", pattern = "中文", tmpdir = dir, fileext = ".R")
+    withr::local_tempfile("defn2_file", pattern = "にほんご", tmpdir = dir, fileext = ".R")
+    withr::local_tempfile("query_file", pattern = "한국어", tmpdir = dir, fileext = ".R")
+
+    writeLines(c("my_fn <- function(x) {", "  x + 1", "}"), defn_file)
+    writeLines(c("my_fn"), query_file)
+
+    client %>% did_save(defn_file)
+    client %>% did_save(query_file)
+
+    result <- client %>% respond_definition(query_file, c(0, 0))
+
+    expect_equal(result$range$start, list(line = 0, character = 0))
+    expect_equal(result$range$end, list(line = 2, character = 1))
+
+    # remove definition
+    writeLines("", defn_file)
+    client %>% did_save(defn_file)
+
+    result <- client %>% respond_definition(query_file, c(0, 0),
+        retry_when = function(result) {
+            length(result) > 0
+        })
+
+    expect_length(result, 0)
+
+    # move function into different file
+    writeLines(c("my_fn <- function(x) {", "  x + 1", "}"), defn2_file)
+    client %>% did_save(defn2_file)
+
+    result <- client %>% respond_definition(query_file, c(0, 0))
+
+    expect_equal(result$uri, path_to_uri(defn2_file))
+
+})

--- a/tests/testthat/test-unicode-path.R
+++ b/tests/testthat/test-unicode-path.R
@@ -2,15 +2,15 @@ context("Test Unicode path")
 
 test_that("Works with unicode path", {
     skip_on_cran()
+    if (.Platform$OS.type == "windows") {
+        Sys.setlocale(locale = "chinese")
+    }
 
-    dir <- file.path(tempdir(), "中文 にほんご 한국어")
+    dir <- file.path(tempdir(), "中 文")
     dir.create(dir, showWarnings = FALSE, recursive = TRUE)
     client <- language_client(dir)
 
-    withr::local_tempfile("defn_file", pattern = "中文", tmpdir = dir, fileext = ".R")
-    withr::local_tempfile("defn2_file", pattern = "にほんご", tmpdir = dir, fileext = ".R")
-    withr::local_tempfile("query_file", pattern = "한국어", tmpdir = dir, fileext = ".R")
-
+    withr::local_tempfile(c("defn_file", "defn2_file", "query_file"), pattern = "中文", fileext = ".R")
     writeLines(c("my_fn <- function(x) {", "  x + 1", "}"), defn_file)
     writeLines(c("my_fn"), query_file)
 

--- a/tests/testthat/test-unicode-path.R
+++ b/tests/testthat/test-unicode-path.R
@@ -4,14 +4,18 @@ test_that("Works with unicode path", {
     skip_on_cran()
     if (.Platform$OS.type == "windows") {
         skip_if_not(Sys.getenv("CI", "false") == "true")
+        old_locale <- Sys.getlocale("LC_CTYPE")
         Sys.setlocale(locale = "chinese")
+        on.exit({
+            Sys.setlocale(locale = old_locale)
+        })
     }
 
-    dir <- file.path(tempdir(), "中 文")
+    dir <- file.path(tempdir(), "\U4E2D \U6587")
     dir.create(dir, showWarnings = FALSE, recursive = TRUE)
     client <- language_client(dir)
 
-    withr::local_tempfile(c("defn_file", "defn2_file", "query_file"), pattern = "中文", fileext = ".R")
+    withr::local_tempfile(c("defn_file", "defn2_file", "query_file"), pattern = "\U4E2D\U6587", fileext = ".R")
     writeLines(c("my_fn <- function(x) {", "  x + 1", "}"), defn_file)
     writeLines(c("my_fn"), query_file)
 

--- a/tests/testthat/test-unicode-path.R
+++ b/tests/testthat/test-unicode-path.R
@@ -3,6 +3,7 @@ context("Test Unicode path")
 test_that("Works with unicode path", {
     skip_on_cran()
     if (.Platform$OS.type == "windows") {
+        skip_if_not(Sys.getenv("CI", "false") == "true")
         Sys.setlocale(locale = "chinese")
     }
 


### PR DESCRIPTION
it should fix some of the issues in #277.

We still need to fix the round trip issue

```
r$> a = "file:///foo/bar/中文.R"

r$> (b = languageserver:::path_from_uri(a))
[1] "/foo/bar/中文.R"

r$> (languageserver:::path_to_uri(b))
[1] "file:///foo/bar/%E4%B8%AD%E6%96%87.R"
```