### PR TITLE
Support folding ranges for comments

### DIFF
--- a/R/folding.R
+++ b/R/folding.R
@@ -45,7 +45,7 @@ get_comment_folding_ranges <- function(xdoc) {
         })
     })
     comm_ranges <- unlist(comm_ranges, recursive = FALSE, use.names = FALSE)
-    comm_ranges <- comm_ranges[vapply(comm_ranges, length, integer(1)) > 0]
+    comm_ranges <- comm_ranges[lengths(comm_ranges) > 0]
     comm_folding_ranges <- lapply(comm_ranges, function(item) {
         list(
             startLine = item[1] - 1,

--- a/R/folding.R
+++ b/R/folding.R
@@ -4,6 +4,68 @@ FoldingRangeKind <- list(
   Region = "region"
 )
 
+get_expr_folding_ranges <- function(xdoc) {
+    exprs <- xml_find_all(xdoc, "//expr[@line2 > @line1]")
+    if (length(exprs) == 0) {
+        return(NULL)
+    }
+    expr_line1 <- as.integer(xml_attr(exprs, "line1"))
+    expr_line2 <- as.integer(xml_attr(exprs, "line2"))
+    expr_folding_ranges <- .mapply(function(line1, line2) {
+        list(
+            startLine = line1 - 1,
+            endLine = line2 - 1,
+            kind = FoldingRangeKind$Region
+        )
+    }, list(expr_line1, expr_line2), NULL)
+    expr_folding_ranges
+}
+
+get_comment_folding_ranges <- function(xdoc) {
+    comments <- xml_find_all(xdoc, "//COMMENT")
+    if (length(comments) == 0) {
+        return(NULL)
+    }
+    comm_line1 <- as.integer(xml_attr(comments, "line1"))
+    comm_col1 <- as.integer(xml_attr(comments, "col1"))
+    comm_runs <- c(1L, diff(comm_col1) != 0)
+    comm_groups <- cumsum(comm_runs)
+    comm_max_group <- comm_groups[[length(comm_groups)]]
+    comm_lines <- lapply(seq_len(comm_max_group), function(i) {
+        lines <- comm_line1[comm_groups == i]
+        sub_groups <- cumsum(c(0L, diff(lines)) != 1L)
+        max_sub_group <- sub_groups[[length(sub_groups)]]
+        lapply(seq_len(max_sub_group), function(j) {
+            lines[sub_groups == j]
+        })
+    })
+    comm_lines <- unlist(comm_lines,
+        recursive = FALSE, use.names = FALSE)
+    comm_folding_ranges <- lapply(comm_lines, function(item) {
+        list(
+            startLine = item[1] - 1,
+            endLine = item[length(item)] - 1,
+            kind = FoldingRangeKind$Comment
+        )
+    })
+    comm_folding_ranges
+}
+
+get_document_section_folding_ranges <- function(uri, document) {
+    sections <- get_document_sections(uri, document, type = c("section", "chunk"))
+    if (length(sections) == 0) {
+        return(NULL)
+    }
+    section_folding_ranges <- lapply(sections, function(section) {
+        list(
+            startLine = section$start_line - 1,
+            endLine = section$end_line - 1,
+            kind = FoldingRangeKind$Region
+        )
+    })
+    section_folding_ranges
+}
+
 #' Get all the folding ranges in the document
 #' @keywords internal
 document_folding_range_reply <- function(id, uri, workspace, document) {
@@ -17,30 +79,13 @@ document_folding_range_reply <- function(id, uri, workspace, document) {
 
     xdoc <- parse_data$xml_doc
     if (!is.null(xdoc)) {
-        exprs <- xml_find_all(xdoc, "//expr[@line2 > @line1]")
-        expr_line1 <- as.integer(xml_attr(exprs, "line1"))
-        expr_line2 <- as.integer(xml_attr(exprs, "line2"))
-        expr_folding_ranges <- .mapply(function(line1, line2) {
-            list(
-                startLine = line1 - 1,
-                endLine = line2 - 1,
-                kind = FoldingRangeKind$Region
-            )
-        }, list(expr_line1, expr_line2), NULL)
-        result <- c(result, expr_folding_ranges)
+        result <- c(result,
+            get_expr_folding_ranges(xdoc),
+            get_comment_folding_ranges(xdoc)
+        )
     }
 
-    sections <- get_document_sections(uri, document, type = c("section", "chunk"))
-    if (length(sections)) {
-        section_folding_ranges <- lapply(sections, function(section) {
-            list(
-                startLine = section$start_line - 1,
-                endLine = section$end_line - 1,
-                kind = FoldingRangeKind$Region
-            )
-        })
-        result <- c(result, section_folding_ranges)
-    }
+    result <- c(result, get_document_section_folding_ranges(uri, document))
 
     result <- unique(result)
     if (length(result) == 0) {

--- a/R/folding.R
+++ b/R/folding.R
@@ -31,20 +31,25 @@ get_comment_folding_ranges <- function(xdoc) {
     comm_runs <- c(1L, diff(comm_col1) != 0)
     comm_groups <- cumsum(comm_runs)
     comm_max_group <- comm_groups[[length(comm_groups)]]
-    comm_lines <- lapply(seq_len(comm_max_group), function(i) {
+    comm_ranges <- lapply(seq_len(comm_max_group), function(i) {
         lines <- comm_line1[comm_groups == i]
         sub_groups <- cumsum(c(0L, diff(lines)) != 1L)
         max_sub_group <- sub_groups[[length(sub_groups)]]
         lapply(seq_len(max_sub_group), function(j) {
-            lines[sub_groups == j]
+            lns <- lines[sub_groups == j]
+            start_line <- lns[1]
+            end_line <- lns[length(lns)]
+            if (end_line > start_line) {
+                c(start_line, end_line)
+            }
         })
     })
-    comm_lines <- unlist(comm_lines,
-        recursive = FALSE, use.names = FALSE)
-    comm_folding_ranges <- lapply(comm_lines, function(item) {
+    comm_ranges <- unlist(comm_ranges, recursive = FALSE, use.names = FALSE)
+    comm_ranges <- comm_ranges[vapply(comm_ranges, length, integer(1)) > 0]
+    comm_folding_ranges <- lapply(comm_ranges, function(item) {
         list(
             startLine = item[1] - 1,
-            endLine = item[length(item)] - 1,
+            endLine = item[2] - 1,
             kind = FoldingRangeKind$Comment
         )
     })

--- a/tests/testthat/test-folding.R
+++ b/tests/testthat/test-folding.R
@@ -1,6 +1,6 @@
 context("Test Folding Range")
 
-test_that("Document folding rage works", {
+test_that("Expression folding rage works", {
     skip_on_cran()
     client <- language_client()
 
@@ -21,15 +21,9 @@ test_that("Document folding rage works", {
     expect_equivalent(result[[1]]$endLine, 2)
 })
 
-test_that("Document section folding range works", {
+test_that("Section folding range works", {
     skip_on_cran()
-    client <- language_client(capabilities = list(
-        textDocument = list(
-            documentSymbol = list(
-                hierarchicalDocumentSymbolSupport = TRUE
-            )
-        )
-    ))
+    client <- language_client()
 
     withr::local_tempfile(c("defn_file"), fileext = ".R")
     writeLines(c(
@@ -59,15 +53,9 @@ test_that("Document section folding range works", {
     expect_equal(result[[3]]$endLine, 8)
 })
 
-test_that("Document comment folding range works", {
+test_that("Comment folding range works", {
     skip_on_cran()
-    client <- language_client(capabilities = list(
-        textDocument = list(
-            documentSymbol = list(
-                hierarchicalDocumentSymbolSupport = TRUE
-            )
-        )
-    ))
+    client <- language_client()
 
     withr::local_tempfile(c("defn_file"), fileext = ".R")
     writeLines(c(
@@ -98,15 +86,9 @@ test_that("Document comment folding range works", {
     expect_equal(result[[3]]$endLine, 8)
 })
 
-test_that("Document folding range works in Rmarkdown", {
+test_that("Folding range works in Rmarkdown", {
     skip_on_cran()
-    client <- language_client(capabilities = list(
-        textDocument = list(
-            documentSymbol = list(
-                hierarchicalDocumentSymbolSupport = TRUE
-            )
-        )
-    ))
+    client <- language_client()
 
     withr::local_tempfile(c("defn_file"), fileext = ".Rmd")
     writeLines(c(
@@ -117,6 +99,11 @@ test_that("Document folding range works in Rmarkdown", {
         "f <- function(x) {",
         "  x + 1",
         "}",
+        "# title",
+        "# description",
+        "g <- function(x) {",
+        "  x - 1",
+        "}",
         "```"
     ), defn_file)
 
@@ -124,13 +111,17 @@ test_that("Document folding range works in Rmarkdown", {
     result <- client %>% respond_document_folding_range(defn_file)
     result <- result[order(sapply(result, "[[", "startLine"))]
 
-    expect_equal(length(result), 4)
+    expect_equal(length(result), 6)
     expect_equal(result[[1]]$startLine, 0)
-    expect_equal(result[[1]]$endLine, 7)
+    expect_equal(result[[1]]$endLine, 12)
     expect_equal(result[[2]]$startLine, 2)
-    expect_equal(result[[2]]$endLine, 7)
+    expect_equal(result[[2]]$endLine, 12)
     expect_equal(result[[3]]$startLine, 3)
-    expect_equal(result[[3]]$endLine, 7)
+    expect_equal(result[[3]]$endLine, 12)
     expect_equal(result[[4]]$startLine, 4)
     expect_equal(result[[4]]$endLine, 6)
+    expect_equal(result[[5]]$startLine, 7)
+    expect_equal(result[[5]]$endLine, 8)
+    expect_equal(result[[6]]$startLine, 9)
+    expect_equal(result[[6]]$endLine, 11)
 })

--- a/tests/testthat/test-folding.R
+++ b/tests/testthat/test-folding.R
@@ -45,7 +45,9 @@ test_that("Document section folding range works", {
     ), defn_file)
 
     client %>% did_save(defn_file)
-    result <- client %>% respond_document_folding_range(defn_file)
+    result <- client %>%
+        respond_document_folding_range(defn_file) %>%
+        keep(~ .$kind == FoldingRangeKind$Region)
     result <- result[order(sapply(result, "[[", "startLine"))]
 
     expect_equal(length(result), 3)
@@ -53,6 +55,45 @@ test_that("Document section folding range works", {
     expect_equal(result[[1]]$endLine, 6)
     expect_equal(result[[2]]$startLine, 1)
     expect_equal(result[[2]]$endLine, 6)
+    expect_equal(result[[3]]$startLine, 7)
+    expect_equal(result[[3]]$endLine, 8)
+})
+
+test_that("Document comment folding range works", {
+    skip_on_cran()
+    client <- language_client(capabilities = list(
+        textDocument = list(
+            documentSymbol = list(
+                hierarchicalDocumentSymbolSupport = TRUE
+            )
+        )
+    ))
+
+    withr::local_tempfile(c("defn_file"), fileext = ".R")
+    writeLines(c(
+        "# test 1",
+        "# test 2",
+        "f <- function(x) {",
+        "  # step1",
+        "  # step1",
+        "  x + 1",
+        "}",
+        "# test 3",
+        "# test 4",
+        "g <- function(x) { x - 1 }"
+    ), defn_file)
+
+    client %>% did_save(defn_file)
+    result <- client %>%
+        respond_document_folding_range(defn_file) %>%
+        keep(~ .$kind == FoldingRangeKind$Comment)
+    result <- result[order(sapply(result, "[[", "startLine"))]
+
+    expect_equal(length(result), 3)
+    expect_equal(result[[1]]$startLine, 0)
+    expect_equal(result[[1]]$endLine, 1)
+    expect_equal(result[[2]]$startLine, 3)
+    expect_equal(result[[2]]$endLine, 4)
     expect_equal(result[[3]]$startLine, 7)
     expect_equal(result[[3]]$endLine, 8)
 })


### PR DESCRIPTION
This PR adds support of folding ranges for comments so that consecutive lines of comments that start with the same column can be folded.

```r
# comment range 1
# comment range 1
a <- 1

# comment range 2
# comment range 2
b <- 2

# not comment range
c <- 3

f <- function(x, y) {
  # comment range 3
  # comment range 3
  x + y
}
```

The comments in the same folding ranges could be folded.

![Kapture 2020-07-10 at 21 54 39](https://user-images.githubusercontent.com/4662568/87162097-0f254480-c2f8-11ea-957f-d209ef5ac1e6.gif)
