### PR TITLE
Implement renameProvider

### DIFF
--- a/R/capabilities.R
+++ b/R/capabilities.R
@@ -59,7 +59,7 @@ ServerCapabilities <- list(
     documentFormattingProvider = TRUE,
     documentRangeFormattingProvider = TRUE,
     documentOnTypeFormattingProvider = DocumentOnTypeFormattingOptions,
-    # renameProvider = FALSE,
+    renameProvider = TRUE,
     documentLinkProvider = DocumentLinkOptions,
     colorProvider = TRUE,
     foldingRangeProvider = TRUE

--- a/R/capabilities.R
+++ b/R/capabilities.R
@@ -38,6 +38,10 @@ DocumentLinkOptions <- list(
     resolveProvider = FALSE
 )
 
+RenameOptions <- list(
+    prepareProvider = TRUE
+)
+
 ExecuteCommandOptions <- list(
     commands = NULL
 )
@@ -67,3 +71,14 @@ ServerCapabilities <- list(
     # executeCommandProvider = ExecuteCommandOptions,
     # workspace = list()
 )
+
+update_server_capabilities <- function(server_capabilities, client_capabilities) {
+    # RenameOptions may only be specified if the client states that
+    # it supports prepareSupport in its initial initialize request
+    if (isTRUE(server_capabilities$renameProvider) &&
+        isTRUE(client_capabilities$textDocument$rename$prepareSupport)) {
+        server_capabilities$renameProvider <- RenameOptions
+    }
+
+    server_capabilities
+}

--- a/R/handlers-general.R
+++ b/R/handlers-general.R
@@ -17,10 +17,12 @@ on_initialize <- function(self, id, params) {
     self$workspace <- Workspace$new(self$rootPath)
     self$initializationOptions <- params$initializationOptions
     self$ClientCapabilities <- params$capabilities
-    ServerCapabilities <- merge_list(
-        ServerCapabilities,
+    server_capabilities <- update_server_capabilities(
+        ServerCapabilities, self$ClientCapabilities)
+    server_capabilities <- merge_list(
+        server_capabilities,
         getOption("languageserver.server_capabilities"))
-    self$deliver(Response$new(id = id, result = list(capabilities = ServerCapabilities)))
+    self$deliver(Response$new(id = id, result = list(capabilities = server_capabilities)))
 }
 
 #' `initialized` handler

--- a/R/handlers-general.R
+++ b/R/handlers-general.R
@@ -22,6 +22,7 @@ on_initialize <- function(self, id, params) {
     server_capabilities <- merge_list(
         server_capabilities,
         getOption("languageserver.server_capabilities"))
+    self$ServerCapabilities <- server_capabilities
     self$deliver(Response$new(id = id, result = list(capabilities = server_capabilities)))
 }
 

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -256,7 +256,7 @@ text_document_on_type_formatting  <- function(self, id, params) {
 #'
 #' Handler to the `textDocument/rename` [Request].
 #' @keywords internal
-text_document_rename  <- function(self, id, params) {
+text_document_rename <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
@@ -270,7 +270,11 @@ text_document_rename  <- function(self, id, params) {
 #' Handler to the `textDocument/prepareRename` [Request].
 #' @keywords internal
 text_document_prepare_rename  <- function(self, id, params) {
-
+    textDocument <- params$textDocument
+    uri <- uri_escape_unicode(textDocument$uri)
+    document <- self$workspace$documents$get(uri)
+    point <- document$from_lsp_position(params$position)
+    self$deliver(prepare_rename_reply(id, uri, self$workspace, document, point))
 }
 
 #' `textDocument/foldingRange` request handler

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -257,7 +257,12 @@ text_document_on_type_formatting  <- function(self, id, params) {
 #' Handler to the `textDocument/rename` [Request].
 #' @keywords internal
 text_document_rename  <- function(self, id, params) {
-
+    textDocument <- params$textDocument
+    uri <- uri_escape_unicode(textDocument$uri)
+    document <- self$workspace$documents$get(uri)
+    point <- document$from_lsp_position(params$position)
+    newName <- params$newName
+    self$deliver(rename_reply(id, uri, self$workspace, document, point, newName))
 }
 
 #' `textDocument/prepareRename` request handler

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -210,6 +210,7 @@ LanguageServer$set("public", "register_handlers", function() {
         `textDocument/foldingRange` = text_document_folding_range,
         `textDocument/references` = text_document_references,
         `textDocument/rename` = text_document_rename,
+        `textDocument/prepareRename` = text_document_prepare_rename,
         `workspace/symbol` = workspace_symbol
     )
 

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -209,6 +209,7 @@ LanguageServer$set("public", "register_handlers", function() {
         `textDocument/colorPresentation` = text_document_color_presentation,
         `textDocument/foldingRange` = text_document_folding_range,
         `textDocument/references` = text_document_references,
+        `textDocument/rename` = text_document_rename,
         `workspace/symbol` = workspace_symbol
     )
 

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -27,6 +27,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
         rootPath = NULL,
         initializationOptions = NULL,
         ClientCapabilities = NULL,
+        ServerCapabilities = NULL,
 
         diagnostics_task_manager = NULL,
         parse_task_manager = NULL,

--- a/R/rename.R
+++ b/R/rename.R
@@ -1,3 +1,31 @@
+prepare_rename_reply <- function(id, uri, workspace, document, point, newName) {
+  defn <- definition_reply(id, uri, workspace, document, point)
+
+  if (length(defn$result)) {
+    xdoc <- workspace$get_parse_data(uri)$xml_doc
+    row <- point$row + 1
+    col <- point$col + 1
+    token <- xdoc_find_token(xdoc, row, col)
+    Response$new(
+      id,
+      result = range(
+        start = document$to_lsp_position(
+          row = as.integer(xml_attr(token, "line1")) - 1,
+          col = as.integer(xml_attr(token, "col1")) - 1),
+        end = document$to_lsp_position(
+          row = as.integer(xml_attr(token, "line2")) - 1,
+          col = as.integer(xml_attr(token, "col2")))
+      )
+    )
+  } else {
+    Response$new(
+      id,
+      result = NULL,
+      error = list(message = "Cannot rename the symbol")
+    )
+  }
+}
+
 #' @keywords internal
 rename_reply <- function(id, uri, workspace, document, point, newName) {
   refs <- references_reply(NULL, uri, workspace, document, point)

--- a/R/rename.R
+++ b/R/rename.R
@@ -1,0 +1,27 @@
+#' @keywords internal
+rename_reply <- function(id, uri, workspace, document, point, newName) {
+  refs <- references_reply(NULL, uri, workspace, document, point)
+  result <- list()
+
+  for (ref in refs$result) {
+    result[[ref$uri]] <- c(result[[ref$uri]], list(text_edit(
+      range = ref$range,
+      new_text = newName
+    )))
+  }
+
+  logger$info("rename_reply: ", result)
+
+  if (length(result)) {
+    Response$new(
+      id,
+      result = list(
+        changes = result
+      )
+    )
+  } else {
+    Response$new(
+      id
+    )
+  }
+}

--- a/R/rename.R
+++ b/R/rename.R
@@ -1,5 +1,5 @@
 prepare_rename_reply <- function(id, uri, workspace, document, point, newName) {
-  defn <- definition_reply(id, uri, workspace, document, point)
+  defn <- definition_reply(NULL, uri, workspace, document, point)
 
   if (length(defn$result)) {
     xdoc <- workspace$get_parse_data(uri)$xml_doc

--- a/R/rename.R
+++ b/R/rename.R
@@ -20,10 +20,10 @@ prepare_rename_reply <- function(id, uri, workspace, document, point) {
       )
     )
   } else {
-    Response$new(
+    ResponseErrorMessage$new(
       id,
-      result = NULL,
-      error = list(message = "Cannot rename the symbol")
+      errortype = "RequestCancelled",
+      message = "Cannot rename the symbol"
     )
   }
 }

--- a/R/rename.R
+++ b/R/rename.R
@@ -1,20 +1,22 @@
-prepare_rename_reply <- function(id, uri, workspace, document, point, newName) {
+prepare_rename_reply <- function(id, uri, workspace, document, point) {
+  token <- document$detect_token(point)
   defn <- definition_reply(NULL, uri, workspace, document, point)
 
+  logger$info("prepare_rename_reply: ", list(
+    token = token,
+    defn = defn$result
+  ))
+
   if (length(defn$result)) {
-    xdoc <- workspace$get_parse_data(uri)$xml_doc
-    row <- point$row + 1
-    col <- point$col + 1
-    token <- xdoc_find_token(xdoc, row, col)
     Response$new(
       id,
       result = range(
         start = document$to_lsp_position(
-          row = as.integer(xml_attr(token, "line1")) - 1,
-          col = as.integer(xml_attr(token, "col1")) - 1),
+          row = token$range$start$row,
+          col = token$range$start$col),
         end = document$to_lsp_position(
-          row = as.integer(xml_attr(token, "line2")) - 1,
-          col = as.integer(xml_attr(token, "col2")))
+          row = token$range$end$row,
+          col = token$range$end$col)
       )
     )
   } else {

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ These editors are supported by installing the corresponding package.
 - [x] [documentRangeFormattingProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rangeFormatting)
 - [x] [documentOnTypeFormattingProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_onTypeFormatting)
 - [x] [renameProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename)
+- [x] [prepareRenameProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_prepareRename)
 - [x] [documentLinkProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentLink)
 - [x] [colorProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentColor)
 - [x] [colorPresentation](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_colorPresentation)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ These editors are supported by installing the corresponding package.
 - [x] [documentFormattingProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting)
 - [x] [documentRangeFormattingProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rangeFormatting)
 - [x] [documentOnTypeFormattingProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_onTypeFormatting)
-- [ ] [renameProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename)
+- [x] [renameProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename)
 - [x] [documentLinkProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentLink)
 - [x] [colorProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentColor)
 - [x] [colorPresentation](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_colorPresentation)

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -209,6 +209,19 @@ respond_references <- function(client, path, pos, ...) {
     )
 }
 
+respond_rename <- function(client, path, pos, newName, ...) {
+    respond(
+        client,
+        "textDocument/rename",
+        list(
+            textDocument = list(uri = path_to_uri(path)),
+            position = list(line = pos[1], character = pos[2]),
+            newName = newName
+        ),
+        ...
+    )
+}
+
 
 respond_formatting <- function(client, path, ...) {
     respond(

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -222,6 +222,18 @@ respond_rename <- function(client, path, pos, newName, ...) {
     )
 }
 
+respond_prepare_rename <- function(client, path, pos, ...) {
+    respond(
+        client,
+        "textDocument/prepareRename",
+        list(
+            textDocument = list(uri = path_to_uri(path)),
+            position = list(line = pos[1], character = pos[2])
+        ),
+        ...
+    )
+}
+
 
 respond_formatting <- function(client, path, ...) {
     respond(

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -94,12 +94,13 @@ did_save <- function(client, path) {
         client,
         "textDocument/didSave",
         params)
+    Sys.sleep(0.5)
     invisible(client)
 }
 
 
-respond <- function(client, method, params, timeout, retry = TRUE,
-                            retry_when = function(result) length(result) == 0) {
+respond <- function(client, method, params, timeout, allow_error = FALSE,
+    retry = TRUE, retry_when = function(result) length(result) == 0) {
     if (missing(timeout)) {
         if (Sys.getenv("R_COVR", "") == "true") {
             # we give more time to covr
@@ -109,9 +110,14 @@ respond <- function(client, method, params, timeout, retry = TRUE,
         }
     }
     storage <- new.env(parent = .GlobalEnv)
-    cb <- function(self, result) {
-        storage$done <- TRUE
-        storage$result <- result
+    cb <- function(self, result, error = NULL) {
+        if (is.null(error)) {
+            storage$done <- TRUE
+            storage$result <- result
+        } else if (allow_error) {
+            storage$done <- TRUE
+            storage$result <- error
+        }
     }
 
     start_time <- Sys.time()
@@ -134,7 +140,7 @@ respond <- function(client, method, params, timeout, retry = TRUE,
             return(NULL)
         }
         Sys.sleep(0.2)
-        return(Recall(client, method, params, remaining, retry, retry_when))
+        return(Recall(client, method, params, remaining, allow_error, retry, retry_when))
     }
     return(result)
 }

--- a/tests/testthat/test-rename.R
+++ b/tests/testthat/test-rename.R
@@ -1,0 +1,271 @@
+context("Test Rename")
+
+test_that("Rename works for functions in files", {
+    skip_on_cran()
+    client <- language_client()
+
+    withr::local_tempfile(c("defn_file", "defn2_file", "query_file"), fileext = ".R")
+    writeLines(c("my_fn <- function(x) {", "  x + 1", "}"), defn_file)
+    writeLines(c("my_fn"), query_file)
+
+    client %>% did_save(defn_file)
+    client %>% did_save(query_file)
+
+    # query at the beginning of token
+    result <- client %>% respond_rename(query_file, c(0, 0), "new_fn")
+    expect_length(result$changes, 2)
+
+    result1 <- result$changes[[path_to_uri(defn_file)]]
+    expect_length(result1, 1)
+    expect_equal(result1[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result1[[1]]$range$end, list(line = 0, character = 5))
+    expect_equal(result1[[1]]$newText, "new_fn")
+
+    result2 <- result$changes[[path_to_uri(query_file)]]
+    expect_length(result2, 1)
+    expect_equal(result2[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result2[[1]]$range$end, list(line = 0, character = 5))
+    expect_equal(result2[[1]]$newText, "new_fn")
+
+    # query in the middle of token
+    result <- client %>% respond_rename(query_file, c(0, 3), "new_fn")
+    expect_length(result$changes, 2)
+
+    result1 <- result$changes[[path_to_uri(defn_file)]]
+    expect_length(result1, 1)
+    expect_equal(result1[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result1[[1]]$range$end, list(line = 0, character = 5))
+    expect_equal(result1[[1]]$newText, "new_fn")
+
+    result2 <- result$changes[[path_to_uri(query_file)]]
+    expect_length(result2, 1)
+    expect_equal(result2[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result2[[1]]$range$end, list(line = 0, character = 5))
+    expect_equal(result2[[1]]$newText, "new_fn")
+
+    # query at the end of token
+    result <- client %>% respond_rename(query_file, c(0, 5), "new_fn")
+    expect_length(result$changes, 2)
+
+    result1 <- result$changes[[path_to_uri(defn_file)]]
+    expect_length(result1, 1)
+    expect_equal(result1[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result1[[1]]$range$end, list(line = 0, character = 5))
+    expect_equal(result1[[1]]$newText, "new_fn")
+
+    result2 <- result$changes[[path_to_uri(query_file)]]
+    expect_length(result2, 1)
+    expect_equal(result2[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result2[[1]]$range$end, list(line = 0, character = 5))
+    expect_equal(result2[[1]]$newText, "new_fn")
+
+    # remove definition
+    writeLines("", defn_file)
+    client %>% did_save(defn_file)
+
+    result <- client %>% respond_rename(query_file, c(0, 0), "new_fn",
+        retry_when = function(result) {
+            length(result$changes) > 0
+        })
+
+    expect_length(result$changes, 0)
+
+    # move function into different file
+    writeLines(c("my_fn <- function(x) {", "  x + 1", "}"), defn2_file)
+    client %>% did_save(defn2_file)
+
+    result <- client %>% respond_rename(query_file, c(0, 0), "new_fn")
+    expect_length(result$changes, 2)
+
+    result1 <- result$changes[[path_to_uri(defn2_file)]]
+    expect_length(result1, 1)
+    expect_equal(result1[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result1[[1]]$range$end, list(line = 0, character = 5))
+    expect_equal(result1[[1]]$newText, "new_fn")
+
+    result2 <- result$changes[[path_to_uri(query_file)]]
+    expect_length(result2, 1)
+    expect_equal(result2[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result2[[1]]$range$end, list(line = 0, character = 5))
+    expect_equal(result2[[1]]$newText, "new_fn")
+})
+
+test_that("Rename works in single file", {
+    skip_on_cran()
+    client <- language_client()
+
+    withr::local_tempfile(c("single_file"), fileext = ".R")
+    writeLines(
+        c("my_fn <- function(x) {x + 1}", "my_fn", ".nonexistent"),
+        single_file)
+
+    client %>% did_save(single_file)
+
+    # first query a known function to make sure the file is processed
+    result <- client %>% respond_rename(single_file, c(1, 0), "new_fn")
+    expect_length(result$changes, 1)
+
+    result <- result$changes[[path_to_uri(single_file)]]
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result[[1]]$range$end, list(line = 0, character = 5))
+    expect_equal(result[[1]]$newText, "new_fn")
+
+    expect_equal(result[[2]]$range$start, list(line = 1, character = 0))
+    expect_equal(result[[2]]$range$end, list(line = 1, character = 5))
+    expect_equal(result[[2]]$newText, "new_fn")
+
+    # then query the missing function. The file is processed, don't need to retry
+    result <- client %>% respond_rename(single_file, c(2, 0), "new_fn", retry = FALSE)
+
+    expect_length(result$changes, 0)
+})
+
+test_that("Rename works in scope with different assignment operators", {
+    skip_on_cran()
+    client <- language_client()
+
+    withr::local_tempfile(c("single_file"), fileext = ".R")
+    writeLines(c(
+        "my_fn <- function(var1) {",
+        "  var2 <- 1",
+        "  var3 = 2",
+        "  3 -> var4",
+        "  for (var5 in 1:10) {",
+        "    var1 + var2 + var3 + var4 + var5",
+        "  }",
+        "}",
+        "my_fn(1)"
+    ), single_file)
+
+    client %>% did_save(single_file)
+
+    # first query a known function to make sure the file is processed
+    result <- client %>% respond_rename(single_file, c(8, 0), "new_fn")
+    expect_length(result$changes, 1)
+
+    result <- result$changes[[path_to_uri(single_file)]]
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 0, character = 0))
+    expect_equal(result[[1]]$range$end, list(line = 0, character = 5))
+    expect_equal(result[[1]]$newText, "new_fn")
+
+    expect_equal(result[[2]]$range$start, list(line = 8, character = 0))
+    expect_equal(result[[2]]$range$end, list(line = 8, character = 5))
+    expect_equal(result[[2]]$newText, "new_fn")
+
+    result <- client %>% respond_rename(single_file, c(5, 5), "new_fn")
+    expect_length(result$changes, 1)
+
+    result <- result$changes[[path_to_uri(single_file)]]
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 0, character = 18))
+    expect_equal(result[[1]]$range$end, list(line = 0, character = 22))
+    expect_equal(result[[1]]$newText, "new_fn")
+
+    expect_equal(result[[2]]$range$start, list(line = 5, character = 4))
+    expect_equal(result[[2]]$range$end, list(line = 5, character = 8))
+    expect_equal(result[[2]]$newText, "new_fn")
+
+    result <- client %>% respond_rename(single_file, c(5, 12), "new_fn")
+    expect_length(result$changes, 1)
+
+    result <- result$changes[[path_to_uri(single_file)]]
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 1, character = 2))
+    expect_equal(result[[1]]$range$end, list(line = 1, character = 6))
+    expect_equal(result[[1]]$newText, "new_fn")
+
+    expect_equal(result[[2]]$range$start, list(line = 5, character = 11))
+    expect_equal(result[[2]]$range$end, list(line = 5, character = 15))
+    expect_equal(result[[2]]$newText, "new_fn")
+
+    result <- client %>% respond_rename(single_file, c(5, 20), "new_fn")
+    expect_length(result$changes, 1)
+
+    result <- result$changes[[path_to_uri(single_file)]]
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 2, character = 2))
+    expect_equal(result[[1]]$range$end, list(line = 2, character = 6))
+    expect_equal(result[[1]]$newText, "new_fn")
+
+    expect_equal(result[[2]]$range$start, list(line = 5, character = 18))
+    expect_equal(result[[2]]$range$end, list(line = 5, character = 22))
+    expect_equal(result[[2]]$newText, "new_fn")
+
+
+    result <- client %>% respond_rename(single_file, c(5, 26), "new_fn")
+    expect_length(result$changes, 1)
+
+    result <- result$changes[[path_to_uri(single_file)]]
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 3, character = 7))
+    expect_equal(result[[1]]$range$end, list(line = 3, character = 11))
+    expect_equal(result[[1]]$newText, "new_fn")
+
+    expect_equal(result[[2]]$range$start, list(line = 5, character = 25))
+    expect_equal(result[[2]]$range$end, list(line = 5, character = 29))
+    expect_equal(result[[2]]$newText, "new_fn")
+
+
+    result <- client %>% respond_rename(single_file, c(5, 34), "new_fn")
+    expect_length(result$changes, 1)
+
+    result <- result$changes[[path_to_uri(single_file)]]
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 4, character = 7))
+    expect_equal(result[[1]]$range$end, list(line = 4, character = 11))
+    expect_equal(result[[1]]$newText, "new_fn")
+
+    expect_equal(result[[2]]$range$start, list(line = 5, character = 32))
+    expect_equal(result[[2]]$range$end, list(line = 5, character = 36))
+    expect_equal(result[[2]]$newText, "new_fn")
+})
+
+test_that("Rename in Rmarkdown works", {
+    skip_on_cran()
+    client <- language_client()
+
+    withr::local_tempfile(c("single_file"), fileext = ".Rmd")
+    writeLines(
+        c(
+            "```{r}",
+            "my_fn <- function(x) {x + 1}",
+            "```",
+            "",
+            "```{r}",
+            "my_fn",
+            ".nonexistent",
+            "```"
+        ),
+        single_file
+    )
+
+    client %>% did_save(single_file)
+
+    # first query a known function to make sure the file is processed
+    result <- client %>% respond_rename(single_file, c(5, 0), "new_fn")
+    expect_length(result$changes, 1)
+
+    result <- result$changes[[path_to_uri(single_file)]]
+    expect_length(result, 2)
+
+    expect_equal(result[[1]]$range$start, list(line = 1, character = 0))
+    expect_equal(result[[1]]$range$end, list(line = 1, character = 5))
+    expect_equal(result[[1]]$newText, "new_fn")
+
+    expect_equal(result[[2]]$range$start, list(line = 5, character = 0))
+    expect_equal(result[[2]]$range$end, list(line = 5, character = 5))
+    expect_equal(result[[2]]$newText, "new_fn")
+
+    # then query the missing function. The file is processed, don't need to retry
+    result <- client %>% respond_rename(single_file, c(6, 0), "new_fn", retry = FALSE)
+    expect_length(result$changes, 0)
+})

--- a/tests/testthat/test-rename.R
+++ b/tests/testthat/test-rename.R
@@ -289,10 +289,9 @@ test_that("Prepare rename works in single file", {
     expect_equal(result$start, list(line = 0, character = 0))
     expect_equal(result$end, list(line = 0, character = 5))
 
-    result <- client %>% respond_prepare_rename(single_file, c(2, 0))
-    expect_null(result)
+    error <- client %>% respond_prepare_rename(single_file, c(2, 0), allow_error = TRUE)
+    expect_equal(error$message, "Cannot rename the symbol")
 
-    result <- client %>% respond_prepare_rename(single_file, c(0, 27))
-    expect_null(result)
-
+    error <- client %>% respond_prepare_rename(single_file, c(0, 27), allow_error = TRUE)
+    expect_equal(error$message, "Cannot rename the symbol")
 })

--- a/tests/testthat/test-rename.R
+++ b/tests/testthat/test-rename.R
@@ -269,3 +269,30 @@ test_that("Rename in Rmarkdown works", {
     result <- client %>% respond_rename(single_file, c(6, 0), "new_fn", retry = FALSE)
     expect_length(result$changes, 0)
 })
+
+test_that("Prepare rename works in single file", {
+    skip_on_cran()
+    client <- language_client()
+
+    withr::local_tempfile(c("single_file"), fileext = ".R")
+    writeLines(
+        c("my_fn <- function(x) {x + 123}", "my_fn", "new_fn"),
+        single_file)
+
+    client %>% did_save(single_file)
+
+    result <- client %>% respond_prepare_rename(single_file, c(1, 0))
+    expect_equal(result$start, list(line = 1, character = 0))
+    expect_equal(result$end, list(line = 1, character = 5))
+
+    result <- client %>% respond_prepare_rename(single_file, c(0, 0))
+    expect_equal(result$start, list(line = 0, character = 0))
+    expect_equal(result$end, list(line = 0, character = 5))
+
+    result <- client %>% respond_prepare_rename(single_file, c(2, 0))
+    expect_null(result)
+
+    result <- client %>% respond_prepare_rename(single_file, c(0, 27))
+    expect_null(result)
+
+})


### PR DESCRIPTION
Close #337 

This PR implements [prepareRename](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_prepareRename) and [renameProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename) based on the referenceProvider implemented by #338 by transforming the references into a [WorkspaceEdit](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspaceEdit).

![Kapture 2020-09-19 at 21 55 06](https://user-images.githubusercontent.com/4662568/93668953-ef15bc80-fac2-11ea-9ea6-21e2e98517a1.gif)
