### PR TITLE
Load documents referenced in source() calls

### DIFF
--- a/R/document.R
+++ b/R/document.R
@@ -293,6 +293,11 @@ parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcr
             if (!(pkg %in% env$packages)) {
                 env$packages <- c(env$packages, pkg)
             }
+        } else if (f %in% "source") {
+            call <- match.call(base::source, as.call(e))
+            if (!is.character(call$file)) next
+            if (!is.null(call$local) && !identical(call$local, FALSE)) next
+            env$sources <- c(env$sources, call$file)
         }
     }
     env
@@ -316,6 +321,7 @@ parse_document <- function(uri, content) {
         parse_env <- function() {
             env <- new.env(parent = .GlobalEnv)
             env$packages <- character()
+            env$sources <- character()
             env$nonfuncts <- character()
             env$functs <- character()
             env$formals <- list()

--- a/R/document.R
+++ b/R/document.R
@@ -376,6 +376,18 @@ parse_callback <- function(self, uri, version, parse_data) {
             }
         }
     }
+
+    for (source_file in parse_data$sources) {
+        source_path <- fs::path_abs(source_file, self$rootPath)
+        if (!file.exists(source_path)) next
+        source_uri <- path_to_uri(source_path)
+        if (self$workspace$documents$has(source_uri)) next
+        source_doc <- Document$new(source_uri, NULL, stringi::stri_read_lines(source_path))
+        self$workspace$documents$set(source_uri, source_doc)
+        self$text_sync(source_uri, document = source_doc, parse = TRUE)
+    }
+
+    NULL
 }
 
 parse_task <- function(self, uri, document, delay = 0) {


### PR DESCRIPTION
Closes #20 

This PR detects top-level `source()` calls and load documents referenced in such calls.

For example,

`sources.R`:

```r
source("source1.R")
```

`source1.R`:

```r
source("source2.R")

f <- function(x) {
  x + 1
}
```

`source2.R`:

```r
g <- function(x) {
  x + 1
}
```

Opening `sources.R` will also load `source1.R` and `source2.R`.