### PR TITLE
Support startup library specified in profile

### DIFF
--- a/R/document.R
+++ b/R/document.R
@@ -283,15 +283,11 @@ parse_callback <- function(self, uri, version, parse_data) {
     self$workspace$update_parse_data(uri, parse_data)
 
     if (!identical(old_parse_data$packages, parse_data$packages)) {
-        if (length(parse_data$packages)) {
-            self$resolve_task_manager$add_task(
-                uri,
-                resolve_task(self, uri, doc, parse_data$packages)
-            )
-            doc$loaded_packages <- parse_data$packages
-        } else {
-            doc$loaded_packages <- character()
-        }
+        self$resolve_task_manager$add_task(
+            uri,
+            resolve_task(self, uri, doc, parse_data$packages)
+        )
+        doc$loaded_packages <- parse_data$packages
         self$workspace$update_loaded_packages()
     }
 

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -276,12 +276,11 @@ GlobalEnv <- R6::R6Class("GlobalEnv",
 )
 
 
-resolve_attached_packages <- function(pkgs) {
-    startup_packages <- .packages()
+resolve_attached_packages <- function(pkgs = NULL) {
     for (pkg in pkgs) {
         tryCatch(library(pkg, character.only = TRUE),
             error = function(e) NULL
         )
     }
-    rev(setdiff(.packages(), startup_packages))
+    rev(.packages())
 }

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -1,5 +1,4 @@
-startup_packages <- c("base", "methods", "datasets", "utils",
-    "grDevices", "graphics", "stats")
+startup_packages <- c("base", "methods", "datasets", "utils", "grDevices", "graphics", "stats")
 
 #' A data structure for a session workspace
 #'

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -29,7 +29,7 @@ Workspace <- R6::R6Class("Workspace",
             self$namespaces <- collections::dict()
             self$startup_packages <- callr::r(resolve_attached_packages,
                 system_profile = TRUE, user_profile = TRUE)
-            self$startup_packages <- self$startup_packages
+            self$loaded_packages <- self$startup_packages
             for (pkgname in self$loaded_packages) {
                 self$namespaces$set(pkgname, PackageNamespace$new(pkgname))
             }

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -1,5 +1,3 @@
-startup_packages <- c("base", "methods", "datasets", "utils", "grDevices", "graphics", "stats")
-
 #' A data structure for a session workspace
 #'
 #' A `Workspace` is initialized at the start of a session, when the language
@@ -19,7 +17,8 @@ Workspace <- R6::R6Class("Workspace",
         imported_packages = NULL,
         namespace_file_mt = NULL,
 
-        loaded_packages = startup_packages,
+        startup_packages = NULL,
+        loaded_packages = NULL,
 
         initialize = function(root) {
             self$root <- root
@@ -28,6 +27,9 @@ Workspace <- R6::R6Class("Workspace",
             self$imported_packages <- character(0)
             self$global_env <- GlobalEnv$new(self$documents)
             self$namespaces <- collections::dict()
+            self$startup_packages <- callr::r(resolve_attached_packages,
+                system_profile = TRUE, user_profile = TRUE)
+            self$startup_packages <- self$startup_packages
             for (pkgname in self$loaded_packages) {
                 self$namespaces$set(pkgname, PackageNamespace$new(pkgname))
             }
@@ -199,7 +201,7 @@ Workspace <- R6::R6Class("Workspace",
         },
 
         update_loaded_packages = function() {
-            loaded_packages <- union(startup_packages, self$imported_packages)
+            loaded_packages <- union(self$startup_packages, self$imported_packages)
             for (doc in self$documents$values()) {
                 loaded_packages <- union(loaded_packages, doc$loaded_packages)
             }


### PR DESCRIPTION
Close #301

This PR respects the attached packages specified in user/system profile so that the initial auto-completion could include the package exported objects on startup.