### PR TITLE
Change dev version download script in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ install.packages("languageserver")
 The development version of `languageserver` could be installed by running the following in R:
 
 ```r
-source("https://install-github.me/REditorSupport/languageserver")
+# install.packages("devtools")
+devtools::install_github("REditorSupport/languageserver")
 ```
 
 ## Language Clients


### PR DESCRIPTION
The deprecated message from the `install-github.me` services. Replacing it with the `devtools` alternative.

```r
source("https://install-github.me/REditorSupport/languageserver")
# The install-github.me service is deprecated, please stop using it.
```
