### PR TITLE
Rmd chunk symbol

### DIFF
--- a/R/symbol.R
+++ b/R/symbol.R
@@ -145,15 +145,12 @@ get_rmd_document_section_symbols <- function(uri, document) {
     chunk_symbols <- lapply(seq_len(length(block_lines) / 2), function(i) {
         start_line <- block_lines[[2 * i - 1]]
         end_line <- block_lines[[2 * i]]
-        name <- NULL
+        label <- stringi::stri_match_first_regex(content[[start_line]],
+            "^\\s*```+\\s*\\{[a-zA-Z0-9_]+\\s*(([^,'\"]+)|'(.+)'|\"(.+)\")\\s*(,.+)?\\}\\s*$"
+        )[1, 3:5]
+        name <- label[!is.na(label)]
 
-        args_text <- stringi::stri_match_first_regex(document$line(start_line),
-            "^\\s*```+\\s*\\{([a-zA-Z0-9_]+( *[ ,].*)?)\\}\\s*$")[1, 3]
-        if (!is.na(args_text)) {
-            name <- trimws(args_text)
-        }
-
-        if (is.null(name)) {
+        if (length(name) == 0) {
             unnamed_chunks <<- unnamed_chunks + 1
             name <- sprintf("unnamed-chunk-%d", unnamed_chunks)
         }
@@ -165,7 +162,7 @@ get_rmd_document_section_symbols <- function(uri, document) {
                 uri = uri,
                 range = range(
                     start = document$to_lsp_position(row = start_line - 1, col = 0),
-                    end = document$to_lsp_position(row = end_line - 1, col = nchar(document$line(end_line)))
+                    end = document$to_lsp_position(row = end_line - 1, col = nchar(content[[end_line]]))
                 )
             )
         )

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -145,10 +145,9 @@ get_rmd_document_section_symbols <- function(uri, document) {
     chunk_symbols <- lapply(seq_len(length(block_lines) / 2), function(i) {
         start_line <- block_lines[[2 * i - 1]]
         end_line <- block_lines[[2 * i]]
-        line <- document$line(end_line)
         name <- NULL
 
-        args_text <- stringi::stri_match_first_regex(line,
+        args_text <- stringi::stri_match_first_regex(document$line(start_line),
             "^\\s*```+\\s*\\{([a-zA-Z0-9_]+( *[ ,].*)?)\\}\\s*$")[1, 3]
         if (!is.na(args_text)) {
             name <- args_text
@@ -166,7 +165,7 @@ get_rmd_document_section_symbols <- function(uri, document) {
                 uri = uri,
                 range = range(
                     start = document$to_lsp_position(row = start_line - 1, col = 0),
-                    end = document$to_lsp_position(row = end_line - 1, col = nchar(line))
+                    end = document$to_lsp_position(row = end_line - 1, col = nchar(document$line(end_line)))
                 )
             )
         )

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -92,19 +92,19 @@ get_rmd_document_section_symbols <- function(uri, document) {
         return(NULL)
     }
 
+    section_lines <- grepl("^#+\\s+\\S+", content)
     if (grepl("^---\\s*$", content[[1]])) {
         front_start <- 1L
         front_end <- 2L
         while (front_end <= document$nline) {
             if (grepl("^---\\s*$", content[[front_end]])) {
-                block_lines <- c(front_start, front_end, block_lines)
                 break
             }
             front_end <- front_end + 1L
         }
+        section_lines[seq.int(front_start, front_end)] <- FALSE
     }
 
-    section_lines <- grepl("^#+\\s+\\S+", content)
     for (i in seq_len(length(block_lines) / 2)) {
         section_lines[seq.int(block_lines[[2 * i - 1]], block_lines[[2 * i]])] <- FALSE
     }

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -150,7 +150,7 @@ get_rmd_document_section_symbols <- function(uri, document) {
         args_text <- stringi::stri_match_first_regex(document$line(start_line),
             "^\\s*```+\\s*\\{([a-zA-Z0-9_]+( *[ ,].*)?)\\}\\s*$")[1, 3]
         if (!is.na(args_text)) {
-            name <- args_text
+            name <- trimws(args_text)
         }
 
         if (is.null(name)) {
@@ -160,7 +160,7 @@ get_rmd_document_section_symbols <- function(uri, document) {
 
         symbol_information(
             name = name,
-            kind = SymbolKind$String,
+            kind = SymbolKind$Key,
             location = list(
                 uri = uri,
                 range = range(

--- a/tests/testthat/test-symbol.R
+++ b/tests/testthat/test-symbol.R
@@ -141,6 +141,30 @@ test_that("Document section symbol works in Rmarkdown", {
         "## section2",
         "```{r}",
         "g <- function(x) { x - 1 }",
+        "```",
+        "```{r,eval=FALSE}",
+        "x0 <- 0",
+        "```",
+        "```{r chunk1}",
+        "x1 <- 1",
+        "```",
+        "```{r chunk1a, eval=FALSE}",
+        "x1 <- 1",
+        "```",
+        "```{r 'chunk2'}",
+        "x2 <- 2",
+        "```",
+        "```{r 'chunk2a', eval=TRUE}",
+        "x2 <- 2",
+        "```",
+        "```{r \"chunk3\"}",
+        "x3 <- 3",
+        "```",
+        "```{r \"chunk3a\", eval=FALSE}",
+        "x3 <- 3",
+        "```",
+        "```{r \"chunk4, new\", eval=FALSE}",
+        "x3 <- 3",
         "```"
     ), defn_file)
 
@@ -149,7 +173,11 @@ test_that("Document section symbol works in Rmarkdown", {
 
     expect_equal(
         result %>% map_chr(~ .$name) %>% sort(),
-        c("section1", "subsection1", "f", "section2", "g") %>% sort()
+        c("section1", "subsection1", "unnamed-chunk-1",
+            "f", "section2", "unnamed-chunk-2", "g",
+            "unnamed-chunk-3", "chunk1", "chunk1a", "chunk2", "chunk2a",
+            "chunk3", "chunk3a", "chunk4, new"
+        ) %>% sort()
     )
     expect_equivalent(
         result %>% detect(~ .$name == "section1") %>% pluck("location", "range"),
@@ -165,10 +193,50 @@ test_that("Document section symbol works in Rmarkdown", {
     )
     expect_equivalent(
         result %>% detect(~ .$name == "section2") %>% pluck("location", "range"),
-        range(position(12, 0), position(15, 3))
+        range(position(12, 0), position(39, 3))
     )
     expect_equivalent(
         result %>% detect(~ .$name == "g") %>% pluck("location", "range"),
         range(position(14, 0), position(14, 26))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "unnamed-chunk-1") %>% pluck("location", "range"),
+        range(position(7, 0), position(11, 3))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "unnamed-chunk-2") %>% pluck("location", "range"),
+        range(position(13, 0), position(15, 3))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "unnamed-chunk-3") %>% pluck("location", "range"),
+        range(position(16, 0), position(18, 3))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "chunk1") %>% pluck("location", "range"),
+        range(position(19, 0), position(21, 3))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "chunk1a") %>% pluck("location", "range"),
+        range(position(22, 0), position(24, 3))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "chunk2") %>% pluck("location", "range"),
+        range(position(25, 0), position(27, 3))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "chunk2a") %>% pluck("location", "range"),
+        range(position(28, 0), position(30, 3))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "chunk3") %>% pluck("location", "range"),
+        range(position(31, 0), position(33, 3))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "chunk3a") %>% pluck("location", "range"),
+        range(position(34, 0), position(36, 3))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "chunk4, new") %>% pluck("location", "range"),
+        range(position(37, 0), position(39, 3))
     )
 })


### PR DESCRIPTION
This PR enhances #186 by adding chunk symbols in addition to section symbols for R markdown documents.

Also requested at https://github.com/Ikuyadeu/vscode-R/issues/363.

For the following document,

````
---
title: new document
---

# hello

Hello, world!

```{r}
x <- rnorm(100)
y <- rnorm(100)
m <- lm(y ~ x)

fun1 <- function(x, y) {
  x + y
}
```

```{r chunk-1}
x <- rnorm(100)
y <- rnorm(100)
m <- lm(y ~ x)

fun2 <- function(x, y) {
  x + y
}
```

```{r chunk-2, eval=TRUE}
x <- rnorm(100)
y <- rnorm(100)
m <- lm(y ~ x)

fun3 <- function(x, y) {
  x + y
}
```

```{r "chunk-3"}
x <- rnorm(100)
y <- rnorm(100)
m <- lm(y ~ x)

fun4 <- function(x, y) {
  x + y
}
```

```{r 'chunk-4', eval=TRUE}
x <- rnorm(100)
```

```{r 'chunk-5, new test', eval=TRUE}
x <- rnorm(100)
```

```{r}
x <- 1
```

````

we could get the following symbols:

<img width="238" alt="image" src="https://user-images.githubusercontent.com/4662568/85038160-d7bfee00-b1b8-11ea-898e-c8bccaddc6de.png">
