### PR TITLE
Convert roxygen comments to documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     parallel,
     R6 (>= 2.4.1),
     repr (>= 1.1.0),
+    roxygen2 (>= 7.0.0),
     stringi (>= 1.1.7),
     styler (>= 1.2.0),
     tools,

--- a/R/completion.R
+++ b/R/completion.R
@@ -424,7 +424,7 @@ completion_item_resolve_reply <- function(id, workspace, params) {
             doc_string <- NULL
             if (is.character(doc)) {
                 doc_string <- doc
-            } else if (is.list(doc) && is.character(doc$description)) {
+            } else if (is.list(doc)) {
                 doc_string <- doc$description
             }
 

--- a/R/document.R
+++ b/R/document.R
@@ -214,9 +214,8 @@ parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcr
 
             doc_line1 <- detect_comments(content, expr_range$start$line) + 1
             if (doc_line1 <= expr_range$start$line) {
-                env$documentation[[symbol]] <- paste0(uncomment(
-                    content[seq.int(doc_line1, expr_range$start$line)]),
-                collapse = "  \n")
+                comment <- content[seq.int(doc_line1, expr_range$start$line)]
+                env$documentation[[symbol]] <- convert_comment_to_documentation(comment)
             }
 
             if (type == "function") {

--- a/R/hover.R
+++ b/R/hover.R
@@ -69,9 +69,13 @@ hover_reply <- function(id, uri, workspace, document, point) {
                         doc_text <- NULL
                         doc_line1 <- detect_comments(document$content, def_line1 - 1) + 1
                         if (doc_line1 < def_line1) {
-                            doc_text <- paste0(
-                                uncomment(document$line(seq.int(doc_line1, def_line1 - 1))),
-                                    collapse = "  \n")
+                            comment <- document$line(seq.int(doc_line1, def_line1 - 1))
+                            doc_obj <- convert_comment_to_documentation(comment)
+                            if (is.character(doc_obj)) {
+                                doc_text <- doc_obj
+                            } else if (is.list(doc_obj)) {
+                                doc_text <- doc_obj$description
+                            }
                         }
                         contents <- c(sprintf("```r\n%s\n```", def_text), doc_text)
                         resolved <- TRUE
@@ -138,6 +142,8 @@ hover_reply <- function(id, uri, workspace, document, point) {
             doc_string <- NULL
             if (is.character(doc)) {
                 doc_string <- doc
+            } else if (is.list(doc)) {
+                doc_string <- doc$description
             }
             contents <- c(sprintf("```r\n%s\n```", sig), doc_string)
         }

--- a/R/hover.R
+++ b/R/hover.R
@@ -66,18 +66,22 @@ hover_reply <- function(id, uri, workspace, document, point) {
                         }
                         def_text <- trimws(paste0(document$line(seq.int(def_line1, def_line2)),
                             collapse = "\n"))
-                        doc_text <- NULL
+                        doc_string <- NULL
                         doc_line1 <- detect_comments(document$content, def_line1 - 1) + 1
                         if (doc_line1 < def_line1) {
                             comment <- document$line(seq.int(doc_line1, def_line1 - 1))
-                            doc_obj <- convert_comment_to_documentation(comment)
-                            if (is.character(doc_obj)) {
-                                doc_text <- doc_obj
-                            } else if (is.list(doc_obj)) {
-                                doc_text <- doc_obj$description
+                            doc <- convert_comment_to_documentation(comment)
+                            if (is.character(doc)) {
+                                doc_string <- doc
+                            } else if (is.list(doc)) {
+                                if (is.null(doc$markdown)) {
+                                    doc_string <- doc$description
+                                } else {
+                                    doc_string <- doc$markdown
+                                }
                             }
                         }
-                        contents <- c(sprintf("```r\n%s\n```", def_text), doc_text)
+                        contents <- c(sprintf("```r\n%s\n```", def_text), doc_string)
                         resolved <- TRUE
                     }
                 }
@@ -143,7 +147,11 @@ hover_reply <- function(id, uri, workspace, document, point) {
             if (is.character(doc)) {
                 doc_string <- doc
             } else if (is.list(doc)) {
-                doc_string <- doc$description
+                if (is.null(doc$markdown)) {
+                    doc_string <- doc$description
+                } else {
+                    doc_string <- doc$markdown
+                }
             }
             contents <- c(sprintf("```r\n%s\n```", sig), doc_string)
         }

--- a/R/signature.R
+++ b/R/signature.R
@@ -24,7 +24,7 @@ signature_reply <- function(id, uri, workspace, document, point) {
             doc_string <- ""
             if (is.character(doc)) {
                 doc_string <- doc
-            } else if (is.list(doc) && is.character(doc$description)) {
+            } else if (is.list(doc)) {
                 doc_string <- doc$description
             }
             documentation <- list(kind = "markdown", value = doc_string)

--- a/R/utils.R
+++ b/R/utils.R
@@ -570,12 +570,13 @@ format_roxy_tag <- function(item) {
         content <- format_roxy_text(item$val)
     } else {
         tag <- sprintf("`@%s` ", item$tag)
-        content <- switch(item$tag,
-            param = sprintf("`%s` %s", item$val$name, format_roxy_text(item$val$description)),
-            example = ,
-            examples = sprintf("\n```r\n%s\n```", item$val),
+        content <- if (item$tag == "param") {
+            sprintf("`%s` %s", item$val$name, format_roxy_text(item$val$description))
+        } else if (item$tag %in% c("example", "examples", "usage")) {
+            sprintf("\n```r\n%s\n```", item$val)
+        } else {
             format_roxy_text(item$raw)
-        )
+        }
     }
     paste0(tag, content, "  \n")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -531,34 +531,32 @@ uncomment <- function(x) gsub("^\\s*#+'?\\s*", "", x)
 
 convert_comment_to_documentation <- function(comment) {
     result <- NULL
-    if (requireNamespace("roxygen2", quietly = TRUE)) {
-        roxy <- roxygen2::parse_text(c(
-            comment,
-            "NULL"
-        ), env = NULL)
-        if (length(roxy)) {
-            result <- list(
-                title = NULL,
-                description = NULL,
-                arguments = list(),
-                markdown = NULL
-            )
-            items <- lapply(roxy[[1]]$tags, function(item) {
-                if (item$tag == "title") {
-                    result$title <<- item$val
-                } else if (item$tag == "description") {
-                    result$description <<- item$val
-                } else if (item$tag == "param") {
-                    result$arguments[[item$val$name]] <<- item$val$description
-                }
-
-                format_roxy_tag(item)
-            })
-            if (is.null(result$description)) {
-                result$description <- result$title
+    roxy <- tryCatch(roxygen2::parse_text(c(
+        comment,
+        "NULL"
+    ), env = NULL), error = function(e) NULL)
+    if (length(roxy)) {
+        result <- list(
+            title = NULL,
+            description = NULL,
+            arguments = list(),
+            markdown = NULL
+        )
+        items <- lapply(roxy[[1]]$tags, function(item) {
+            if (item$tag == "title") {
+                result$title <<- item$val
+            } else if (item$tag == "description") {
+                result$description <<- item$val
+            } else if (item$tag == "param") {
+                result$arguments[[item$val$name]] <<- item$val$description
             }
-            result$markdown <- paste0(items, collapse = "\n")
+
+            format_roxy_tag(item)
+        })
+        if (is.null(result$description)) {
+            result$description <- result$title
         }
+        result$markdown <- paste0(items, collapse = "\n")
     }
     if (is.null(result)) {
         result <- paste0(uncomment(comment), collapse = "  \n")

--- a/R/utils.R
+++ b/R/utils.R
@@ -570,10 +570,12 @@ format_roxy_tag <- function(item) {
         content <- format_roxy_text(item$val)
     } else {
         tag <- sprintf("`@%s` ", item$tag)
-        content <- if (item$tag == "param") {
-            sprintf("`%s` %s", item$val$name, format_roxy_text(item$val$description))
-        } else if (item$tag %in% c("example", "examples", "usage")) {
+        content <- if (item$tag %in% c("usage", "example", "examples", "eval", "evalRd")) {
             sprintf("\n```r\n%s\n```", item$val)
+        } else if (is.character(item$val) && length(item$val) > 1) {
+            paste0(sprintf("`%s`", item$val), collapse = " ")
+        } else if (is.list(item$val)) {
+            sprintf("`%s` %s", item$val$name, format_roxy_text(item$val$description))
         } else {
             format_roxy_text(item$raw)
         }

--- a/R/utils.R
+++ b/R/utils.R
@@ -572,6 +572,7 @@ format_roxy_tag <- function(item) {
         tag <- sprintf("`@%s` ", item$tag)
         content <- switch(item$tag,
             param = sprintf("`%s` %s", item$val$name, format_roxy_text(item$val$description)),
+            example = ,
             examples = sprintf("\n```r\n%s\n```", item$val),
             format_roxy_text(item$raw)
         )

--- a/R/utils.R
+++ b/R/utils.R
@@ -565,21 +565,22 @@ convert_comment_to_documentation <- function(comment) {
 }
 
 format_roxy_tag <- function(item) {
-    if (item$tag == "title") {
+    if (item$tag %in% c("title", "description")) {
         tag <- ""
-        content <- sprintf("**%s**\n", item$val)
-    } else if (item$tag == "description") {
-        tag <- ""
-        content <- sprintf("%s\n", item$val)
+        content <- format_roxy_text(item$val)
     } else {
         tag <- sprintf("`@%s` ", item$tag)
         content <- switch(item$tag,
-            param = sprintf("`%s` %s", item$val$name, item$val$description),
+            param = sprintf("`%s` %s", item$val$name, format_roxy_text(item$val$description)),
             examples = sprintf("\n```r\n%s\n```", item$val),
-            item$raw
+            format_roxy_text(item$raw)
         )
     }
     paste0(tag, content, "  \n")
+}
+
+format_roxy_text <- function(text) {
+    gsub("\n", "  \n", text, fixed = TRUE)
 }
 
 find_doc_item <- function(doc, tag) {


### PR DESCRIPTION
Close #304

This PR imports `roxygen2` and implements `convert_comment_to_documentation` where `roxygen2::parse_text()` is tried to parse comments as roxygen tags to provide structured documentation.

The information presented in hover contains all parsed roxygen tags presented in markdown format while only description is presented in completion resolve of symbol and function arguments and function signature, which is consistent with currently presented information provided by these providers.

Following is a screencast:

![Kapture 2020-07-07 at 22 47 05](https://user-images.githubusercontent.com/4662568/86798943-f290ce80-c0a3-11ea-8ede-87190ec0a936.gif)
