### PR TITLE
Support all symbols in definitions

### DIFF
--- a/R/document.R
+++ b/R/document.R
@@ -222,12 +222,7 @@ parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcr
             if (type == "function") {
                 env$functs <- c(env$functs, symbol)
                 env$formals[[symbol]] <- value[[2L]]
-
-                signature <- format(value[1:2])
-                signature <- paste0(trimws(signature, which = "left"), collapse = "")
-                signature <- gsub("^function\\s*", symbol, signature)
-                signature <- gsub("\\s*NULL$", "", signature)
-                env$signatures[[symbol]] <- signature
+                env$signatures[[symbol]] <- get_signature(symbol, value)
             } else {
                 env$nonfuncts <- c(env$nonfuncts, symbol)
             }

--- a/R/document.R
+++ b/R/document.R
@@ -199,33 +199,37 @@ parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcr
         } else if (f == "repeat") {
             Recall(content, e[[2L]], env, level + 1L, cur_srcref)
         } else if (f %in% c("<-", "=") && length(e) == 3L && is.symbol(e[[2L]])) {
-            funct <- as.character(e[[2L]])
-            env$objects <- c(env$objects, funct)
-            if (is.call(e[[3L]]) && e[[3L]][[1L]] == "function") {
-                # functions
-                env$functs <- c(env$functs, funct)
-                func <- e[[3L]]
-                env$formals[[funct]] <- func[[2L]]
+            symbol <- as.character(e[[2L]])
+            value <- e[[3L]]
+            type <- get_expr_type(value)
 
-                signature <- func
-                signature <- format(signature[1:2])
+            env$objects <- c(env$objects, symbol)
+
+            expr_range <- expr_range(cur_srcref)
+            env$definitions[[symbol]] <- list(
+                name = symbol,
+                type = type,
+                range = expr_range
+            )
+
+            doc_line1 <- detect_comments(content, expr_range$start$line) + 1
+            if (doc_line1 <= expr_range$start$line) {
+                env$documentation[[symbol]] <- paste0(uncomment(
+                    content[seq.int(doc_line1, expr_range$start$line)]),
+                collapse = "  \n")
+            }
+
+            if (type == "function") {
+                env$functs <- c(env$functs, symbol)
+                env$formals[[symbol]] <- value[[2L]]
+
+                signature <- format(value[1:2])
                 signature <- paste0(trimws(signature, which = "left"), collapse = "")
-                signature <- gsub("^function\\s*", funct, signature)
+                signature <- gsub("^function\\s*", symbol, signature)
                 signature <- gsub("\\s*NULL$", "", signature)
-                env$signatures[[funct]] <- signature
-
-                expr_range <- expr_range(cur_srcref)
-                env$definition_ranges[[funct]] <- expr_range
-
-                doc_line1 <- detect_comments(content, expr_range$start$line) + 1
-                if (doc_line1 <= expr_range$start$line) {
-                    env$documentation[[funct]] <- paste0(uncomment(
-                        content[seq.int(doc_line1, expr_range$start$line)]),
-                            collapse = "  \n")
-                }
+                env$signatures[[symbol]] <- signature
             } else {
-                # symbols
-                env$nonfuncts <- c(env$nonfuncts, funct)
+                env$nonfuncts <- c(env$nonfuncts, symbol)
             }
         } else if (f %in% c("library", "require") && length(e) == 2L) {
             pkg <- as.character(e[[2L]])
@@ -259,7 +263,7 @@ parse_document <- function(uri, content) {
             env$functs <- character()
             env$formals <- list()
             env$signatures <- list()
-            env$definition_ranges <- list()
+            env$definitions <- list()
             env$documentation <- list()
             env$xml_data <- NULL
             env$xml_doc <- NULL

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -250,7 +250,7 @@ GlobalEnv <- R6::R6Class("GlobalEnv",
         get_documentation = function(topic) {
             for (doc in self$documents$values()) {
                 if (!is.null(doc$parse_data)) {
-                    if (topic %in% doc$parse_data$functs) {
+                    if (topic %in% doc$parse_data$objects) {
                         return(doc$parse_data$documentation[[topic]])
                     }
                 }
@@ -261,10 +261,10 @@ GlobalEnv <- R6::R6Class("GlobalEnv",
         get_definition = function(symbol, exported_only = TRUE) {
             for (doc in self$documents$values()) {
                 if (!is.null(doc$parse_data)) {
-                    if (symbol %in% doc$parse_data$functs) {
+                    if (symbol %in% doc$parse_data$objects) {
                         def <- location(
                             uri = doc$uri,
-                            range = doc$parse_data$definition_ranges[[symbol]]
+                            range = doc$parse_data$definitions[[symbol]]$range
                         )
                         return(def)
                     }

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -37,6 +37,7 @@ get_document_symbol_kind <- function(type) {
         character = SymbolKind$String,
         `function` = SymbolKind$Function,
         `NULL` = SymbolKind$Null,
+        `class` = SymbolKind$Class,
         SymbolKind$Variable
     )
 }

--- a/R/symbol.R
+++ b/R/symbol.R
@@ -35,6 +35,8 @@ get_document_symbol_kind <- function(type) {
         double = SymbolKind$Number,
         complex = SymbolKind$Number,
         character = SymbolKind$String,
+        array = SymbolKind$Array,
+        list = SymbolKind$Struct,
         `function` = SymbolKind$Function,
         `NULL` = SymbolKind$Null,
         `class` = SymbolKind$Class,

--- a/R/utils.R
+++ b/R/utils.R
@@ -55,6 +55,17 @@ capture_print <- function(x) {
     paste0(utils::capture.output(print(x)), collapse = "\n")
 }
 
+get_expr_type <- function(expr) {
+    if (is.call(expr)) {
+        if (is.symbol(expr[[1]]) && expr[[1]] == "function") {
+            "function"
+        } else {
+            "object"
+        }
+    } else {
+        typeof(expr)
+    }
+}
 
 uri_escape_unicode <- function(uri) {
     if (length(uri) == 0) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -57,12 +57,17 @@ capture_print <- function(x) {
 
 get_expr_type <- function(expr) {
     if (is.call(expr)) {
-        if (is.symbol(expr[[1]]) && expr[[1]] == "function") {
+        func <- deparse(expr[[1]], nlines = 1)
+        if (func == "function") {
             "function"
-        } else if (grepl("(R6:::?)?R6Class", deparse(expr[[1]], nlines = 1))) {
+        } else if (func == "c") {
+            "array"
+        } else if (func == "list") {
+            "list"
+        } else if (grepl("(R6:::?)?R6Class", func)) {
             "class"
         } else {
-            "object"
+            "variable"
         }
     } else {
         typeof(expr)

--- a/R/utils.R
+++ b/R/utils.R
@@ -201,6 +201,14 @@ extract_blocks <- function(content) {
     blocks
 }
 
+get_signature <- function(symbol, expr) {
+    signature <- format(expr[1:2])
+    signature <- paste0(trimws(signature, which = "left"), collapse = "")
+    signature <- gsub("^function\\s*", symbol, signature)
+    signature <- gsub("\\s*NULL$", "", signature)
+    signature
+}
+
 get_r_document_sections <- function(uri, document, type = c("section", "subsections")) {
     sections <- NULL
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -60,7 +60,7 @@ get_expr_type <- function(expr) {
         func <- deparse(expr[[1]], nlines = 1)
         if (func == "function") {
             "function"
-        } else if (func == "c") {
+        } else if (func %in% c("c", "matrix", "array")) {
             "array"
         } else if (func == "list") {
             "list"

--- a/R/utils.R
+++ b/R/utils.R
@@ -59,6 +59,8 @@ get_expr_type <- function(expr) {
     if (is.call(expr)) {
         if (is.symbol(expr[[1]]) && expr[[1]] == "function") {
             "function"
+        } else if (grepl("(R6:::?)?R6Class", deparse(expr[[1]], nlines = 1))) {
+            "class"
         } else {
             "object"
         }

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -173,24 +173,25 @@ Workspace <- R6::R6Class("Workspace",
             if (is.null(parse_data)) {
                 return(list())
             }
-            parse_data$definition_ranges
+            parse_data$definitions
         },
 
         get_definitions_for_query = function(pattern) {
-            ranges <- list()
+            result <- list()
             for (doc in self$documents$values()) {
                 parse_data <- doc$parse_data
                 if (is.null(parse_data)) next
-                doc_ranges <- lapply(
-                        parse_data$definition_ranges,
-                        function(r) list(
-                            uri = doc$uri,
-                            range = r
-                        )
+                symbols <- names(parse_data$definitions)
+                matches <- symbols[fuzzy_find(symbols, pattern)]
+                result <- c(result, lapply(
+                    unname(parse_data$definitions[matches]),
+                    function(def) c(
+                        uri = doc$uri,
+                        def
                     )
-                ranges <- append(ranges, doc_ranges[fuzzy_find(names(doc_ranges), pattern)])
+                ))
             }
-            ranges
+            result
         },
 
         get_parse_data = function(uri) {


### PR DESCRIPTION
This PR adds all symbols to definitions so that it is easier to search symbols via document/workspace symbol search.

```r
func <- function(x, y) {
  m <- x + y
  n <- x * y
  m + n
}

# R6 class
Person <- R6::R6Class("Person",
  private = list(
    name = NULL,
    age = NULL
  ),
  public = list(
    initialize = function(name) {
      private$name <- name
    },
    greeting = function() {
      cat("Hello, my name is ", private$name, "!\n", sep = "")
    }
))

person <- Person$new(name = "Somebody")

num <- 1
lgl <- TRUE
text <- "hello"

vec <- c(1, 2, 3)

lst <- list(
  x = 1,
  y = 2,
  z = list(a = 1, b = 2)
)

var <- rnorm(100)
```

The above code has the following symbol outline:

![image](https://user-images.githubusercontent.com/4662568/86331121-38503000-bc7b-11ea-96bc-0704b8b1810b.png)

Some function calls are specially treated to generate different kinds of document symbols. `c()`,`matrix()`, and `array()` creates Array symbol, `list()` creates Struct symbol, and `R6Class()` creates Class symbol. Code editor or extensions could work with these type-like symbols. In VSCode, for example, git integration could show the git history for Class and Struct symbols.

![image](https://user-images.githubusercontent.com/4662568/86331690-fecbf480-bc7b-11ea-888a-08dbe9f76d60.png)

![image](https://user-images.githubusercontent.com/4662568/86331755-186d3c00-bc7c-11ea-94d9-32d195790201.png)

Also, non-function symbols in global namespace could also have documentation to show in completion.

![image](https://user-images.githubusercontent.com/4662568/86331607-e956ca80-bc7b-11ea-9560-8612a8dc270b.png)
