### PR TITLE
Do not load sysdata.rda

### DIFF
--- a/R/workspace.R
+++ b/R/workspace.R
@@ -226,7 +226,7 @@ Workspace <- R6::R6Class("Workspace",
 
         load_all = function(langserver) {
             source_dir <- file.path(self$root, "R")
-            files <- list.files(source_dir)
+            files <- list.files(source_dir, pattern = "\\.r$", ignore.case = TRUE)
             for (f in files) {
                 logger$info("load ", f)
                 path <- file.path(source_dir, f)


### PR DESCRIPTION
In the R directory, some packages have the `sysdata.rda` file (see https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Package-subdirectories for reference), which tries to get loaded on_initialized. This PR proposes to skip that file from `load_all()`.