### PR TITLE
Add '(' to completion trigger characters

### DIFF
--- a/R/capabilities.R
+++ b/R/capabilities.R
@@ -18,7 +18,7 @@ TextDocumentSyncOptions <- list(
 
 CompletionOptions <- list(
     resolveProvider = TRUE,
-    triggerCharacters = list(".", ":")
+    triggerCharacters = list(".", ":", "(")
 )
 
 SignatureHelpOptions <- list(


### PR DESCRIPTION
I think it makes sense to add `(` as a completion trigger character when user types a function call it will show the arguments in completion and signature help at the same time.