### PR TITLE
Recognize symbols created by delayedAssign / assign / makeActiveBinding

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,17 @@
+# languageserver 0.3.10
+
+- Recongize promise and active binding symbols (#362)
+
 # languageserver 0.3.9
 
 - skip tests on solaris 
-- Recongize promise and active binding symbols (#362)
 
 # languageserver 0.3.8
 
 - When closing a file, "Problems" should be removed (#348)
 - Implement renameProvider (#337)
 - Hover on symbol in a function with functional argument causes parse error (#345)
-Hover on non-function symbol in other document should show definition and - documentation (#343)
+- Hover on non-function symbol in other document should show definition and - documentation (#343)
 - Check if symbol on rhs of assignment in definition (#341)
 - Implement referencesProvider (#336)
 - Add comment of notice above temp code of definition (#353)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # languageserver 0.3.9
 
 - skip tests on solaris 
+- Recongize promise and active binding symbols (#362)
 
 # languageserver 0.3.8
 

--- a/R/document.R
+++ b/R/document.R
@@ -218,11 +218,9 @@ parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcr
             Recall(content, e[[3L]], env, level + 1L, cur_srcref)
         } else if (f == "repeat") {
             Recall(content, e[[2L]], env, level + 1L, cur_srcref)
-        } else if (
-            (f %in% c("<-", "=") && length(e) == 3L && is.symbol(e[[2L]])) ||
-            f %in% c("delayedAssign", "makeActiveBinding")
-        ) {
+        } else if (f %in% c("<-", "=", "delayedAssign", "makeActiveBinding")) {
             if (f %in% c("<-", "=")) {
+                if (length(e) != 3L || !is.symbol(e[[2L]])) next
                 symbol <- as.character(e[[2L]])
                 value <- e[[3L]]
             } else if (f == "delayedAssign") {

--- a/R/document.R
+++ b/R/document.R
@@ -181,10 +181,24 @@ parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcr
     if (length(expr) == 0L || is.symbol(expr)) {
           return(env)
     }
+    # We should handle base function specially as users may use base::fun form
+    # The reason that we only take care of `base` (not `utils`) is that only `base` calls can generate symbols
+    # Check if the lang is in base::fun form
+    is_base_call <- function(x) {
+        length(x) == 3L && as.character(x[[1L]]) %in% c("::", ":::") && as.character(x[[2L]]) == "base"
+    }
+    # Be able to handle `pkg::name` case (note `::` is a function)
+    is_symbol <- function(x) {
+        is.symbol(x) || is_base_call(x)
+    }
+    # Handle `base` function specically by removing the `base::` prefix
+    fun_string <- function(x) {
+        if (is_base_call(x)) as.character(x[[3L]]) else as.character(x)
+    }
     for (i in seq_along(expr)) {
         e <- expr[[i]]
-        if (missing(e) || !is.call(e) || !is.symbol(e[[1L]])) next
-        f <- as.character(e[[1L]])
+        if (missing(e) || !is.call(e) || !is_symbol(e[[1L]])) next
+        f <- fun_string(e[[1L]])
         cur_srcref <- if (level == 0L) srcref[[i]] else srcref
         if (f %in% c("{", "(")) {
             Recall(content, e[-1L], env, level + 1L, cur_srcref)
@@ -204,9 +218,23 @@ parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcr
             Recall(content, e[[3L]], env, level + 1L, cur_srcref)
         } else if (f == "repeat") {
             Recall(content, e[[2L]], env, level + 1L, cur_srcref)
-        } else if (f %in% c("<-", "=") && length(e) == 3L && is.symbol(e[[2L]])) {
-            symbol <- as.character(e[[2L]])
-            value <- e[[3L]]
+        } else if (
+            (f %in% c("<-", "=") && length(e) == 3L && is.symbol(e[[2L]])) |
+            f %in% c("delayedAssign", "makeActiveBinding")
+        ) {
+            if (f %in% c("<-", "=")) {
+                symbol <- as.character(e[[2L]])
+                value <- e[[3L]]
+            } else if (f == "delayedAssign") {
+                call <- match.call(base::delayedAssign, as.call(e))
+                symbol <- call$x
+                value <- call$value
+            } else if (f == "makeActiveBinding") {
+                call <- match.call(base::makeActiveBinding, as.call(e))
+                symbol <- call$sym
+                value <- call$fun
+            }
+
             type <- get_expr_type(value)
 
             env$objects <- c(env$objects, symbol)

--- a/R/document.R
+++ b/R/document.R
@@ -219,7 +219,7 @@ parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcr
         } else if (f == "repeat") {
             Recall(content, e[[2L]], env, level + 1L, cur_srcref)
         } else if (
-            (f %in% c("<-", "=") && length(e) == 3L && is.symbol(e[[2L]])) |
+            (f %in% c("<-", "=") && length(e) == 3L && is.symbol(e[[2L]])) ||
             f %in% c("delayedAssign", "makeActiveBinding")
         ) {
             if (f %in% c("<-", "=")) {

--- a/R/document.R
+++ b/R/document.R
@@ -233,6 +233,9 @@ parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcr
                 top_level_envs <- c(default, as.list(extra))
                 any(vapply(top_level_envs, identical, x = arg_env, FUN.VALUE = logical(1L)))
             }
+
+            type <- NULL
+
             if (f %in% c("<-", "=")) {
                 if (length(e) != 3L || !is.symbol(e[[2L]])) next
                 symbol <- as.character(e[[2L]])
@@ -256,9 +259,12 @@ parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcr
                 if (!is_top_level(call$env)) next
                 symbol <- call$sym
                 value <- call$fun
+                type <- "variable"
             }
 
-            type <- get_expr_type(value)
+            if (is.null(type)) {
+                type <- get_expr_type(value)
+            }
 
             env$objects <- c(env$objects, symbol)
 

--- a/R/document.R
+++ b/R/document.R
@@ -227,10 +227,12 @@ parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcr
                 value <- e[[3L]]
             } else if (f == "delayedAssign") {
                 call <- match.call(base::delayedAssign, as.call(e))
+                if (!is.character(call$x)) next
                 symbol <- call$x
                 value <- call$value
             } else if (f == "makeActiveBinding") {
                 call <- match.call(base::makeActiveBinding, as.call(e))
+                if (!is.character(call$sym)) next
                 symbol <- call$sym
                 value <- call$fun
             }

--- a/R/document.R
+++ b/R/document.R
@@ -218,13 +218,18 @@ parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcr
             Recall(content, e[[3L]], env, level + 1L, cur_srcref)
         } else if (f == "repeat") {
             Recall(content, e[[2L]], env, level + 1L, cur_srcref)
-        } else if (f %in% c("<-", "=", "delayedAssign", "makeActiveBinding")) {
+        } else if (f %in% c("<-", "=", "delayedAssign", "makeActiveBinding", "assign")) {
             if (f %in% c("<-", "=")) {
                 if (length(e) != 3L || !is.symbol(e[[2L]])) next
                 symbol <- as.character(e[[2L]])
                 value <- e[[3L]]
             } else if (f == "delayedAssign") {
                 call <- match.call(base::delayedAssign, as.call(e))
+                if (!is.character(call$x)) next
+                symbol <- call$x
+                value <- call$value
+            } else if (f == "assign") {
+                call <- match.call(base::assign, as.call(e))
                 if (!is.character(call$x)) next
                 symbol <- call$x
                 value <- call$value

--- a/tests/testthat/test-symbol.R
+++ b/tests/testthat/test-symbol.R
@@ -24,13 +24,14 @@ test_that("Document Symbol works", {
         "   sym = 'a3'",
         ")",
         "delayedAssign(('d4'), 4)",
-        "makeActiveBinding(('a4'), function() 4, environment())"
+        "makeActiveBinding(('a4'), function() 4, environment())",
+        "assgin(value = '1', x = 'assign1')"
     ), defn_file)
 
     client %>% did_save(defn_file)
     result <- client %>% respond_document_symbol(defn_file)
 
-    expect_equal(result %>% map_chr(~ .$name) %>% sort(), c("f", "g", "p", "m", "d1", "d2", "d3", "a1", "a2", "a3") %>% sort())
+    expect_equal(result %>% map_chr(~ .$name) %>% sort(), c("f", "g", "p", "m", "d1", "d2", "d3", "a1", "a2", "a3", "assign1") %>% sort())
     expect_equivalent(
         result %>% detect(~ .$name == "f") %>% pluck("location", "range"),
         range(position(0, 0), position(2, 1))

--- a/tests/testthat/test-symbol.R
+++ b/tests/testthat/test-symbol.R
@@ -22,7 +22,9 @@ test_that("Document Symbol works", {
         "base::makeActiveBinding(",
         "   fun = function() stop('3'),",
         "   sym = 'a3'",
-        ")"
+        ")",
+        "delayedAssign(('d4'), 4)",
+        "makeActiveBinding(('a4'), function() 4, environment())"
     ), defn_file)
 
     client %>% did_save(defn_file)

--- a/tests/testthat/test-symbol.R
+++ b/tests/testthat/test-symbol.R
@@ -25,13 +25,24 @@ test_that("Document Symbol works", {
         ")",
         "delayedAssign(('d4'), 4)",
         "makeActiveBinding(('a4'), function() 4, environment())",
-        "assign(value = '1', x = 'assign1')"
+        "assign(value = '1', x = 'assign1')",
+        "delayedAssign('d6', 6, assign.env = globalenv())",
+        "delayedAssign('d7', 7, assign.env = emptyenv())",
+        "delayedAssign('d8', 8, assign.env = parent.frame(1))",
+        "makeActiveBinding('a5', function() 5, .GlobalEnv)",
+        "makeActiveBinding('a6', function() 6, new.env())",
+        "assign('assign2', 2, pos = -1L)",
+        "assign('assign3', 3, pos = environment())",
+        "assign('assign4', 4, pos = new.env())"
     ), defn_file)
 
     client %>% did_save(defn_file)
     result <- client %>% respond_document_symbol(defn_file)
 
-    expect_equal(result %>% map_chr(~ .$name) %>% sort(), c("f", "g", "p", "m", "d1", "d2", "d3", "a1", "a2", "a3", "assign1") %>% sort())
+    expect_equal(
+        result %>% map_chr(~ .$name) %>% sort(),
+        c("f", "g", "p", "m", "d1", "d2", "d3", "a1", "a2", "a3", "assign1", "d6", "d8", "a5", "assign2", "assign3") %>% sort()
+    )
     expect_equivalent(
         result %>% detect(~ .$name == "f") %>% pluck("location", "range"),
         range(position(0, 0), position(2, 1))

--- a/tests/testthat/test-symbol.R
+++ b/tests/testthat/test-symbol.R
@@ -25,7 +25,7 @@ test_that("Document Symbol works", {
         ")",
         "delayedAssign(('d4'), 4)",
         "makeActiveBinding(('a4'), function() 4, environment())",
-        "assgin(value = '1', x = 'assign1')"
+        "assign(value = '1', x = 'assign1')"
     ), defn_file)
 
     client %>% did_save(defn_file)

--- a/tests/testthat/test-symbol.R
+++ b/tests/testthat/test-symbol.R
@@ -13,13 +13,22 @@ test_that("Document Symbol works", {
         "p <- 1",
         "m <- list(",
         "  x = p + 1",
+        ")",
+        "delayedAssign('d1', 1)",
+        "delayedAssign(value = function() 2, x = 'd2')",
+        "base::delayedAssign(value = '3', 'd3')",
+        "makeActiveBinding('a1', function() 1, environment())",
+        "makeActiveBinding(function() '2', sym = 'a2')",
+        "base::makeActiveBinding(",
+        "   fun = function() stop('3'),",
+        "   sym = 'a3'",
         ")"
     ), defn_file)
 
     client %>% did_save(defn_file)
     result <- client %>% respond_document_symbol(defn_file)
 
-    expect_equal(result %>% map_chr(~ .$name) %>% sort(), c("f", "g", "p", "m") %>% sort())
+    expect_equal(result %>% map_chr(~ .$name) %>% sort(), c("f", "g", "p", "m", "d1", "d2", "d3", "a1", "a2", "a3") %>% sort())
     expect_equivalent(
         result %>% detect(~ .$name == "f") %>% pluck("location", "range"),
         range(position(0, 0), position(2, 1))
@@ -35,6 +44,18 @@ test_that("Document Symbol works", {
     expect_equivalent(
         result %>% detect(~ .$name == "m") %>% pluck("location", "range"),
         range(position(5, 0), position(7, 1))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "m") %>% pluck("location", "range"),
+        range(position(5, 0), position(7, 1))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "d3") %>% pluck("location", "range"),
+        range(position(10, 0), position(10, 38))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "a3") %>% pluck("location", "range"),
+        range(position(13, 0), position(16, 1))
     )
 })
 


### PR DESCRIPTION
Closes #362 


## A simple test file

```r
x <- 1
y <- "a"
z <- function() {
  'hello'
}
delayedAssign("d1", 1)
delayedAssign(value = function() 2, x = "d2")
base::delayedAssign(value = "3", "d3")
var <- "d4"
delayedAssign(var, 4)
delayedAssign(("d5"), var)

makeActiveBinding("a1", function() 1, environment())
makeActiveBinding(function() "2", sym = "a2")
base::makeActiveBinding(fun = function() stop("3"), sym = "a3")
makeActiveBinding(("a4"), function() 1, environment())

assign(value = "1", "assign1")
```

## Outline can display the promise / active binding symbols now


<img width="972" alt="image" src="https://user-images.githubusercontent.com/8368933/104089817-dd903480-52ac-11eb-9571-f56c483e7aca.png">
