### PR TITLE
Remove diagnostics of closed files in non-package workspace

### DIFF
--- a/R/handlers-textsync.R
+++ b/R/handlers-textsync.R
@@ -100,6 +100,7 @@ text_document_did_close <- function(self, params) {
 
     # do not remove document in package
     if (!(is_package(self$rootPath) && is_from_workspace)) {
+        diagnostics_callback(self, uri, NULL, list())
         self$workspace$documents$remove(uri)
         self$workspace$update_loaded_packages()
     }


### PR DESCRIPTION
Close #348 

If the workspace is not a package, closing a document in workspace will also remove its diagnostics.