### PR TITLE
Not trigger on-type-formatting on comment line

### DIFF
--- a/R/formatting.R
+++ b/R/formatting.R
@@ -155,10 +155,10 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
     use_zero <- FALSE
     if (ch == "\n") {
         start_line <- end_line - 1
-        if (grepl("^\\s*$", content[[start_line]])) {
+        if (grepl("^\\s*(#.*)?$", content[[start_line]])) {
             return(Response$new(id))
         }
-        if (grepl("^\\s*(#.+)?$", content[[end_line]])) {
+        if (grepl("^\\s*(#.*)?$", content[[end_line]])) {
             # use "0" to complete the potentially incomplete expression
             last_line <- content[end_line]
             content[end_line] <- "0"


### PR DESCRIPTION
This PR disables on-type-formatting on both whitespace line and comment line.

In VSCode, the vscode-R auto inserts `#' ` on enter, i.e.

```
#' Press enter here and auto insert the following line
#' 
```

If formatting is perfomed, then the whitespace after `#'` is styled out, which is annoying in writing roxygen documentation.