### PR TITLE
Improve hover for function docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     parallel,
     R6 (>= 2.4.1),
     repr (>= 1.1.0),
+    rmarkdown,
     roxygen2 (>= 7.0.0),
     stringi (>= 1.1.7),
     styler (>= 1.2.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,6 @@ Imports:
     parallel,
     R6 (>= 2.4.1),
     repr (>= 1.1.0),
-    rmarkdown,
     roxygen2 (>= 7.0.0),
     stringi (>= 1.1.7),
     styler (>= 1.2.0),
@@ -45,7 +44,8 @@ Suggests:
     processx (>= 3.4.1),
     purrr (>= 0.3.3),
     testthat (>= 2.1.0),
-    withr (>= 2.3.0)
+    withr (>= 2.3.0),
+    rmarkdown (>= 2.0)
 ByteCompile: yes
 Encoding: UTF-8
 LazyData: true

--- a/R/utils.R
+++ b/R/utils.R
@@ -664,3 +664,13 @@ xml_single_quote <- function(x) {
     x <- gsub("'", "&apos;", x, fixed = TRUE)
     x
 }
+
+html_to_markdown <- function(html){
+    temp_file <- paste(tempdir(), 'tempHelpFile.html', sep = '\\')
+    temp_file_md <- paste(tempdir(), 'tempHelpFile.md', sep = '\\')
+    cat(html, file = temp_file)
+    rmarkdown::pandoc_convert(temp_file, to = 'gfm', output = temp_file_md)
+    md <- paste(readLines(temp_file_md), collapse = '\n')
+    return(md)
+}
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -671,7 +671,7 @@ html_to_markdown <- function(html) {
     stringi::stri_write_lines(html, html_file)
     result <- tryCatch({
         rmarkdown::pandoc_convert(html_file, to = "gfm", output = md_file)
-        paste0(stringi::stri_read_lines(md_file, encoding = 'utf-8'), collapse = "\n")
+        paste0(stringi::stri_read_lines(md_file, encoding = "utf-8"), collapse = "\n")
     }, error = function(e) {
         logger$info("html_to_markdown failed: ", conditionMessage(e))
         NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -669,9 +669,15 @@ html_to_markdown <- function(html) {
     if (!rmarkdown::pandoc_available()) {
         return(NULL)
     }
-    html_file <- tempfile(fileext = ".html")
-    md_file <- tempfile(fileext = ".md")
+    html_file <- file.path(tempdir(), "temp.html")
+    md_file <- file.path(tempdir(), "temp.md")
     stringi::stri_write_lines(html, html_file)
-    rmarkdown::pandoc_convert(html_file, to = "gfm", output = md_file)
-    paste0(stringi::stri_read_lines(md_file), collapse = "\n")
+    result <- tryCatch({
+        rmarkdown::pandoc_convert(html_file, to = "gfm", output = md_file)
+        paste0(stringi::stri_read_lines(md_file), collapse = "\n")
+    }, error = function(e) {
+        logger$info("html_to_markdown failed: ", conditionMessage(e))
+        NULL
+    })
+    result
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -666,9 +666,6 @@ xml_single_quote <- function(x) {
 }
 
 html_to_markdown <- function(html) {
-    if (!rmarkdown::pandoc_available()) {
-        return(NULL)
-    }
     html_file <- file.path(tempdir(), "temp.html")
     md_file <- file.path(tempdir(), "temp.md")
     stringi::stri_write_lines(html, html_file)

--- a/R/utils.R
+++ b/R/utils.R
@@ -665,12 +665,13 @@ xml_single_quote <- function(x) {
     x
 }
 
-html_to_markdown <- function(html){
-    temp_file <- paste(tempdir(), 'tempHelpFile.html', sep = '\\')
-    temp_file_md <- paste(tempdir(), 'tempHelpFile.md', sep = '\\')
-    cat(html, file = temp_file)
-    rmarkdown::pandoc_convert(temp_file, to = 'gfm', output = temp_file_md)
-    md <- paste(readLines(temp_file_md), collapse = '\n')
-    return(md)
+html_to_markdown <- function(html) {
+    if (!rmarkdown::pandoc_available()) {
+        return(NULL)
+    }
+    html_file <- tempfile(fileext = ".html")
+    md_file <- tempfile(fileext = ".md")
+    stringi::stri_write_lines(html, html_file)
+    rmarkdown::pandoc_convert(html_file, to = "gfm", output = md_file)
+    paste0(stringi::stri_read_lines(md_file), collapse = "\n")
 }
-

--- a/R/utils.R
+++ b/R/utils.R
@@ -671,7 +671,7 @@ html_to_markdown <- function(html) {
     stringi::stri_write_lines(html, html_file)
     result <- tryCatch({
         rmarkdown::pandoc_convert(html_file, to = "gfm", output = md_file)
-        paste0(stringi::stri_read_lines(md_file), collapse = "\n")
+        paste0(stringi::stri_read_lines(md_file, encoding = 'utf-8'), collapse = "\n")
     }, error = function(e) {
         logger$info("html_to_markdown failed: ", conditionMessage(e))
         NULL

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -152,9 +152,18 @@ Workspace <- R6::R6Class("Workspace",
                 if (self$help_cache$has(key)) {
                     return(self$help_cache$get(key))
                 } else {
-                    html <- enc2utf8(repr::repr_html(hfile))
-                    md <- html_to_markdown(html)
-                    result <- if (is.null(md)) html else md
+                    result <- NULL
+
+                    if (requireNamespace("rmarkdown", quietly = TRUE) &&
+                        rmarkdown::pandoc_available()) {
+                        html <- enc2utf8(repr::repr_html(hfile))
+                        result <- html_to_markdown(html)
+                    }
+
+                    if (is.null(result)) {
+                        result <- enc2utf8(repr::repr_text(hfile))
+                    }
+
                     if (!is.null(result)) {
                         self$help_cache$set(key, result)
                     }

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -146,7 +146,9 @@ Workspace <- R6::R6Class("Workspace",
             )
 
             if (length(hfile) > 0) {
-                enc2utf8(repr::repr_text(hfile))
+                # enc2utf8(repr::repr_text(hfile))
+                html <- enc2utf8(repr::repr_html(hfile))
+                html_to_markdown(html)
             } else {
                 NULL
             }

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -21,6 +21,7 @@ Workspace <- R6::R6Class("Workspace",
 
         startup_packages = NULL,
         loaded_packages = NULL,
+        help_cache = NULL,
 
         initialize = function(root) {
             self$root <- root
@@ -41,6 +42,7 @@ Workspace <- R6::R6Class("Workspace",
             for (pkgname in self$loaded_packages) {
                 self$namespaces$set(pkgname, PackageNamespace$new(pkgname))
             }
+            self$help_cache <- collections::dict()
         },
 
         load_package = function(pkgname) {
@@ -146,12 +148,18 @@ Workspace <- R6::R6Class("Workspace",
             )
 
             if (length(hfile) > 0) {
-                # enc2utf8(repr::repr_text(hfile))
-                html <- enc2utf8(repr::repr_html(hfile))
-                md <- html_to_markdown(html)
-                if (is.null(md)) html else md
-            } else {
-                NULL
+                key <- as.character(hfile)
+                if (self$help_cache$has(key)) {
+                    return(self$help_cache$get(key))
+                } else {
+                    html <- enc2utf8(repr::repr_html(hfile))
+                    md <- html_to_markdown(html)
+                    result <- if (is.null(md)) html else md
+                    if (!is.null(result)) {
+                        self$help_cache$set(key, result)
+                    }
+                    return(result)
+                }
             }
         },
 

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -148,7 +148,8 @@ Workspace <- R6::R6Class("Workspace",
             if (length(hfile) > 0) {
                 # enc2utf8(repr::repr_text(hfile))
                 html <- enc2utf8(repr::repr_html(hfile))
-                html_to_markdown(html)
+                md <- html_to_markdown(html)
+                if (is.null(md)) html else md
             } else {
                 NULL
             }


### PR DESCRIPTION
This PR tries to improve the quality of function documentation in hovers.

To test:
Hover e.g. over these expressions:
``` r
is.character()
is.na()
is.null()
```

~~Known issues:~~
~~Some special characters (e.g. the quotes in the documentation for `is.na`) get rendered incorrectly.~~
(Edit: fixed by specifying the encoding to be utf-8)
