### PR TITLE
Use styler base_indention

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,8 @@ Suggests:
     testthat (>= 2.1.0),
     withr (>= 2.3.0),
     rmarkdown (>= 2.0)
+Remotes:
+    r-lib/styler#764
 ByteCompile: yes
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     repr (>= 1.1.0),
     roxygen2 (>= 7.0.0),
     stringi (>= 1.1.7),
-    styler (>= 1.4.0.9000),
+    styler (>= 1.4.1),
     tools,
     utils,
     xml2 (>= 1.2.2),
@@ -46,8 +46,6 @@ Suggests:
     testthat (>= 2.1.0),
     withr (>= 2.3.0),
     rmarkdown (>= 2.0)
-Remotes:
-    r-lib/styler#764
 ByteCompile: yes
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     repr (>= 1.1.0),
     roxygen2 (>= 7.0.0),
     stringi (>= 1.1.7),
-    styler (>= 1.2.0),
+    styler (>= 1.4.0.9000),
     tools,
     utils,
     xml2 (>= 1.2.2),

--- a/man/style_text.Rd
+++ b/man/style_text.Rd
@@ -4,7 +4,7 @@
 \alias{style_text}
 \title{Edit code style}
 \usage{
-style_text(text, style, indentation = 0L)
+style_text(text, style, indention = 0L)
 }
 \description{
 This functions formats a list of text using \code{\link[styler:style_text]{styler::style_text()}} with the


### PR DESCRIPTION
Closes #400.

This PR uses the latest styler `base_indention` and removes the old hacking way to add indention.

I think we could wait until https://github.com/r-lib/styler/pull/764 is merged upstream so that this PR could be merged too.

We'll update the minimum version of styler in `DESCRIPTION` if a new version (probably v1.4.1) is released to CRAN.