### PR TITLE
Remove '(' from completion trigger chars

### DIFF
--- a/R/capabilities.R
+++ b/R/capabilities.R
@@ -18,7 +18,7 @@ TextDocumentSyncOptions <- list(
 
 CompletionOptions <- list(
     resolveProvider = TRUE,
-    triggerCharacters = list(".", ":", "(")
+    triggerCharacters = list(".", ":")
 )
 
 SignatureHelpOptions <- list(


### PR DESCRIPTION
Having experienced the #369, using `(` as a completion trigger character is in most cases too eager: once the completion is triggered, the new typed character won't trigger the computation of completions in a while. In practice, this will usually disable many other completion items or leave no change for them to show up.

Therefore, I'd like to revert that change by removing `(` from completion trigger characters.