### PR TITLE
Limit string length to provide color and link

### DIFF
--- a/R/color.R
+++ b/R/color.R
@@ -12,7 +12,7 @@ document_color_reply <- function(id, uri, workspace, document) {
 
     xdoc <- parse_data$xml_doc
     if (!is.null(xdoc)) {
-        str_tokens <- xml_find_all(xdoc, "//STR_CONST[@line1=@line2 and @col2 > @col1 + 1]")
+        str_tokens <- xml_find_all(xdoc, "//STR_CONST[@line1=@line2 and @col2>@col1+3 and @col2<@col1+22]")
         str_line1 <- as.integer(xml_attr(str_tokens, "line1"))
         str_col1 <- as.integer(xml_attr(str_tokens, "col1"))
         str_col2 <- as.integer(xml_attr(str_tokens, "col2"))

--- a/R/color.R
+++ b/R/color.R
@@ -12,6 +12,9 @@ document_color_reply <- function(id, uri, workspace, document) {
 
     xdoc <- parse_data$xml_doc
     if (!is.null(xdoc)) {
+        # String length: `@col2-@col1-1`
+        # Shortest color length: 3 (red, tan)
+        # Longest color length: 20 (lightgoldenrodyellow)
         str_tokens <- xml_find_all(xdoc, "//STR_CONST[@line1=@line2 and @col2>@col1+3 and @col2<@col1+22]")
         str_line1 <- as.integer(xml_attr(str_tokens, "line1"))
         str_col1 <- as.integer(xml_attr(str_tokens, "col1"))

--- a/R/link.R
+++ b/R/link.R
@@ -12,6 +12,9 @@ document_link_reply <- function(id, uri, workspace, document, rootPath) {
 
     xdoc <- parse_data$xml_doc
     if (!is.null(xdoc)) {
+        # String length: `@col2-@col1-1`
+        # Limit string length to 255 to avoid potential PATH_MAX error on Windows
+        # On macOS and Linux, PATH_MAX is much larger but we ignore the long strings at the moment.
         str_tokens <- xml_find_all(xdoc, "//STR_CONST[@line1=@line2 and @col2>@col1+1 and @col2<=@col1+256]")
         str_line1 <- as.integer(xml_attr(str_tokens, "line1"))
         str_col1 <- as.integer(xml_attr(str_tokens, "col1"))

--- a/R/link.R
+++ b/R/link.R
@@ -12,7 +12,7 @@ document_link_reply <- function(id, uri, workspace, document, rootPath) {
 
     xdoc <- parse_data$xml_doc
     if (!is.null(xdoc)) {
-        str_tokens <- xml_find_all(xdoc, "//STR_CONST[@line1=@line2 and @col2 > @col1 + 1]")
+        str_tokens <- xml_find_all(xdoc, "//STR_CONST[@line1=@line2 and @col2>@col1+1 and @col2<=@col1+256]")
         str_line1 <- as.integer(xml_attr(str_tokens, "line1"))
         str_col1 <- as.integer(xml_attr(str_tokens, "col1"))
         str_col2 <- as.integer(xml_attr(str_tokens, "col2"))
@@ -22,7 +22,6 @@ document_link_reply <- function(id, uri, workspace, document, rootPath) {
 
         if (length(str_texts)) {
             paths <- fs::path_abs(str_texts, rootPath)
-
             is_link <- file.exists(paths) & !dir.exists(paths)
             link_paths <- path.expand(paths[is_link])
             link_expr <- str_expr[is_link]


### PR DESCRIPTION
Close #313.

For link provider, the string length is limited to 255 characters.

For color provider, the string length is limited from 3 (shorted color name, e.g. `red`) to 20 (longest color name, e.g. `lightgoldenrodyellow`).
