### PR TITLE
Faster completion

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -520,8 +520,12 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
 
     if (length(completions) >= nmax) {
         isIncomplete <- TRUE
-        sort_text <- vapply(completions, "[[", character(1), "sortText")
-        completions <- completions[order(sort_text)][seq_len(nmax)]
+        label_text <- vapply(completions, "[[", character(1), "label")
+        completions <- completions[startsWith(label_text, token)]
+        if (length(completions) >= nmax) {
+            sort_text <- vapply(completions, "[[", character(1), "sortText")
+            completions <- completions[order(sort_text)][seq_len(nmax)]
+        }
     } else {
         isIncomplete <- FALSE
     }

--- a/R/completion.R
+++ b/R/completion.R
@@ -468,17 +468,6 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
 
     completions <- list()
 
-    if (token_result$accessor == "") {
-        call_result <- document$detect_call(point)
-        if (nzchar(call_result$token)) {
-            completions <- c(
-                completions,
-                arg_completion(uri, workspace, point, token,
-                    call_result$token, call_result$package,
-                    exported_only = call_result$accessor != ":::"))
-        }
-    }
-
     if (nzchar(full_token)) {
         if (is.null(package)) {
             completions <- c(completions,
@@ -492,6 +481,17 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
             completions,
             workspace_completion(
                 workspace, token, package, token_result$accessor == "::", snippet_support))
+    }
+
+    if (token_result$accessor == "") {
+        call_result <- document$detect_call(point)
+        if (nzchar(call_result$token)) {
+            completions <- c(
+                completions,
+                arg_completion(uri, workspace, point, token,
+                    call_result$token, call_result$package,
+                    exported_only = call_result$accessor != ":::"))
+        }
     }
 
     if (is.null(token_result$package)) {

--- a/R/completion.R
+++ b/R/completion.R
@@ -504,7 +504,7 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
     init_count <- length(completions)
     nmax <- getOption("languageserver.max_completions", 200)
 
-    if (length(completions) > nmax) {
+    if (init_count > nmax) {
         isIncomplete <- TRUE
         label_text <- vapply(completions, "[[", character(1), "label")
         sort_text <- vapply(completions, "[[", character(1), "sortText")

--- a/R/completion.R
+++ b/R/completion.R
@@ -505,7 +505,7 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
     init_count <- length(completions)
     nmax <- getOption("languageserver.max_completions", 200)
 
-    if (length(completions) >= nmax) {
+    if (length(completions) > nmax) {
         isIncomplete <- TRUE
         label_text <- vapply(completions, "[[", character(1), "label")
         sort_text <- vapply(completions, "[[", character(1), "sortText")

--- a/R/completion.R
+++ b/R/completion.R
@@ -470,13 +470,12 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
 
     if (nzchar(full_token)) {
         if (is.null(package)) {
-            completions <- c(completions,
+            completions <- c(
+                completions,
                 constant_completion(token),
                 package_completion(token),
-                scope_completion(uri, workspace, token, point, snippet_support)
-            )
+                scope_completion(uri, workspace, token, point, snippet_support))
         }
-
         completions <- c(
             completions,
             workspace_completion(

--- a/R/completion.R
+++ b/R/completion.R
@@ -455,6 +455,8 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
                 items = list()
             )))
     }
+
+    t0 <- Sys.time()
     snippet_support <- isTRUE(capabilities$completionItem$snippetSupport) &&
         getOption("languageserver.snippet_support", TRUE)
 
@@ -499,10 +501,24 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
         )
     }
 
+    t1 <- Sys.time()
+    logger$info("completions: ", list(
+        n = length(completions),
+        t = as.numeric(t1 - t0)
+    ))
+
+    if (length(completions) >= 200) {
+        isIncomplete <- TRUE
+        sort_text <- vapply(completions, "[[", character(1), "sortText")
+        completions <- utils::head(completions[order(sort_text)], 200)
+    } else {
+        isIncomplete <- FALSE
+    }
+
     Response$new(
         id,
         result = list(
-            isIncomplete = FALSE,
+            isIncomplete = isIncomplete,
             items = completions
         )
     )

--- a/R/utils.R
+++ b/R/utils.R
@@ -180,7 +180,8 @@ check_scope <- function(uri, document, point) {
     }
 }
 
-match_with <- function(x, pattern) {
+match_with <- function(x, token) {
+    pattern <- gsub(".", "\\.", token, fixed = TRUE)
     grepl(pattern, x, ignore.case = TRUE)
 }
 


### PR DESCRIPTION
Closes #412 

This PR improves the performance of completion by limiting the max number of completions to return to the client and utilizing the `isIncomplete` feature.

If the completion list contains more than `nmax` (by default, 200) items, then the list is sorted by whether it starts with `token` and the `sortText` of the item, and the top `nmax` items are returned with `isIncomplete = TRUE` so that subsequent keystrokes will still trigger completion requests until the completion list is narrowed down to no greater than `nmax`.

This largely avoids too much traffic from the response to the completion request triggered by the first keystroke, which could potentially match too many results.

Old behavior (on my machine working in languageserver project):

1. Type `a`
2. 1619 matches returned to client with `isIncomplete=FALSE`, and subsequent keystrokes do not trigger completion request.

In this case, a notable delay could be observed on first keystroke of a token.

New behavior:

1. Type `a`
2. 1619 matches reduced to 200 returned to client with `isIncomplete=TRUE`.
3. Type `s`
4. 288 matches reduced to 200 returned to client with `isIncomplete=TRUE`
5. Type `.`
6. 119 matches returned to client with `isIncomplete=FALSE`, and subsequent keystrokes do not trigger completion request.

In this case, the traffic between server and client is reduced and the delay on first keystroke is much reduced.