### PR TITLE
More robust rmd chunk pattern

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -157,7 +157,7 @@ check_scope <- function(uri, document, point) {
             document$content[1:(row + 1)], startsWith, logical(1), "```", USE.NAMES = FALSE)
         if (any(flags)) {
             last_match <- document$content[max(which(flags))]
-            stringi::stri_detect_regex(last_match, "`{3,}\\s*\\{r[ ,\\}]") &&
+            stringi::stri_detect_regex(last_match, "```+\\s*\\{[rR][ ,\\}]") &&
                 !identical(sum(flags) %% 2, 0) &&
                 !enclosed_by_quotes(document, point)
         } else {
@@ -186,7 +186,7 @@ seq_safe <- function(a, b) {
 #' @keywords internal
 extract_blocks <- function(content) {
     begins_or_ends <- which(stringi::stri_detect_fixed(content, "```"))
-    begins <- which(stringi::stri_detect_regex(content, "`{3,}\\s*\\{r[ ,\\}]"))
+    begins <- which(stringi::stri_detect_regex(content, "```+\\s*\\{[rR][ ,\\}]"))
     ends <- setdiff(begins_or_ends, begins)
     blocks <- list()
     for (begin in begins) {


### PR DESCRIPTION
This PR is a minor fix of Rmd chunk patterns used to extract R code blocks to work with both of the following cases:

````
```{r}
x <- 1
```

```{R}
x <- 1
```
````