### PR TITLE
Definition provider works with file path

### DIFF
--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -55,7 +55,8 @@ text_document_definition  <- function(self, id, params) {
     uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
-    self$deliver(definition_reply(id, uri, self$workspace, document, point))
+    rootPath <- if (length(self$rootPath)) self$rootPath else dirname(path_from_uri(uri))
+    self$deliver(definition_reply(id, uri, self$workspace, document, point, rootPath))
 }
 
 #' `textDocument/typeDefinition` request handler

--- a/R/link.R
+++ b/R/link.R
@@ -1,5 +1,5 @@
 #' The response to a textDocument/documentLink Request
-#'
+#' @param rootPath Path of workspace folder
 #' @keywords internal
 document_link_reply <- function(id, uri, workspace, document, rootPath) {
     result <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -692,5 +692,15 @@ format_file_size <- function(bytes) {
 
 is_text_file <- function(path, n = 1000) {
     bin <- readBin(path, "raw", n = n)
-    stringi::stri_enc_isutf8(bin)
+    is_utf8 <- stringi::stri_enc_isutf8(bin)
+    if (is_utf8) {
+        return(TRUE)
+    } else {
+        result <- stringi::stri_enc_detect(bin)[[1]]
+        conf <- result$Confidence[1]
+        if (identical(conf, 1)) {
+            return(TRUE)
+        }
+    }
+    return(FALSE)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -692,6 +692,5 @@ format_file_size <- function(bytes) {
 
 is_text_file <- function(path, n = 1000) {
     bin <- readBin(path, "raw", n = n)
-    result <- tryCatch(rawToChar(bin), error = function(e) NULL)
-    !is.null(result)
+    stringi::stri_enc_isutf8(bin)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -689,3 +689,9 @@ format_file_size <- function(bytes) {
     obj_size <- structure(bytes, class = "object_size")
     format(obj_size, units = "auto")
 }
+
+is_text_file <- function(path, n = 1000) {
+    bin <- readBin(path, "raw", n = n)
+    result <- tryCatch(rawToChar(bin), error = function(e) NULL)
+    !is.null(result)
+}

--- a/man/definition_reply.Rd
+++ b/man/definition_reply.Rd
@@ -4,7 +4,7 @@
 \alias{definition_reply}
 \title{Get the location of a specified function definition}
 \usage{
-definition_reply(id, uri, workspace, document, point)
+definition_reply(id, uri, workspace, document, point, rootPath)
 }
 \description{
 If the function is not found in a file but is found in a loaded package,

--- a/man/document_link_reply.Rd
+++ b/man/document_link_reply.Rd
@@ -6,6 +6,9 @@
 \usage{
 document_link_reply(id, uri, workspace, document, rootPath)
 }
+\arguments{
+\item{rootPath}{Path of workspace folder}
+}
 \description{
 The response to a textDocument/documentLink Request
 }

--- a/tests/testthat/test-definition.R
+++ b/tests/testthat/test-definition.R
@@ -275,8 +275,8 @@ test_that("Go to Definition works for file paths", {
 
     writeLines(c("my_fn <- function(x) {", "  x + 1", "}"), defn_file)
     writeLines(c(
-        sprintf("source(\"%s\")", defn_file),
-        sprintf("source(\"%s\")", basename(defn_file))
+        sprintf("source('%s')", defn_file),
+        sprintf("source('%s')", basename(defn_file))
     ), query_file)
 
     client %>% did_save(defn_file)

--- a/tests/testthat/test-definition.R
+++ b/tests/testthat/test-definition.R
@@ -272,6 +272,7 @@ test_that("Go to Definition works for file paths", {
     query_file <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
 
     defn_file <- format(fs::path(defn_file))
+    query_file <- format(fs::path(query_file))
 
     writeLines(c("my_fn <- function(x) {", "  x + 1", "}"), defn_file)
     writeLines(c(

--- a/tests/testthat/test-definition.R
+++ b/tests/testthat/test-definition.R
@@ -261,3 +261,30 @@ test_that("Go to Definition in Rmarkdown works", {
 
     expect_equal(length(result), 0)
 })
+
+test_that("Go to Definition works for file paths", {
+    skip_on_cran()
+
+    dir <- tempdir()
+    client <- language_client(dir)
+
+    defn_file <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
+    query_file <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
+
+    defn_file <- format(fs::path(defn_file))
+
+    writeLines(c("my_fn <- function(x) {", "  x + 1", "}"), defn_file)
+    writeLines(c(
+        sprintf("source(\"%s\")", defn_file),
+        sprintf("source(\"%s\")", basename(defn_file))
+    ), query_file)
+
+    client %>% did_save(defn_file)
+    client %>% did_save(query_file)
+
+    result <- client %>% respond_definition(query_file, c(0, 9))
+    expect_equal(result$uri, path_to_uri(defn_file))
+
+    result <- client %>% respond_definition(query_file, c(1, 9))
+    expect_equal(result$uri, path_to_uri(defn_file))
+})


### PR DESCRIPTION
Closes #415 

This PR makes `STR_CONST` token which is either an absolute path or a path relative to workspace `rootPath`.

It also checks if the file is a text file by reading its first 1000 bits  into a raw vector using `readBin` and see if ~~`rawToChar` succeeds~~ it is a text file by detecting its text encoding with `{stringi}` functions.

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/4662568/114290042-25427a00-9aaf-11eb-871e-338ae61c76b8.png">
