### PR TITLE
Improve folding

### DIFF
--- a/tests/testthat/test-folding.R
+++ b/tests/testthat/test-folding.R
@@ -18,7 +18,7 @@ test_that("Expression folding rage works", {
 
     expect_equal(length(result), 1)
     expect_equivalent(result[[1]]$startLine, 0)
-    expect_equivalent(result[[1]]$endLine, 2)
+    expect_equivalent(result[[1]]$endLine, 1)
 })
 
 test_that("Section folding range works", {
@@ -48,7 +48,7 @@ test_that("Section folding range works", {
     expect_equal(result[[1]]$startLine, 0)
     expect_equal(result[[1]]$endLine, 6)
     expect_equal(result[[2]]$startLine, 1)
-    expect_equal(result[[2]]$endLine, 6)
+    expect_equal(result[[2]]$endLine, 5)
     expect_equal(result[[3]]$startLine, 7)
     expect_equal(result[[3]]$endLine, 8)
 })
@@ -119,9 +119,9 @@ test_that("Folding range works in Rmarkdown", {
     expect_equal(result[[3]]$startLine, 3)
     expect_equal(result[[3]]$endLine, 12)
     expect_equal(result[[4]]$startLine, 4)
-    expect_equal(result[[4]]$endLine, 6)
+    expect_equal(result[[4]]$endLine, 5)
     expect_equal(result[[5]]$startLine, 7)
     expect_equal(result[[5]]$endLine, 8)
     expect_equal(result[[6]]$startLine, 9)
-    expect_equal(result[[6]]$endLine, 11)
+    expect_equal(result[[6]]$endLine, 10)
 })


### PR DESCRIPTION
Close #316 

This PR make folding range provider only create folding ranges for multi-line expressions with `()`, `[]` and `{}`, and the folding range end is a line above the closing bracket so when the range is folded the closing bracket could be seen. Now the folding ranges are consistent with behavior of most other language servers.

```r
if (x > 0) {
  # hello
  # hello2
  x + 1
} else if (x < -1) {
  x - 1
} else {
  x
}
```

Before:

![image](https://user-images.githubusercontent.com/4662568/89093407-b7f12c00-d3ec-11ea-845e-3040a3161cf7.png)

After:

<img width="246" alt="image" src="https://user-images.githubusercontent.com/4662568/89093413-c7707500-d3ec-11ea-9ab2-8bcad0177f6c.png">


And multi-line expressions not enclosed in a pair of brackets are no longer foldable. For example, a pipeline expression could no longer be folded as it is not enclosed in brackets.

```r
kable(dt, format = "html", caption = "Demo Table") %>%
  kable_styling(bootstrap_options = "striped",
    full_width = FALSE) %>%
  add_header_above(c(" ", "Group 1" = 2, "Group 2[note]" = 2)) %>%
  add_footnote(c("table footnote"))
```

