### PR TITLE
Update xpaths to adapt to token change in parse data in R 4.0

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -277,15 +277,15 @@ workspace_completion <- function(workspace, token,
 scope_completion_symbols_xpath <- paste(
     "FUNCTION/following-sibling::SYMBOL_FORMALS",
     "forcond/SYMBOL",
-    "expr/LEFT_ASSIGN[not(following-sibling::expr/FUNCTION)]/preceding-sibling::expr[count(*)=1]/SYMBOL",
-    "expr/RIGHT_ASSIGN[not(preceding-sibling::expr/FUNCTION)]/following-sibling::expr[count(*)=1]/SYMBOL",
-    "equal_assign/EQ_ASSIGN[not(following-sibling::expr/FUNCTION)]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    "*/LEFT_ASSIGN[not(following-sibling::expr/FUNCTION)]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    "*/RIGHT_ASSIGN[not(preceding-sibling::expr/FUNCTION)]/following-sibling::expr[count(*)=1]/SYMBOL",
+    "*/EQ_ASSIGN[not(following-sibling::expr/FUNCTION)]/preceding-sibling::expr[count(*)=1]/SYMBOL",
     sep = "|")
 
 scope_completion_functs_xpath <- paste(
-    "expr/LEFT_ASSIGN[following-sibling::expr/FUNCTION]/preceding-sibling::expr[count(*)=1]/SYMBOL",
-    "expr/RIGHT_ASSIGN[preceding-sibling::expr/FUNCTION]/following-sibling::expr[count(*)=1]/SYMBOL",
-    "equal_assign/EQ_ASSIGN[following-sibling::expr/FUNCTION]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    "*/LEFT_ASSIGN[following-sibling::expr/FUNCTION]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    "*/RIGHT_ASSIGN[preceding-sibling::expr/FUNCTION]/following-sibling::expr[count(*)=1]/SYMBOL",
+    "*/EQ_ASSIGN[following-sibling::expr/FUNCTION]/preceding-sibling::expr[count(*)=1]/SYMBOL",
     sep = "|")
 
 scope_completion <- function(uri, workspace, token, point, snippet_support = NULL) {

--- a/R/definition.R
+++ b/R/definition.R
@@ -1,8 +1,8 @@
 definition_xpath <- paste(
     "FUNCTION/following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]",
-    "expr[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
-    "expr[RIGHT_ASSIGN/following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
-    "equal_assign[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
+    "*[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
+    "*[RIGHT_ASSIGN/following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
+    "*[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
     "forcond/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]",
     sep = "|")
 

--- a/R/hover.R
+++ b/R/hover.R
@@ -1,8 +1,8 @@
 hover_xpath <- paste(
     "FUNCTION[following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]]/parent::expr",
-    "expr[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
-    "expr[RIGHT_ASSIGN/following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
-    "equal_assign[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
+    "*[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
+    "*[RIGHT_ASSIGN/following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
+    "*[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]",
     "forcond/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]",
     sep = "|")
 

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -136,8 +136,9 @@ test_that("Completion of symbols in scope works", {
         c(
             "xvar0 <- rnorm(10)",
             "my_fun <- function(xvar1) {",
-            "    xvar2 <- 1",
-            "    for (xvar3 in 1:10) {",
+            "    xvar2 = 1",
+            "    2 -> xvar3",
+            "    for (xvar4 in 1:10) {",
             "        xvar",
             "    }",
             "}"
@@ -148,11 +149,11 @@ test_that("Completion of symbols in scope works", {
     client %>% did_save(temp_file)
 
     result <- client %>% respond_completion(
-        temp_file, c(3, 12),
+        temp_file, c(5, 12),
         retry_when = function(result) length(result) == 0 || length(result$items) == 0
     )
 
-    expect_length(result$items %>% discard(~ .$kind == CompletionItemKind$Text), 4)
+    expect_length(result$items %>% discard(~ .$kind == CompletionItemKind$Text), 5)
     expect_length(result$items %>%
         keep(~ .$label == "xvar0") %>%
         discard(~ .$kind == CompletionItemKind$Text), 1)
@@ -164,6 +165,9 @@ test_that("Completion of symbols in scope works", {
         discard(~ .$kind == CompletionItemKind$Text), 1)
     expect_length(result$items %>%
         keep(~ .$label == "xvar3") %>%
+        discard(~ .$kind == CompletionItemKind$Text), 1)
+    expect_length(result$items %>%
+        keep(~ .$label == "xvar4") %>%
         discard(~ .$kind == CompletionItemKind$Text), 1)
 })
 

--- a/tests/testthat/test-definition.R
+++ b/tests/testthat/test-definition.R
@@ -86,7 +86,7 @@ test_that("Go to Definition works in single file", {
     expect_equal(length(result), 0)
 })
 
-test_that("Go to Definition works in scope", {
+test_that("Go to Definition works in scope with different assignment operators", {
     skip_on_cran()
     client <- language_client()
 


### PR DESCRIPTION
Close #327 

`LEFT_ASSIGN`, `RIGHT_ASSIGN`, and `EQ_ASSIGN` are restrictive enough to limit the scope of the XPath selectors, so no need to specify their parent node.