### PR TITLE
Improve token completion

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -404,39 +404,26 @@ scope_completion <- function(uri, workspace, token, point, snippet_support = NUL
     completions
 }
 
-token_completion <- function(uri, workspace, token, point, exclude = NULL) {
+token_completion <- function(uri, workspace, token, exclude = NULL) {
     xdoc <- workspace$get_parse_data(uri)$xml_doc
     if (is.null(xdoc)) {
         return(list())
     }
 
-    expr_symbols <- character()
-    doc_symbols <- character()
-
-    enclosing_scopes <- xdoc_find_enclosing_scopes(xdoc,
-        point$row + 1, point$col + 1)
-    exprs <- xml_find_all(enclosing_scopes,
-        "self::expr[preceding-sibling::OP-LEFT-BRACE or parent::exprlist]")
-    if (length(exprs)) {
-        expr <- exprs[[length(exprs)]]
-        expr_symbols <- unique(xml_text(xml_find_all(expr,
-            "descendant::*[self::SYMBOL or self::SYMBOL_SUB or self::SYMBOL_FORMALS or self::SYMBOL_FUNCTION_CALL]")))
-        expr_symbols <- expr_symbols[startsWith(expr_symbols, token)]
-    }
-
-    if (nzchar(token)) {
-        doc_symbols <- unique(xml_text(xml_find_all(xdoc,
-            "//SYMBOL | //SYMBOL_SUB | //SYMBOL_FORMALS | //SYMBOL_FUNCTION_CALL")))
-        doc_symbols <- doc_symbols[startsWith(doc_symbols, token)]
-    }
-
-    symbols <- sanitize_names(c(expr_symbols, doc_symbols))
+    symbols <- unique(xml_text(xml_find_all(xdoc,
+        glue("//*[
+            (self::SYMBOL[preceding-sibling::OP-DOLLAR] or self::SYMBOL_SUB) and
+            starts-with(text(),'{token_quote}')]",
+            token_quote = xml_single_quote(token)
+        )
+    )))
     symbols <- setdiff(symbols, exclude)
     token_completions <- lapply(symbols, function(symbol) {
         list(
             label = symbol,
             kind = CompletionItemKind$Text,
-            sortText = paste0(sort_prefixes$token, symbol)
+            sortText = paste0(sort_prefixes$token, symbol),
+            detail = "[token]"
         )
     })
 }
@@ -492,7 +479,7 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
         existing_symbols <- vapply(completions, "[[", character(1), "label")
         completions <- c(
             completions,
-            token_completion(uri, workspace, token, point, existing_symbols)
+            token_completion(uri, workspace, token, existing_symbols)
         )
     }
 

--- a/R/completion.R
+++ b/R/completion.R
@@ -410,13 +410,25 @@ token_completion <- function(uri, workspace, token, exclude = NULL) {
         return(list())
     }
 
-    symbols <- unique(xml_text(xml_find_all(xdoc,
+    token_quote <- xml_single_quote(token)
+
+    symbols <- xml_text(xml_find_all(xdoc,
         glue("//*[
             (self::SYMBOL[preceding-sibling::OP-DOLLAR] or self::SYMBOL_SUB) and
             starts-with(text(),'{token_quote}')]",
-            token_quote = xml_single_quote(token)
+            token_quote = token_quote
         )
-    )))
+    ))
+
+    if (nzchar(token)) {
+        symbols <- c(symbols, xml_text(xml_find_all(xdoc,
+            glue("//*[(self::SYMBOL or self::SYMBOL_SUB or self::SYMBOL_FORMALS or self::SYMBOL_FUNCTION_CALL) and
+                starts-with(text(),'{token_quote}')]",
+                token_quote = token_quote
+            )
+        )))
+    }
+
     symbols <- setdiff(symbols, exclude)
     token_completions <- lapply(symbols, function(symbol) {
         list(

--- a/R/completion.R
+++ b/R/completion.R
@@ -422,8 +422,7 @@ token_completion <- function(uri, workspace, token, exclude = NULL) {
         list(
             label = symbol,
             kind = CompletionItemKind$Text,
-            sortText = paste0(sort_prefixes$token, symbol),
-            detail = "[token]"
+            sortText = paste0(sort_prefixes$token, symbol)
         )
     })
 }


### PR DESCRIPTION
This PR improves the token completion with the following changes:

1. Since #369 allows `(` to trigger completion to in accompany with https://github.com/Ikuyadeu/vscode-R/pull/530, the current token_completion may produce too many symbols once `(` triggers completion. This PR makes token_completion only show symbols after `$` and `SYMBOL_SUB` symbols like `foo` in `mutate(foo = bar)` when trigger `token` is empty (e.g. `foo$` and `fun(`), which are the most frequent ways to introduce new data variables.
2. If `token` is not empty, then all symbols from the document that start with `token` are searched, which is the original method.

This makes it possible to work with the following examples:

```r
library(data.table)
library(dplyr)
library(tibble)

tbl1 <- tibble(
  Name = c("Product1", "Product2", "Product3"),
  Quality = c("Good", "Good", "Best"),
  Score = c(8, 9, 10),
  Type = c("B", "B", "A")
)

tbl1 %>%
  mutate(Score_mean = mean(Score)) %>%
  select(|

x <- iris
x %>%
  mutate(score1 = Petal.Length + Petal.Width, score2 = Petal.Length * Petal.Width) %>%
  filter(|


df <- list(
  test1 = 1,
  test2 = 2
)
df$test3 <- 3
df$te|


dt <- data.table(var1 = 1:10, var2 = rnorm(10))
dt[, var3 := var1 + var2]
dt[, var4 := var|]
```

where `|` is the cursor and the completion should work as expected to complete the tokens from the document.