### PR TITLE
Add token completion

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -373,7 +373,7 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
     token <- token_result$token
     package <- token_result$package
 
-    completions <- token_completion(uri, workspace, token)
+    completions <- list()
 
     if (nzchar(full_token)) {
         if (is.null(package)) {
@@ -398,7 +398,12 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
                 exported_only = call_result$accessor != ":::"))
     }
 
-    logger$info("completions: ", length(completions))
+    if (!(token_result$accessor %in% c("::", ":::"))) {
+        completions <- c(
+            completions,
+            token_completion(uri, workspace, token)
+        )
+    }
 
     Response$new(
         id,

--- a/R/completion.R
+++ b/R/completion.R
@@ -342,7 +342,7 @@ token_completion <- function(uri, workspace, token) {
         return(list())
     }
 
-    symbols <- unique(xml_text(xml_find_all(xdoc, "//SYMBOL | //SYMBOL_SUB")))
+    symbols <- unique(xml_text(xml_find_all(xdoc, "//SYMBOL | //SYMBOL_SUB | //SYMBOL_FUNCTION_CALL")))
     symbols <- symbols[startsWith(symbols, token)]
     token_completions <- lapply(symbols, function(symbol) {
         list(

--- a/R/completion.R
+++ b/R/completion.R
@@ -398,7 +398,7 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
                 exported_only = call_result$accessor != ":::"))
     }
 
-    if (!(token_result$accessor %in% c("::", ":::"))) {
+    if (is.null(token_result$package)) {
         completions <- c(
             completions,
             token_completion(uri, workspace, token)

--- a/R/completion.R
+++ b/R/completion.R
@@ -39,7 +39,8 @@ sort_prefixes <- list(
     scope = "1-",
     workspace = "2-",
     imported = "3-",
-    global = "4-"
+    global = "4-",
+    token = "5-"
 )
 
 constants <- c("TRUE", "FALSE", "NULL",
@@ -335,6 +336,23 @@ scope_completion <- function(uri, workspace, token, point, snippet_support = NUL
     completions
 }
 
+token_completion <- function(uri, workspace, token) {
+    xdoc <- workspace$get_parse_data(uri)$xml_doc
+    if (is.null(xdoc)) {
+        return(list())
+    }
+
+    symbols <- unique(xml_text(xml_find_all(xdoc, "//SYMBOL | //SYMBOL_SUB")))
+    symbols <- symbols[startsWith(symbols, token)]
+    token_completions <- lapply(symbols, function(symbol) {
+        list(
+            label = symbol,
+            kind = CompletionItemKind$Text,
+            sortText = paste0(sort_prefixes$token, symbol)
+        )
+    })
+}
+
 #' The response to a textDocument/completion request
 #' @keywords internal
 completion_reply <- function(id, uri, workspace, document, point, capabilities) {
@@ -349,12 +367,13 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
     snippet_support <- isTRUE(capabilities$completionItem$snippetSupport) &&
         getOption("languageserver.snippet_support", TRUE)
 
-    completions <- list()
     token_result <- document$detect_token(point, forward = FALSE)
 
     full_token <- token_result$full_token
     token <- token_result$token
     package <- token_result$package
+
+    completions <- token_completion(uri, workspace, token)
 
     if (nzchar(full_token)) {
         if (is.null(package)) {

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -36,7 +36,7 @@ test_that("Simple completion works", {
     expect_true("path_real" %in% (result$items %>% map_chr(~.$label)))
 
     result <- client %>% respond_completion(temp_file, c(3, 7))
-    expect_length(result$items, 0)
+    expect_length(result$items %>% discard(~.$kind == CompletionItemKind$Text), 0)
 
     result <- client %>% respond_completion(temp_file, c(4, 4))
     expect_length(result$items %>% keep(~ .$label == ".Machine"), 1)
@@ -96,7 +96,9 @@ test_that("Completion of user function works", {
         temp_file, c(1, 4),
         retry_when = function(result) length(result) == 0 || length(result$items) == 0)
 
-    expect_length(result$items %>% keep(~.$label == "my_fun"), 1)
+    expect_length(result$items %>%
+        keep(~ .$label == "my_fun") %>%
+        discard(~ .$kind == CompletionItemKind$Text), 1)
 
 })
 
@@ -119,7 +121,9 @@ test_that("Completion of user function contains no duplicate symbols", {
         temp_file, c(2, 4),
         retry_when = function(result) length(result) == 0 || length(result$items) == 0)
 
-    expect_length(result$items %>% keep(~ .$label == "my_fun"), 1)
+    expect_length(result$items %>%
+        keep(~ .$label == "my_fun") %>%
+        discard(~ .$kind == CompletionItemKind$Text), 1)
 
 })
 
@@ -148,11 +152,19 @@ test_that("Completion of symbols in scope works", {
         retry_when = function(result) length(result) == 0 || length(result$items) == 0
     )
 
-    expect_length(result$items, 4)
-    expect_length(result$items %>% keep(~ .$label == "xvar0"), 1)
-    expect_length(result$items %>% keep(~ .$label == "xvar1"), 1)
-    expect_length(result$items %>% keep(~ .$label == "xvar2"), 1)
-    expect_length(result$items %>% keep(~ .$label == "xvar3"), 1)
+    expect_length(result$items %>% discard(~ .$kind == CompletionItemKind$Text), 4)
+    expect_length(result$items %>%
+        keep(~ .$label == "xvar0") %>%
+        discard(~ .$kind == CompletionItemKind$Text), 1)
+    expect_length(result$items %>%
+        keep(~ .$label == "xvar1") %>%
+        discard(~ .$kind == CompletionItemKind$Text), 1)
+    expect_length(result$items %>%
+        keep(~ .$label == "xvar2") %>%
+        discard(~ .$kind == CompletionItemKind$Text), 1)
+    expect_length(result$items %>%
+        keep(~ .$label == "xvar3") %>%
+        discard(~ .$kind == CompletionItemKind$Text), 1)
 })
 
 test_that("Completion inside a package works", {
@@ -299,7 +311,7 @@ test_that("Completion in Rmarkdown works", {
     expect_true("path_real" %in% (result$items %>% map_chr(~ .$label)))
 
     result <- client %>% respond_completion(temp_file, c(6, 7))
-    expect_length(result$items, 0)
+    expect_length(result$items %>% discard(~ .$kind == CompletionItemKind$Text), 0)
 
     result <- client %>% respond_completion(temp_file, c(7, 4))
     expect_length(result$items %>% keep(~ .$label == ".Machine"), 1)

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -212,6 +212,31 @@ test_that("Completion of imported objects works inside a package", {
     expect_length(result$items %>% keep(~.$label == "lint_package"), 1)
 })
 
+test_that("Completion of tokens in document works", {
+    skip_on_cran()
+    client <- language_client()
+
+    withr::local_tempfile(c("temp_file"), fileext = ".R")
+    writeLines(
+        c(
+            "df1 <- data.frame(var1 = 1:10, var2 = 10:1)",
+            "df1$var3 <- rnorm(10)",
+            "df1$var"
+        ),
+        temp_file
+    )
+
+    client %>% did_save(temp_file)
+
+    result <- client %>% respond_completion(
+        temp_file, c(2, 7),
+        retry_when = function(result) length(result) == 0 || length(result$items) == 0
+    )
+
+    expect_length(result$items %>% keep(~ .$label == "var1"), 1)
+    expect_length(result$items %>% keep(~ .$label == "var2"), 1)
+    expect_length(result$items %>% keep(~ .$label == "var3"), 1)
+})
 
 test_that("Completion item resolve works", {
     skip_on_cran()


### PR DESCRIPTION
It is hard to provide accurate completion based on static code analysis in the following cases:

* Completion for R6 class members (#75)
* Completion for list or data.frame elements (#158)
* Completion for symbols in a pipeline (https://github.com/Ikuyadeu/vscode-R/issues/323)

This PR is an attempt to partially address these cases by providing completions from symbols that appear in the current document so that the symbols are recognized as texts that could be repeatedly used in the document, as demonstrated in the following images.

<img width="695" alt="image" src="https://user-images.githubusercontent.com/4662568/90911632-d787dd00-e40b-11ea-8b3d-7bcf3fd15c75.png">

![image](https://user-images.githubusercontent.com/4662568/90911559-bfb05900-e40b-11ea-8a70-ca1ef737e53b.png)

Since the token completion items have the lowest ranking, they won't interrupt normal completions but provide some help when the normal code analysis does not provide anything.