### PR TITLE
Update coc help in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,25 @@ These editors are supported by installing the corresponding package.
       :CocInstall coc-r-lsp
       ```
 
-    - or add the following to your Coc config:
+    - or install the languageserver package in R 
 
-      ```json
-      "languageserver": {
-          "R": {
-              "command": "/usr/bin/R",
-              "args" : [ "--slave", "-e", "languageserver::run()"],
-              "filetypes" : ["r"]
-          }
-      }
-      ```
+        ```r
+        install.packages("languageserver")
+        # or install the developement version
+        # devtools::install_github("REditorSupport/languageserver")
+        ```
+      
+      Then add the following to your Coc config:
+
+        ```json
+        "languageserver": {
+            "R": {
+                "command": "/usr/bin/R",
+                "args" : [ "--slave", "-e", "languageserver::run()"],
+                "filetypes" : ["r"]
+            }
+        }
+        ```
 
 - Emacs: [lsp-mode](https://github.com/emacs-lsp/lsp-mode)
 

--- a/README.md
+++ b/README.md
@@ -40,25 +40,25 @@ These editors are supported by installing the corresponding package.
         \ }
     ```
 
-    or, if you use [coc.nvim](https://github.com/neoclide/coc.nvim), you can do one of two things:
+  or, if you use [coc.nvim](https://github.com/neoclide/coc.nvim), you can do one of two things:
 
-      - Install [coc-r-lsp](https://github.com/neoclide/coc-r-lsp) with:
+    - Install [coc-r-lsp](https://github.com/neoclide/coc-r-lsp) with:
 
-        ```vim
-        :CocInstall coc-r-lsp
-        ```
+      ```vim
+      :CocInstall coc-r-lsp
+      ```
 
-      - or add the following to your Coc config:
+    - or add the following to your Coc config:
 
-        ```json
-        "languageserver": {
-            "R": {
-                "command": "/usr/bin/R",
-                "args" : [ "--slave", "-e", "languageserver::run()"],
-                "filetypes" : ["r"]
-            }
-        }
-        ```
+      ```json
+      "languageserver": {
+          "R": {
+              "command": "/usr/bin/R",
+              "args" : [ "--slave", "-e", "languageserver::run()"],
+              "filetypes" : ["r"]
+          }
+      }
+      ```
 
 - Emacs: [lsp-mode](https://github.com/emacs-lsp/lsp-mode)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,25 @@ These editors are supported by installing the corresponding package.
         \ }
     ```
 
-    or use [coc-r-lsp](https://github.com/neoclide/coc-r-lsp) with [coc.nvim](https://github.com/neoclide/coc.nvim)
+    or, if you use [coc.nvim](https://github.com/neoclide/coc.nvim), you can do one of two things:
+
+      - Install [coc-r-lsp](https://github.com/neoclide/coc-r-lsp) with:
+
+        ```vim
+        :CocInstall coc-r-lsp
+        ```
+
+      - or add the following to your Coc config:
+
+        ```json
+        "languageserver": {
+            "R": {
+                "command": "/usr/bin/R",
+                "args" : [ "--slave", "-e", "languageserver::run()"],
+                "filetypes" : ["r"]
+            }
+        }
+        ```
 
 - Emacs: [lsp-mode](https://github.com/emacs-lsp/lsp-mode)
 


### PR DESCRIPTION
Updates README because the original didn't show that coc could be configured entirely from `coc-settings.json`.