### PR TITLE
Options completion

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -114,7 +114,7 @@ arg_completion <- function(uri, workspace, point, token, funct, package = NULL, 
         args <- names(workspace$get_formals(funct, package, exported_only = exported_only))
 
         if (package == "base" && funct == "options") {
-            args <- c(args, names(options()))
+            args <- c(args, names(.Options))
         }
 
         if (is.character(args)) {

--- a/R/completion.R
+++ b/R/completion.R
@@ -112,6 +112,11 @@ arg_completion <- function(uri, workspace, point, token, funct, package = NULL, 
 
     if (!is.null(package)) {
         args <- names(workspace$get_formals(funct, package, exported_only = exported_only))
+
+        if (package == "base" && funct == "options") {
+            args <- c(args, names(options()))
+        }
+
         if (is.character(args)) {
             token_args <- args[startsWith(args, token)]
             token_data <- list(

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -88,6 +88,33 @@ test_that("Completion of function arguments works", {
     expect_length(arg_items, 0)
 })
 
+test_that("Completion of options works", {
+    skip_on_cran()
+    client <- language_client()
+
+    temp_file <- withr::local_tempfile(fileext = ".R")
+    writeLines(
+        c(
+            "options(sci",
+            "options(scipen = 999, useFancy"
+        ),
+        temp_file)
+
+    client %>% did_save(temp_file)
+
+    result <- client %>% respond_completion(temp_file, c(0, 11))
+    arg_items <- result$items %>%
+        keep(~ identical(.$data$type, "parameter")) %>%
+        map_chr(~ .$label)
+    expect_identical(arg_items, "scipen")
+
+    result <- client %>% respond_completion(temp_file, c(1, 30))
+    arg_items <- result$items %>%
+        keep(~ identical(.$data$type, "parameter")) %>%
+        map_chr(~ .$label)
+    expect_identical(arg_items, "useFancyQuotes")
+})
+
 test_that("Completion of function arguments preserves the order of arguments", {
     skip_on_cran()
     client <- language_client()


### PR DESCRIPTION
This PR adds arg completion for `options()` calls so that it is easier to complete options.

Note that if user code calls e.g. `library(data.table)`, and the new options defined in `data.table` will also appear in the options arg completion since the package is also loaded by languageserver.