### PR TITLE
Use empty string instead of NULL as default signature doc

### DIFF
--- a/R/signature.R
+++ b/R/signature.R
@@ -45,7 +45,7 @@ signature_reply <- function(id, uri, workspace, document, point) {
                 )
                 func_expr <- parse(text = func_text, keep.source = FALSE)
                 sig <- get_signature(result$token, func_expr[[1]])
-                documentation <- NULL
+                documentation <- ""
 
                 doc_line1 <- detect_comments(document$content, func_line1 - 1) + 1
                 if (doc_line1 < func_line1) {


### PR DESCRIPTION
With latest vscode-languageclient 7.0.0 used in vscode-r-lsp 0.1.14, the following code does not trigger SignatureHelp:

```r
fun <- function(x, y) {
  x + y
}

fun(
```

It looks like`documentation === null` is no longer accepted by  vscode-languageclient 7.0.0. The [LSP](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp) says the following

```typescript
documentation?: string | MarkupContent;
```

looks like `documentation` could not be `null`.

This PR is a simple fix and it works with latest vscode-r-lsp now.