### PR TITLE
Add hover to function symbol formals

### DIFF
--- a/R/hover.R
+++ b/R/hover.R
@@ -166,7 +166,21 @@ hover_reply <- function(id, uri, workspace, document, point) {
                 }
             } else if (token_name == "SYMBOL_FORMALS") {
                 # function formals
-                # contents <- "function parameter"
+                funct <- xml_find_first(token, "preceding-sibling::FUNCTION/parent::expr")
+                func_line1 <- as.integer(xml_attr(funct, "line1"))
+                doc_line1 <- detect_comments(document$content, func_line1 - 1) + 1
+
+                if (doc_line1 < func_line1) {
+                    comment <- document$content[doc_line1:(func_line1 - 1)]
+                    doc <- convert_comment_to_documentation(comment)
+                    if (is.list(doc)) {
+                        doc_string <- doc$arguments[[token_text]]
+                        if (!is.null(doc_string)) {
+                            contents <- sprintf("`%s` - %s", token_text, doc_string)
+                        }
+                    }
+                }
+
                 resolved <- TRUE
             } else if (token_name == "SYMBOL_PACKAGE") {
                 # package

--- a/tests/testthat/test-hover.R
+++ b/tests/testthat/test-hover.R
@@ -288,6 +288,13 @@ test_that("Hover works with local function", {
 
     client %>% did_save(temp_file)
 
+    result <- client %>% respond_hover(temp_file, c(3, 20))
+    expect_equal(result$range$start, list(line = 3, character = 19))
+    expect_equal(result$range$end, list(line = 3, character = 23))
+    expect_equal(result$contents, list(
+        "`var1` - a number"
+    ))
+
     result <- client %>% respond_hover(temp_file, c(6, 4))
     expect_equal(result$range$start, list(line = 6, character = 2))
     expect_equal(result$range$end, list(line = 6, character = 6))

--- a/tests/testthat/test-hover.R
+++ b/tests/testthat/test-hover.R
@@ -291,9 +291,7 @@ test_that("Hover works with local function", {
     result <- client %>% respond_hover(temp_file, c(3, 20))
     expect_equal(result$range$start, list(line = 3, character = 19))
     expect_equal(result$range$end, list(line = 3, character = 23))
-    expect_equal(result$contents, list(
-        "`var1` - a number"
-    ))
+    expect_equal(result$contents, "`var1` - a number")
 
     result <- client %>% respond_hover(temp_file, c(6, 4))
     expect_equal(result$range$start, list(line = 6, character = 2))


### PR DESCRIPTION
This PR adds hover to function symbol formals so that it is easier to see the documentation of the function argument on hover, especially when the function has many arguments.

```r
#' @param var1 test
#' @param var2 test2
#' @param var3 sum of test and test2
test <- function(var1 = 0, var2 = 1,
                 var3 = var1 + var2
) {
  var1
  var2
}
```

<img width="454" alt="image" src="https://user-images.githubusercontent.com/4662568/105185642-b9193f80-5b6b-11eb-9f49-f0912a8205c7.png">

```r
#' @param index number
res <- lapply(1:10, function(index) {
  index + 1
})
```

<img width="485" alt="image" src="https://user-images.githubusercontent.com/4662568/105185824-f8e02700-5b6b-11eb-8c65-d7f5ada53f55.png">
