### PR TITLE
Fix for #283 - "unexpected '/'" on save

### DIFF
--- a/R/handlers-textsync.R
+++ b/R/handlers-textsync.R
@@ -61,9 +61,9 @@ text_document_will_save <- function(self, params) {
 #' Handler to the `textDocument/didSave` [Notification].
 #' @keywords internal
 text_document_did_save <- function(self, params) {
-    textDocument <- params$textDocument
-    text <- params$text
-    uri <- uri_escape_unicode(textDocument$uri)
+    textDocument <- params[["textDocument"]]
+    text <- params[["text"]]
+    uri <- uri_escape_unicode(textDocument[["uri"]])
     logger$info("did save:", list(uri = uri))
     path <- path_from_uri(uri)
     if (!is.null(text)) {


### PR DESCRIPTION
This pull request resolves issue #283.

It replaces `$` accessors with `[[` to prevent partial matching of `params$text` to `params$textDocument` when `text` is undefined.

Todo:
- [ ] add regression test