### PR TITLE
Make headers in help hover look prettier

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -668,6 +668,7 @@ xml_single_quote <- function(x) {
 html_to_markdown <- function(html) {
     html_file <- file.path(tempdir(), "temp.html")
     md_file <- file.path(tempdir(), "temp.md")
+    logger$info("Converting html to markdown using", html_file, md_file)
     stringi::stri_write_lines(html, html_file)
     result <- tryCatch({
         format <- if (rmarkdown::pandoc_version() >= "2.0") "gfm" else "markdown_github"

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -158,8 +158,8 @@ Workspace <- R6::R6Class("Workspace",
                         rmarkdown::pandoc_available()) {
                         html <- enc2utf8(repr::repr_html(hfile))
                         # Make header look prettier:
-                        pattern <- '<table.*?{(.*?)}.*?<\\/table>\\n*<h2>(.*?)<\\/h2>'
-                        replacement <- '<h2>\\2 {\\1}</h2>'
+                        pattern <- "<table.*?<td>(.*?)\\s*{(.*?)}<\\/td>.*?<\\/table>\\n*<h2>\\s*(.*?)\\s*<\\/h2>"
+                        replacement <- "<b>\\1</b> <i>{\\2}</i><br/>\\3<hr/>"
                         html <- gsub(pattern, replacement, html, perl=TRUE)
                         result <- html_to_markdown(html)
                     }

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -160,7 +160,7 @@ Workspace <- R6::R6Class("Workspace",
                         # Make header look prettier:
                         pattern <- "<table.*?<td>(.*?)\\s*{(.*?)}<\\/td>.*?<\\/table>\\n*<h2>\\s*(.*?)\\s*<\\/h2>"
                         replacement <- "<b>\\1</b> <i>{\\2}</i><br/>\\3<hr/>"
-                        html <- gsub(pattern, replacement, html, perl=TRUE)
+                        html <- gsub(pattern, replacement, html, perl = TRUE)
                         result <- html_to_markdown(html)
                     }
 

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -157,6 +157,10 @@ Workspace <- R6::R6Class("Workspace",
                     if (requireNamespace("rmarkdown", quietly = TRUE) &&
                         rmarkdown::pandoc_available()) {
                         html <- enc2utf8(repr::repr_html(hfile))
+                        # Make header look prettier:
+                        pattern <- '<table.*?{(.*?)}.*?<\\/table>\\n*<h2>(.*?)<\\/h2>'
+                        replacement <- '<h2>\\2 {\\1}</h2>'
+                        html <- gsub(pattern, replacement, html, perl=TRUE)
                         result <- html_to_markdown(html)
                     }
 


### PR DESCRIPTION
Modifies the header of help hovers to remove the first line.
Information about the package is moved to the first proper header instead.
