### PR TITLE
Use a function call as the completer in on-type-formatting

### DIFF
--- a/R/formatting.R
+++ b/R/formatting.R
@@ -126,17 +126,17 @@ range_formatting_reply <- function(id, uri, document, range, options) {
 on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
     content <- document$content
     end_line <- point$row + 1
-    use_zero <- FALSE
+    use_completer <- FALSE
     if (ch == "\n") {
         start_line <- end_line - 1
         if (grepl("^\\s*(#.*)?$", content[[start_line]])) {
             return(Response$new(id))
         }
         if (grepl("^\\s*(#.*)?$", content[[end_line]])) {
-            # use "0" to complete the potentially incomplete expression
+            # use completer to complete the potentially incomplete expression
             last_line <- content[end_line]
-            content[end_line] <- "0"
-            use_zero <- TRUE
+            content[end_line] <- "f()"
+            use_completer <- TRUE
         }
     } else {
         start_line <- end_line
@@ -203,8 +203,9 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
             error = function(e) logger$info("on_type_formatting_reply:styler:", e)
         )
         if (!is.null(new_text)) {
-            if (use_zero) {
-                new_text <- substr(new_text, 1, nchar(new_text) - 1)
+            if (use_completer) {
+                # remove completer from formatted text
+                new_text <- substr(new_text, 1, nchar(new_text) - 3)
                 new_text <- paste0(new_text, trimws(last_line))
             }
             range <- range(


### PR DESCRIPTION
Closes #430 

This PR changes the completer from `0` to `f()` so that the pipe syntax could be supported.