### PR TITLE
Implement referencesProvider

### DIFF
--- a/R/capabilities.R
+++ b/R/capabilities.R
@@ -50,7 +50,7 @@ ServerCapabilities <- list(
     # typeDefinitionProvider = FALSE,
     # implementationProvider = FALSE,
     definitionProvider = TRUE,
-    # referencesProvider = FALSE
+    referencesProvider = TRUE,
     documentHighlightProvider = TRUE,
     documentSymbolProvider = TRUE,
     workspaceSymbolProvider = TRUE,

--- a/R/definition.R
+++ b/R/definition.R
@@ -28,7 +28,7 @@ definition_reply <- function(id, uri, workspace, document, point) {
             token_name <- xml_name(token)
             token_text <- xml_text(token)
             logger$info("definition: ", token_name, token_text)
-            if (token_name %in% c("SYMBOL", "SYMBOL_FUNCTION_CALL")) {
+            if (token_name %in% c("SYMBOL", "SYMBOL_FUNCTION_CALL", "SYMBOL_FORMALS")) {
                 # symbol
                 preceding_dollar <- xml_find_first(token, "preceding-sibling::OP-DOLLAR")
                 if (length(preceding_dollar) == 0) {

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -80,7 +80,11 @@ text_document_implementation  <- function(self, id, params) {
 #' Handler to the `textDocument/references` [Request].
 #' @keywords internal
 text_document_references  <- function(self, id, params) {
-
+    textDocument <- params$textDocument
+    uri <- uri_escape_unicode(textDocument$uri)
+    document <- self$workspace$documents$get(uri)
+    point <- document$from_lsp_position(params$position)
+    self$deliver(references_reply(id, uri, self$workspace, document, point))
 }
 
 #' `textDocument/documentHighlight` request handler

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -208,6 +208,7 @@ LanguageServer$set("public", "register_handlers", function() {
         `textDocument/documentColor` = text_document_document_color,
         `textDocument/colorPresentation` = text_document_color_presentation,
         `textDocument/foldingRange` = text_document_folding_range,
+        `textDocument/references` = text_document_references,
         `workspace/symbol` = workspace_symbol
     )
 

--- a/R/references.R
+++ b/R/references.R
@@ -1,0 +1,61 @@
+#' @keywords internal
+references_reply <- function(id, uri, workspace, document, point) {
+
+  token_result <- document$detect_token(point)
+  resolved <- FALSE
+  result <- NULL
+
+  xdoc <- workspace$get_parse_data(uri)$xml_doc
+  if (token_result$accessor == "" && !is.null(xdoc)) {
+    row <- point$row + 1
+    col <- point$col + 1
+    token <- xdoc_find_token(xdoc, row, col)
+    if (length(token)) {
+      token_name <- xml_name(token)
+      token_text <- xml_text(token)
+      logger$info("definition: ", token_name, token_text)
+      if (token_name %in% c("SYMBOL", "SYMBOL_FUNCTION_CALL")) {
+        # symbol
+        preceding_dollar <- xml_find_first(token, "preceding-sibling::OP-DOLLAR")
+        if (length(preceding_dollar) == 0) {
+          enclosing_scopes <- xdoc_find_enclosing_scopes(xdoc,
+            row, col, top = TRUE)
+          token_quote <- xml_single_quote(token_text)
+          xpath <- glue(definition_xpath, row = row, token_quote = token_quote)
+          all_defs <- xml_find_all(enclosing_scopes, xpath)
+          if (length(all_defs)) {
+            last_def <- all_defs[[length(all_defs)]]
+            result <- list(
+              uri = uri,
+              range = range(
+                start = document$to_lsp_position(
+                  row = as.integer(xml_attr(last_def, "line1")) - 1,
+                  col = as.integer(xml_attr(last_def, "col1")) - 1),
+                end = document$to_lsp_position(
+                  row = as.integer(xml_attr(last_def, "line2")) - 1,
+                  col = as.integer(xml_attr(last_def, "col2")))
+              )
+            )
+            resolved <- TRUE
+          }
+        }
+      } else {
+        resolved <- TRUE
+      }
+    }
+  }
+
+  if (!resolved) {
+    result <- workspace$get_definition(token_result$token, token_result$package,
+      exported_only = token_result$accessor != ":::")
+  }
+
+  if (is.null(result)) {
+    Response$new(id)
+  } else {
+    Response$new(
+      id,
+      result = list(result)
+    )
+  }
+}

--- a/R/references.R
+++ b/R/references.R
@@ -1,3 +1,5 @@
+references_xpath <- "//*[(self::SYMBOL or self::SYMBOL_FUNCTION_CALL or self::SYMBOL_FORMALS) and text() = '{token_quote}']"
+
 #' @keywords internal
 references_reply <- function(id, uri, workspace, document, point) {
 
@@ -18,9 +20,7 @@ references_reply <- function(id, uri, workspace, document, point) {
       doc <- workspace$documents$get(doc_uri)
       xdoc <- workspace$get_parse_data(doc_uri)$xml_doc
       if (!is.null(xdoc)) {
-        symbols <- xml_find_all(xdoc,
-          glue("//*[(self::SYMBOL or self::SYMBOL_FUNCTION_CALL or self::SYMBOL_FORMALS) and text() = '{token_quote}']",
-            token_quote = token_quote))
+        symbols <- xml_find_all(xdoc, glue(references_xpath, token_quote = token_quote))
         line1 <- as.integer(xml_attr(symbols, "line1"))
         col1 <- as.integer(xml_attr(symbols, "col1"))
         line2 <- as.integer(xml_attr(symbols, "line2"))

--- a/R/references.R
+++ b/R/references.R
@@ -19,7 +19,7 @@ references_reply <- function(id, uri, workspace, document, point) {
       xdoc <- workspace$get_parse_data(doc_uri)$xml_doc
       if (!is.null(xdoc)) {
         symbols <- xml_find_all(xdoc,
-          glue("//*[(self::SYMBOL or self::SYMBOL_FUNCTION_CALL) and text() = '{token_quote}']",
+          glue("//*[(self::SYMBOL or self::SYMBOL_FUNCTION_CALL or self::SYMBOL_FORMALS) and text() = '{token_quote}']",
             token_quote = token_quote))
         line1 <- as.integer(xml_attr(symbols, "line1"))
         col1 <- as.integer(xml_attr(symbols, "col1"))

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ These editors are supported by installing the corresponding package.
 - [x] [completionItemResolve](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#completionItem_resolve)
 - [x] [signatureHelpProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp)
 - [x] [definitionProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_definition)
-- [ ] [referencesProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references)
+- [x] [referencesProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references)
 - [x] [documentHighlightProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentHighlight)
 - [x] [documentSymbolProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentSymbol)
 - [x] [workspaceSymbolProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_symbol)

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -197,6 +197,18 @@ respond_definition <- function(client, path, pos, ...) {
     )
 }
 
+respond_references <- function(client, path, pos, ...) {
+    respond(
+        client,
+        "textDocument/references",
+        list(
+            textDocument = list(uri = path_to_uri(path)),
+            position = list(line = pos[1], character = pos[2])
+        ),
+        ...
+    )
+}
+
 
 respond_formatting <- function(client, path, ...) {
     respond(

--- a/tests/testthat/test-references.R
+++ b/tests/testthat/test-references.R
@@ -1,0 +1,223 @@
+context("Test References")
+
+test_that("Find References works for functions in files", {
+    skip_on_cran()
+    client <- language_client()
+
+    withr::local_tempfile(c("defn_file", "defn2_file", "query_file"), fileext = ".R")
+    writeLines(c("my_fn <- function(x) {", "  x + 1", "}"), defn_file)
+    writeLines(c("my_fn"), query_file)
+
+    client %>% did_save(defn_file)
+    client %>% did_save(query_file)
+
+    # query at the beginning of token
+    result <- client %>% respond_references(query_file, c(0, 0))
+    expect_length(result, 2)
+
+    result1 <- result %>% keep(~ .$uri == path_to_uri(defn_file))
+    expect_length(result1, 1)
+    expect_equal(result1[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result1[[1]]$range$end, list(line = 0, character = 5))
+
+    result2 <- result %>% keep(~ .$uri == path_to_uri(query_file))
+    expect_length(result2, 1)
+    expect_equal(result2[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result2[[1]]$range$end, list(line = 0, character = 5))
+
+    # query in the middle of token
+    result <- client %>% respond_references(query_file, c(0, 3))
+    expect_length(result, 2)
+
+    result1 <- result %>% keep(~ .$uri == path_to_uri(defn_file))
+    expect_length(result1, 1)
+    expect_equal(result1[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result1[[1]]$range$end, list(line = 0, character = 5))
+
+    result2 <- result %>% keep(~ .$uri == path_to_uri(query_file))
+    expect_length(result2, 1)
+    expect_equal(result2[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result2[[1]]$range$end, list(line = 0, character = 5))
+
+    # query at the end of token
+    result <- client %>% respond_references(query_file, c(0, 5))
+    expect_length(result, 2)
+
+    result1 <- result %>% keep(~ .$uri == path_to_uri(defn_file))
+    expect_length(result1, 1)
+    expect_equal(result1[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result1[[1]]$range$end, list(line = 0, character = 5))
+
+    result2 <- result %>% keep(~ .$uri == path_to_uri(query_file))
+    expect_length(result2, 1)
+    expect_equal(result2[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result2[[1]]$range$end, list(line = 0, character = 5))
+
+    # remove definition
+    writeLines("", defn_file)
+    client %>% did_save(defn_file)
+
+    result <- client %>% respond_references(query_file, c(0, 0),
+        retry_when = function(result) {
+            length(result) > 0
+        })
+
+    expect_length(result, 0)
+
+    # move function into different file
+    writeLines(c("my_fn <- function(x) {", "  x + 1", "}"), defn2_file)
+    client %>% did_save(defn2_file)
+
+    result <- client %>% respond_references(query_file, c(0, 0))
+    expect_length(result, 2)
+
+    result1 <- result %>% keep(~ .$uri == path_to_uri(defn2_file))
+    expect_length(result1, 1)
+    expect_equal(result1[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result1[[1]]$range$end, list(line = 0, character = 5))
+
+    result2 <- result %>% keep(~ .$uri == path_to_uri(query_file))
+    expect_length(result2, 1)
+    expect_equal(result2[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result2[[1]]$range$end, list(line = 0, character = 5))
+})
+
+test_that("Find References works in single file", {
+    skip_on_cran()
+    client <- language_client()
+
+    withr::local_tempfile(c("single_file"), fileext = ".R")
+    writeLines(
+        c("my_fn <- function(x) {x + 1}", "my_fn", ".nonexistent"),
+        single_file)
+
+    client %>% did_save(single_file)
+
+    # first query a known function to make sure the file is processed
+    result <- client %>% respond_references(single_file, c(1, 0))
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result[[1]]$range$end, list(line = 0, character = 5))
+
+    expect_equal(result[[2]]$range$start, list(line = 1, character = 0))
+    expect_equal(result[[2]]$range$end, list(line = 1, character = 5))
+
+    # then query the missing function. The file is processed, don't need to retry
+    result <- client %>% respond_references(single_file, c(2, 0), retry = FALSE)
+
+    expect_length(result, 0)
+})
+
+test_that("Find References works in scope with different assignment operators", {
+    skip_on_cran()
+    client <- language_client()
+
+    withr::local_tempfile(c("single_file"), fileext = ".R")
+    writeLines(c(
+        "my_fn <- function(var1) {",
+        "  var2 <- 1",
+        "  var3 = 2",
+        "  3 -> var4",
+        "  for (var5 in 1:10) {",
+        "    var1 + var2 + var3 + var4 + var5",
+        "  }",
+        "}",
+        "my_fn(1)"
+    ), single_file)
+
+    client %>% did_save(single_file)
+
+    # first query a known function to make sure the file is processed
+    result <- client %>% respond_references(single_file, c(8, 0))
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result[[1]]$range$end, list(line = 0, character = 5))
+
+    expect_equal(result[[2]]$range$start, list(line = 8, character = 0))
+    expect_equal(result[[2]]$range$end, list(line = 8, character = 5))
+
+    result <- client %>% respond_references(single_file, c(5, 5))
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 0, character = 18))
+    expect_equal(result[[1]]$range$end, list(line = 0, character = 22))
+
+    expect_equal(result[[2]]$range$start, list(line = 5, character = 4))
+    expect_equal(result[[2]]$range$end, list(line = 5, character = 8))
+
+    result <- client %>% respond_references(single_file, c(5, 12))
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 1, character = 2))
+    expect_equal(result[[1]]$range$end, list(line = 1, character = 6))
+
+    expect_equal(result[[2]]$range$start, list(line = 5, character = 11))
+    expect_equal(result[[2]]$range$end, list(line = 5, character = 15))
+
+    result <- client %>% respond_references(single_file, c(5, 20))
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 2, character = 2))
+    expect_equal(result[[1]]$range$end, list(line = 2, character = 6))
+
+    expect_equal(result[[2]]$range$start, list(line = 5, character = 18))
+    expect_equal(result[[2]]$range$end, list(line = 5, character = 22))
+
+
+    result <- client %>% respond_references(single_file, c(5, 26))
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 3, character = 7))
+    expect_equal(result[[1]]$range$end, list(line = 3, character = 11))
+
+    expect_equal(result[[2]]$range$start, list(line = 5, character = 25))
+    expect_equal(result[[2]]$range$end, list(line = 5, character = 29))
+
+
+    result <- client %>% respond_references(single_file, c(5, 34))
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 4, character = 7))
+    expect_equal(result[[1]]$range$end, list(line = 4, character = 11))
+
+    expect_equal(result[[2]]$range$start, list(line = 5, character = 32))
+    expect_equal(result[[2]]$range$end, list(line = 5, character = 36))
+})
+
+test_that("Find References in Rmarkdown works", {
+    skip_on_cran()
+    client <- language_client()
+
+    withr::local_tempfile(c("single_file"), fileext = ".Rmd")
+    writeLines(
+        c(
+            "```{r}",
+            "my_fn <- function(x) {x + 1}",
+            "```",
+            "",
+            "```{r}",
+            "my_fn",
+            ".nonexistent",
+            "```"
+        ),
+        single_file
+    )
+
+    client %>% did_save(single_file)
+
+    # first query a known function to make sure the file is processed
+    result <- client %>% respond_references(single_file, c(5, 0))
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 1, character = 0))
+    expect_equal(result[[1]]$range$end, list(line = 1, character = 5))
+
+    expect_equal(result[[2]]$range$start, list(line = 5, character = 0))
+    expect_equal(result[[2]]$range$end, list(line = 5, character = 5))
+
+    # then query the missing function. The file is processed, don't need to retry
+    result <- client %>% respond_references(single_file, c(6, 0), retry = FALSE)
+    expect_length(result, 0)
+})


### PR DESCRIPTION
Close #336 

This PR implements a simple [referencesProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references) based on the current definitionProvider.

1. Find the definition of the requested token.
2. Find all symbols with the same text of the requested token in all documents in workspace (`R/*.R` for package or otherwise open R documents in non-package workspace)
3. Find the definition of each symbol in each document.
4. Regard the symbol as a reference if its definition is identical to that of the requested token.

This PR also provides test cases for the referencesProvider (also based on test cases of the definitionProvider).

![Kapture 2020-09-19 at 20 39 47](https://user-images.githubusercontent.com/4662568/93667495-fb951780-fab8-11ea-96bf-8649b89a85d7.gif)
