### PR TITLE
Remove symbols starting with `._` from namespace

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -501,11 +501,11 @@ throttle <- function(fun, t = 1) {
 
 #' sanitize package objects names
 #'
-#' Remove unwanted objects, _e.g._ `names<-`, `%>%`, etc.
+#' Remove unwanted objects, _e.g._ `names<-`, `%>%`, `.__C_` etc.
 #'
 #' @keywords internal
 sanitize_names <- function(objects) {
-    objects[stringi::stri_detect_regex(objects, "^(?:[^\\W_]|\\.)(?:[^\\W]|\\.)*$")]
+    objects[stringi::stri_detect_regex(objects, "^([^\\W_]|\\.(?!_))(\\w|\\.)*$")]
 }
 
 na_to_empty_string <- function(x) if (is.na(x)) "" else x

--- a/man/sanitize_names.Rd
+++ b/man/sanitize_names.Rd
@@ -7,6 +7,6 @@
 sanitize_names(objects)
 }
 \description{
-Remove unwanted objects, \emph{e.g.} \verb{names<-}, \verb{\%>\%}, etc.
+Remove unwanted objects, \emph{e.g.} \verb{names<-}, \verb{\%>\%}, \code{.__C_} etc.
 }
 \keyword{internal}


### PR DESCRIPTION
This PR updates `sanitize_names` so that symbols starting with `._` (like shown in the following) are removed from namespace and won't be present in the completions.

<img width="859" alt="image" src="https://user-images.githubusercontent.com/4662568/113086766-e42ba980-9214-11eb-83b0-13fb9f0baab8.png">
