### PR TITLE
Limit link file size

### DIFF
--- a/R/capabilities.R
+++ b/R/capabilities.R
@@ -35,7 +35,7 @@ DocumentOnTypeFormattingOptions <- list(
 )
 
 DocumentLinkOptions <- list(
-    resolveProvider = FALSE
+    resolveProvider = TRUE
 )
 
 RenameOptions <- list(

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -173,7 +173,7 @@ text_document_document_link  <- function(self, id, params) {
 #' Handler to the `documentLink/resolve` [Request].
 #' @keywords internal
 document_link_resolve  <- function(self, id, params) {
-
+    self$deliver(document_link_resolve_reply(id, self$workspace, params))
 }
 
 #' `textDocument/documentColor` request handler

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -173,7 +173,20 @@ text_document_document_link  <- function(self, id, params) {
 #' Handler to the `documentLink/resolve` [Request].
 #' @keywords internal
 document_link_resolve  <- function(self, id, params) {
-    self$deliver(document_link_resolve_reply(id, self$workspace, params))
+    reply <- document_link_resolve_reply(id, self$workspace, params)
+    self$deliver(reply)
+
+    if (!is.null(reply$error)) {
+        self$deliver(
+            Notification$new(
+                method = "window/showMessage",
+                params = list(
+                    type = MessageType$Error,
+                    message = reply$error$message
+                )
+            )
+        )
+    }
 }
 
 #' `textDocument/documentColor` request handler

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -206,6 +206,7 @@ LanguageServer$set("public", "register_handlers", function() {
         `textDocument/documentSymbol` = text_document_document_symbol,
         `textDocument/documentHighlight` = text_document_document_highlight,
         `textDocument/documentLink` = text_document_document_link,
+        `documentLink/resolve` = document_link_resolve,
         `textDocument/documentColor` = text_document_document_color,
         `textDocument/colorPresentation` = text_document_color_presentation,
         `textDocument/foldingRange` = text_document_folding_range,

--- a/R/link.R
+++ b/R/link.R
@@ -55,7 +55,7 @@ document_link_resolve_reply <- function(id, workspace, params) {
     path <- params$data$path
     file_size <- file.size(path)
     if (is.finite(file_size) &&
-        file_size <= getOption("languageserver.link_max_file_size", 16 * 1024^2)) {
+        file_size <= getOption("languageserver.link_file_size_limit", 16 * 1024^2)) {
         params$target <- path_to_uri(path)
         params$data <- NULL
         Response$new(

--- a/R/utils.R
+++ b/R/utils.R
@@ -680,3 +680,12 @@ html_to_markdown <- function(html) {
     })
     result
 }
+
+format_file_size <- function(bytes) {
+    if (bytes == 0) {
+        return("0.00 B")
+    }
+    e <- floor(log(bytes) / log(1024))
+    u <- substr("KMGTP", e, e)
+    sprintf("%.2f %sB", bytes / 1024^e, u)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -682,10 +682,6 @@ html_to_markdown <- function(html) {
 }
 
 format_file_size <- function(bytes) {
-    if (bytes == 0) {
-        return("0.00 B")
-    }
-    e <- floor(log(bytes) / log(1024))
-    u <- substr("KMGTP", e, e)
-    sprintf("%.2f %sB", bytes / 1024^e, u)
+    obj_size <- structure(bytes, class = "object_size")
+    format(obj_size, units = "auto")
 }

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ These editors are supported by installing the corresponding package.
 - [x] [renameProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename)
 - [x] [prepareRenameProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_prepareRename)
 - [x] [documentLinkProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentLink)
+- [x] [documentLinkResolve](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#documentLink_resolve)
 - [x] [colorProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentColor)
 - [x] [colorPresentation](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_colorPresentation)
 - [x] [foldingRangeProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_foldingRange)

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -354,6 +354,15 @@ respond_document_link <- function(client, path, ...) {
     )
 }
 
+respond_document_link_resolve <- function(client, params, ...) {
+    respond(
+        client,
+        "documentLink/resolve",
+        params,
+        ...
+    )
+}
+
 respond_document_color <- function(client, path, ...) {
     respond(
         client,

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -9,6 +9,8 @@ test_that("Document link works", {
     src_file1 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
     src_file2 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
     temp_file <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
+    src_file1 <- format(fs::path(src_file1))
+    src_file2 <- format(fs::path(src_file2))
 
     writeLines(
         c(
@@ -79,6 +81,8 @@ test_that("Document link works with raw strings", {
     src_file1 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
     src_file2 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
     temp_file <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
+    src_file1 <- format(fs::path(src_file1))
+    src_file2 <- format(fs::path(src_file2))
 
     writeLines(
         c(
@@ -148,6 +152,8 @@ test_that("Document link works in Rmarkdown", {
     src_file1 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
     src_file2 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
     temp_file <- withr::local_tempfile(tmpdir = dir, fileext = ".Rmd")
+    src_file1 <- format(fs::path(src_file1))
+    src_file2 <- format(fs::path(src_file2))
 
     writeLines(
         c(

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -9,8 +9,6 @@ test_that("Document link works", {
     src_file1 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
     src_file2 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
     temp_file <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
-    src_file1 <- fs::path(src_file1)
-    src_file2 <- fs::path(src_file2)
 
     writeLines(
         c(
@@ -44,19 +42,31 @@ test_that("Document link works", {
     expect_length(result, 4)
     expect_equal(result[[1]]$range$start, list(line = 0, character = 8))
     expect_equal(result[[1]]$range$end, list(line = 0, character = 8 + nchar(src_file1)))
-    expect_equal(result[[1]]$target, path_to_uri(src_file1))
+    expect_equal(result[[1]]$data$path, src_file1)
 
     expect_equal(result[[2]]$range$start, list(line = 1, character = 8))
     expect_equal(result[[2]]$range$end, list(line = 1, character = 8 + nchar(basename(src_file1))))
-    expect_equal(result[[2]]$target, path_to_uri(src_file1))
+    expect_equal(result[[2]]$data$path, src_file1)
 
     expect_equal(result[[3]]$range$start, list(line = 2, character = 8))
     expect_equal(result[[3]]$range$end, list(line = 2, character = 8 + nchar(src_file2)))
-    expect_equal(result[[3]]$target, path_to_uri(src_file2))
+    expect_equal(result[[3]]$data$path, src_file2)
 
     expect_equal(result[[4]]$range$start, list(line = 3, character = 8))
     expect_equal(result[[4]]$range$end, list(line = 3, character = 8 + nchar(basename(src_file2))))
-    expect_equal(result[[4]]$target, path_to_uri(src_file2))
+    expect_equal(result[[4]]$data$path, src_file2)
+
+    resolve <- client %>% respond_document_link_resolve(result[[1]])
+    expect_equal(resolve$target, path_to_uri(src_file1))
+
+    resolve <- client %>% respond_document_link_resolve(result[[2]])
+    expect_equal(resolve$target, path_to_uri(src_file1))
+
+    resolve <- client %>% respond_document_link_resolve(result[[3]])
+    expect_equal(resolve$target, path_to_uri(src_file2))
+
+    resolve <- client %>% respond_document_link_resolve(result[[4]])
+    expect_equal(resolve$target, path_to_uri(src_file2))
 })
 
 test_that("Document link works with raw strings", {
@@ -69,8 +79,6 @@ test_that("Document link works with raw strings", {
     src_file1 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
     src_file2 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
     temp_file <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
-    src_file1 <- fs::path(src_file1)
-    src_file2 <- fs::path(src_file2)
 
     writeLines(
         c(
@@ -104,19 +112,31 @@ test_that("Document link works with raw strings", {
     expect_length(result, 4)
     expect_equal(result[[1]]$range$start, list(line = 0, character = 9))
     expect_equal(result[[1]]$range$end, list(line = 0, character = 9 + nchar(src_file1) + 2))
-    expect_equal(result[[1]]$target, path_to_uri(src_file1))
+    expect_equal(result[[1]]$data$path, src_file1)
 
     expect_equal(result[[2]]$range$start, list(line = 1, character = 9))
     expect_equal(result[[2]]$range$end, list(line = 1, character = 9 + nchar(basename(src_file1)) + 2))
-    expect_equal(result[[2]]$target, path_to_uri(src_file1))
+    expect_equal(result[[2]]$data$path, src_file1)
 
     expect_equal(result[[3]]$range$start, list(line = 2, character = 9))
     expect_equal(result[[3]]$range$end, list(line = 2, character = 9 + nchar(src_file2) + 4))
-    expect_equal(result[[3]]$target, path_to_uri(src_file2))
+    expect_equal(result[[3]]$data$path, src_file2)
 
     expect_equal(result[[4]]$range$start, list(line = 3, character = 9))
     expect_equal(result[[4]]$range$end, list(line = 3, character = 9 + nchar(basename(src_file2)) + 6))
-    expect_equal(result[[4]]$target, path_to_uri(src_file2))
+    expect_equal(result[[4]]$data$path, src_file2)
+
+    resolve <- client %>% respond_document_link_resolve(result[[1]])
+    expect_equal(resolve$target, path_to_uri(src_file1))
+
+    resolve <- client %>% respond_document_link_resolve(result[[2]])
+    expect_equal(resolve$target, path_to_uri(src_file1))
+
+    resolve <- client %>% respond_document_link_resolve(result[[3]])
+    expect_equal(resolve$target, path_to_uri(src_file2))
+
+    resolve <- client %>% respond_document_link_resolve(result[[4]])
+    expect_equal(resolve$target, path_to_uri(src_file2))
 })
 
 test_that("Document link works in Rmarkdown", {
@@ -128,8 +148,6 @@ test_that("Document link works in Rmarkdown", {
     src_file1 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
     src_file2 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
     temp_file <- withr::local_tempfile(tmpdir = dir, fileext = ".Rmd")
-    src_file1 <- fs::path(src_file1)
-    src_file2 <- fs::path(src_file2)
 
     writeLines(
         c(
@@ -169,17 +187,29 @@ test_that("Document link works in Rmarkdown", {
     expect_length(result, 4)
     expect_equal(result[[1]]$range$start, list(line = 5, character = 8))
     expect_equal(result[[1]]$range$end, list(line = 5, character = 8 + nchar(src_file1)))
-    expect_equal(result[[1]]$target, path_to_uri(src_file1))
+    expect_equal(result[[1]]$data$path, src_file1)
 
     expect_equal(result[[2]]$range$start, list(line = 6, character = 8))
     expect_equal(result[[2]]$range$end, list(line = 6, character = 8 + nchar(basename(src_file1))))
-    expect_equal(result[[2]]$target, path_to_uri(src_file1))
+    expect_equal(result[[2]]$data$path, src_file1)
 
     expect_equal(result[[3]]$range$start, list(line = 7, character = 8))
     expect_equal(result[[3]]$range$end, list(line = 7, character = 8 + nchar(src_file2)))
-    expect_equal(result[[3]]$target, path_to_uri(src_file2))
+    expect_equal(result[[3]]$data$path, src_file2)
 
     expect_equal(result[[4]]$range$start, list(line = 8, character = 8))
     expect_equal(result[[4]]$range$end, list(line = 8, character = 8 + nchar(basename(src_file2))))
-    expect_equal(result[[4]]$target, path_to_uri(src_file2))
+    expect_equal(result[[4]]$data$path, src_file2)
+
+    resolve <- client %>% respond_document_link_resolve(result[[1]])
+    expect_equal(resolve$target, path_to_uri(src_file1))
+
+    resolve <- client %>% respond_document_link_resolve(result[[2]])
+    expect_equal(resolve$target, path_to_uri(src_file1))
+
+    resolve <- client %>% respond_document_link_resolve(result[[3]])
+    expect_equal(resolve$target, path_to_uri(src_file2))
+
+    resolve <- client %>% respond_document_link_resolve(result[[4]])
+    expect_equal(resolve$target, path_to_uri(src_file2))
 })


### PR DESCRIPTION
Closes #391 

The main reason not to use file extension is that there are too many text file extensions so that it might not be a good idea. To keep user from following a link to a large file that might freeze the editor, we only need to avoid providing links to large files.

This PR checks file size at `documentLink/resolve` so that large files won't be provided links. By default, the file size limit is 16MB. User could customize it via `options(languageserver.link_file_size_limit = bytes)`.

The reason to check file size at resolve stage is that we could let the user know that the file exists via editor text decoration (e.g. text underlined in vscode).