### PR TITLE
Use sortText in completions

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -101,15 +101,17 @@ ns_function_completion <- function(ns, token, exported_only, snippet_support) {
     functs <- functs[startsWith(functs, token)]
     if (nsname == WORKSPACE) {
         tag <- "[workspace]"
+        sort_prefix <- "1-"
     } else {
         tag <- paste0("{", nsname, "}")
+        sort_prefix <- "3-"
     }
     if (isTRUE(snippet_support)) {
         completions <- lapply(functs, function(object) {
             list(label = object,
                 kind = CompletionItemKind$Function,
                 detail = tag,
-                sortText = paste0("3-", object),
+                sortText = paste0(sort_prefix, object),
                 insertText = paste0(object, "($0)"),
                 insertTextFormat = InsertTextFormat$Snippet,
                 data = list(
@@ -122,7 +124,7 @@ ns_function_completion <- function(ns, token, exported_only, snippet_support) {
             list(label = object,
                 kind = CompletionItemKind$Function,
                 detail = tag,
-                sortText = paste0("3-", object),
+                sortText = paste0(sort_prefix, object),
                 data = list(
                     type = "function",
                     package = nsname

--- a/R/completion.R
+++ b/R/completion.R
@@ -45,7 +45,7 @@ constant_completion <- function(token) {
     completions <- lapply(consts, function(const) {
         list(label = const,
             kind = CompletionItemKind$Constant,
-            sortText = paste0("3-", const),
+            sortText = paste0("4-", const),
             data = list(type = "constant")
         )
     })
@@ -59,7 +59,7 @@ package_completion <- function(token) {
     completions <- lapply(token_packages, function(package) {
         list(label = package,
             kind = CompletionItemKind$Module,
-            sortText = paste0("3-", package),
+            sortText = paste0("4-", package),
             data = list(type = "package")
         )
     })
@@ -101,10 +101,10 @@ ns_function_completion <- function(ns, token, exported_only, snippet_support) {
     functs <- functs[startsWith(functs, token)]
     if (nsname == WORKSPACE) {
         tag <- "[workspace]"
-        sort_prefix <- "1-"
+        sort_prefix <- "2-"
     } else {
         tag <- paste0("{", nsname, "}")
-        sort_prefix <- "3-"
+        sort_prefix <- "4-"
     }
     if (isTRUE(snippet_support)) {
         completions <- lapply(functs, function(object) {
@@ -150,7 +150,7 @@ imported_object_completion <- function(workspace, token, snippet_support) {
                 item <- list(label = object,
                     kind = CompletionItemKind$Function,
                     detail = paste0("{", nsname, "}"),
-                    sortText = paste0("2-", object),
+                    sortText = paste0("3-", object),
                     insertText = paste0(object, "($0)"),
                     insertTextFormat = InsertTextFormat$Snippet,
                     data = list(
@@ -161,7 +161,7 @@ imported_object_completion <- function(workspace, token, snippet_support) {
                 item <- list(label = object,
                     kind = CompletionItemKind$Function,
                     detail = paste0("{", nsname, "}"),
-                    sortText = paste0("2-", object),
+                    sortText = paste0("3-", object),
                     data = list(
                         type = "function",
                         package = nsname
@@ -194,10 +194,10 @@ workspace_completion <- function(workspace, token,
             }
             if (nsname == WORKSPACE) {
                 tag <- "[workspace]"
-                sort_prefix <- "1-"
+                sort_prefix <- "2-"
             } else {
                 tag <- paste0("{", nsname, "}")
-                sort_prefix <- "3-"
+                sort_prefix <- "4-"
             }
 
             functs_completions <- ns_function_completion(ns, token,
@@ -245,7 +245,7 @@ workspace_completion <- function(workspace, token,
                 list(label = object,
                      kind = CompletionItemKind$Field,
                      detail = tag,
-                     sortText = paste0("3-", object),
+                     sortText = paste0("4-", object),
                      data = list(
                          type = "nonfunction",
                          package = package

--- a/R/completion.R
+++ b/R/completion.R
@@ -43,8 +43,11 @@ constants <- c("TRUE", "FALSE", "NULL",
 constant_completion <- function(token) {
     consts <- constants[startsWith(constants, token)]
     completions <- lapply(consts, function(const) {
-        list(label = const, kind = CompletionItemKind$Constant,
-            data = list(type = "constant"))
+        list(label = const,
+            kind = CompletionItemKind$Constant,
+            sortText = paste0("3-", const),
+            data = list(type = "constant")
+        )
     })
 }
 
@@ -54,8 +57,11 @@ package_completion <- function(token) {
     installed_packages <- .packages(all.available = TRUE)
     token_packages <- installed_packages[startsWith(installed_packages, token)]
     completions <- lapply(token_packages, function(package) {
-        list(label = package, kind = CompletionItemKind$Module,
-            data = list(type = "package"))
+        list(label = package,
+            kind = CompletionItemKind$Module,
+            sortText = paste0("3-", package),
+            data = list(type = "package")
+        )
     })
     completions
 }
@@ -74,7 +80,7 @@ arg_completion <- function(workspace, token, funct, package = NULL, exported_onl
                 list(label = arg,
                     kind = CompletionItemKind$Variable,
                     detail = "parameter",
-                    preselect = TRUE,
+                    sortText = paste0("0-", arg),
                     insertText = paste0(arg, " = "),
                     insertTextFormat = InsertTextFormat$PlainText,
                     data = list(
@@ -103,6 +109,7 @@ ns_function_completion <- function(ns, token, exported_only, snippet_support) {
             list(label = object,
                 kind = CompletionItemKind$Function,
                 detail = tag,
+                sortText = paste0("3-", object),
                 insertText = paste0(object, "($0)"),
                 insertTextFormat = InsertTextFormat$Snippet,
                 data = list(
@@ -115,6 +122,7 @@ ns_function_completion <- function(ns, token, exported_only, snippet_support) {
             list(label = object,
                 kind = CompletionItemKind$Function,
                 detail = tag,
+                sortText = paste0("3-", object),
                 data = list(
                     type = "function",
                     package = nsname
@@ -140,6 +148,7 @@ imported_object_completion <- function(workspace, token, snippet_support) {
                 item <- list(label = object,
                     kind = CompletionItemKind$Function,
                     detail = paste0("{", nsname, "}"),
+                    sortText = paste0("2-", object),
                     insertText = paste0(object, "($0)"),
                     insertTextFormat = InsertTextFormat$Snippet,
                     data = list(
@@ -150,6 +159,7 @@ imported_object_completion <- function(workspace, token, snippet_support) {
                 item <- list(label = object,
                     kind = CompletionItemKind$Function,
                     detail = paste0("{", nsname, "}"),
+                    sortText = paste0("2-", object),
                     data = list(
                         type = "function",
                         package = nsname
@@ -182,8 +192,10 @@ workspace_completion <- function(workspace, token,
             }
             if (nsname == WORKSPACE) {
                 tag <- "[workspace]"
+                sort_prefix <- "1-"
             } else {
                 tag <- paste0("{", nsname, "}")
+                sort_prefix <- "3-"
             }
 
             functs_completions <- ns_function_completion(ns, token,
@@ -195,6 +207,7 @@ workspace_completion <- function(workspace, token,
                 list(label = object,
                      kind = CompletionItemKind$Field,
                      detail = tag,
+                     sortText = paste0(sort_prefix, object),
                      data = list(
                          type = "nonfunction",
                          package = nsname
@@ -206,6 +219,7 @@ workspace_completion <- function(workspace, token,
                 list(label = object,
                      kind = CompletionItemKind$Field,
                      detail = tag,
+                     sortText = paste0(sort_prefix, object),
                      data = list(
                          type = "lazydata",
                          package = nsname
@@ -229,6 +243,7 @@ workspace_completion <- function(workspace, token,
                 list(label = object,
                      kind = CompletionItemKind$Field,
                      detail = tag,
+                     sortText = paste0("3-", object),
                      data = list(
                          type = "nonfunction",
                          package = package
@@ -278,6 +293,7 @@ scope_completion <- function(uri, workspace, token, point, snippet_support = NUL
         list(
             label = symbol,
             kind = CompletionItemKind$Field,
+            sortText = paste0("1-", symbol),
             detail = "[scope]"
         )
     })
@@ -290,6 +306,7 @@ scope_completion <- function(uri, workspace, token, point, snippet_support = NUL
                 label = symbol,
                 kind = CompletionItemKind$Function,
                 detail = "[scope]",
+                sortText = paste0("1-", symbol),
                 insertText = paste0(symbol, "($0)"),
                 insertTextFormat = InsertTextFormat$Snippet
             )
@@ -299,6 +316,7 @@ scope_completion <- function(uri, workspace, token, point, snippet_support = NUL
             list(
                 label = symbol,
                 kind = CompletionItemKind$Function,
+                sortText = paste0("1-", symbol),
                 detail = "[scope]"
             )
         })

--- a/R/completion.R
+++ b/R/completion.R
@@ -34,6 +34,14 @@ InsertTextFormat <- list(
     Snippet = 2
 )
 
+sort_prefixes <- list(
+    arg = "0-",
+    scope = "1-",
+    workspace = "2-",
+    imported = "3-",
+    global = "4-"
+)
+
 constants <- c("TRUE", "FALSE", "NULL",
     "NA", "NA_integer_", "NA_real_", "NA_complex_", "NA_character_",
     "Inf", "NaN")
@@ -45,7 +53,7 @@ constant_completion <- function(token) {
     completions <- lapply(consts, function(const) {
         list(label = const,
             kind = CompletionItemKind$Constant,
-            sortText = paste0("4-", const),
+            sortText = paste0(sort_prefixes$global, const),
             data = list(type = "constant")
         )
     })
@@ -59,7 +67,7 @@ package_completion <- function(token) {
     completions <- lapply(token_packages, function(package) {
         list(label = package,
             kind = CompletionItemKind$Module,
-            sortText = paste0("4-", package),
+            sortText = paste0(sort_prefixes$global, package),
             data = list(type = "package")
         )
     })
@@ -80,7 +88,7 @@ arg_completion <- function(workspace, token, funct, package = NULL, exported_onl
                 list(label = arg,
                     kind = CompletionItemKind$Variable,
                     detail = "parameter",
-                    sortText = paste0("0-", arg),
+                    sortText = paste0(sort_prefixes$arg, arg),
                     insertText = paste0(arg, " = "),
                     insertTextFormat = InsertTextFormat$PlainText,
                     data = list(
@@ -101,10 +109,10 @@ ns_function_completion <- function(ns, token, exported_only, snippet_support) {
     functs <- functs[startsWith(functs, token)]
     if (nsname == WORKSPACE) {
         tag <- "[workspace]"
-        sort_prefix <- "2-"
+        sort_prefix <- sort_prefixes$workspace
     } else {
         tag <- paste0("{", nsname, "}")
-        sort_prefix <- "4-"
+        sort_prefix <- sort_prefixes$global
     }
     if (isTRUE(snippet_support)) {
         completions <- lapply(functs, function(object) {
@@ -150,7 +158,7 @@ imported_object_completion <- function(workspace, token, snippet_support) {
                 item <- list(label = object,
                     kind = CompletionItemKind$Function,
                     detail = paste0("{", nsname, "}"),
-                    sortText = paste0("3-", object),
+                    sortText = paste0(sort_prefixes$imported, object),
                     insertText = paste0(object, "($0)"),
                     insertTextFormat = InsertTextFormat$Snippet,
                     data = list(
@@ -161,7 +169,7 @@ imported_object_completion <- function(workspace, token, snippet_support) {
                 item <- list(label = object,
                     kind = CompletionItemKind$Function,
                     detail = paste0("{", nsname, "}"),
-                    sortText = paste0("3-", object),
+                    sortText = paste0(sort_prefixes$imported, object),
                     data = list(
                         type = "function",
                         package = nsname
@@ -194,10 +202,10 @@ workspace_completion <- function(workspace, token,
             }
             if (nsname == WORKSPACE) {
                 tag <- "[workspace]"
-                sort_prefix <- "2-"
+                sort_prefix <- sort_prefixes$workspace
             } else {
                 tag <- paste0("{", nsname, "}")
-                sort_prefix <- "4-"
+                sort_prefix <- sort_prefixes$global
             }
 
             functs_completions <- ns_function_completion(ns, token,
@@ -245,7 +253,7 @@ workspace_completion <- function(workspace, token,
                 list(label = object,
                      kind = CompletionItemKind$Field,
                      detail = tag,
-                     sortText = paste0("4-", object),
+                     sortText = paste0(sort_prefixes$global, object),
                      data = list(
                          type = "nonfunction",
                          package = package
@@ -295,7 +303,7 @@ scope_completion <- function(uri, workspace, token, point, snippet_support = NUL
         list(
             label = symbol,
             kind = CompletionItemKind$Field,
-            sortText = paste0("1-", symbol),
+            sortText = paste0(sort_prefixes$scope, symbol),
             detail = "[scope]"
         )
     })
@@ -308,7 +316,7 @@ scope_completion <- function(uri, workspace, token, point, snippet_support = NUL
                 label = symbol,
                 kind = CompletionItemKind$Function,
                 detail = "[scope]",
-                sortText = paste0("1-", symbol),
+                sortText = paste0(sort_prefixes$scope, symbol),
                 insertText = paste0(symbol, "($0)"),
                 insertTextFormat = InsertTextFormat$Snippet
             )
@@ -318,7 +326,7 @@ scope_completion <- function(uri, workspace, token, point, snippet_support = NUL
             list(
                 label = symbol,
                 kind = CompletionItemKind$Function,
-                sortText = paste0("1-", symbol),
+                sortText = paste0(sort_prefixes$scope, symbol),
                 detail = "[scope]"
             )
         })


### PR DESCRIPTION
Close #285 

This PR uses `CompletionItem.sortText` defined in <https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion> to give different categories of completion items certain priorities.

The principle here is sorting by scope from local to global:

0. Function arguments
1. Scope symbols
2. Workspace symbols
3. Imported symbols
4. Constants, Packages, Namespace symbols