### PR TITLE
check if lintr is new enough

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     desc (>= 1.2.0),
     fs (>= 1.3.1),
     jsonlite (>= 1.6),
-    lintr (>= 2.0.1.9000),
+    lintr (>= 2.0.1),
     parallel,
     R6 (>= 2.4.1),
     repr (>= 1.1.0),
@@ -46,8 +46,6 @@ Suggests:
     testthat (>= 2.1.0),
     withr (>= 2.3.0),
     rmarkdown (>= 2.0)
-Remotes:
-    jimhester/lintr
 ByteCompile: yes
 Encoding: UTF-8
 NeedsCompilation: yes

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -5,6 +5,17 @@
 #' @name diagnostics
 NULL
 
+
+#' Check if lintr is 2.0.1.9000 above. A number of features relies on it.
+#' @noRd
+lintr_is_new_enough <- function() {
+    return(
+        utils::packageVersion("lintr") >= "2.0.1.9000" &&
+            "text" %in% methods::formalArgs(lintr::lint)
+    )
+}
+
+
 DiagnosticSeverity <- list(
     Error = 1,
     Warning = 2,
@@ -84,15 +95,19 @@ diagnose_file <- function(uri, content) {
         content <- c(content, "")
     }
 
-    linters <- NULL
-
-    linter_file <- find_config(path)
-    if (is.null(linter_file)) {
-        linters <- getOption("languageserver.default_linters", NULL)
-    }
-
     lint_cache <- getOption("languageserver.lint_cache", TRUE)
-    lints <- lintr::lint(path, linters = linters, cache = lint_cache, text = content)
+    if (lintr_is_new_enough()) {
+        lints <- lintr::lint(path, cache = lint_cache, text = content)
+    } else {
+        # TODO: remove it once new version of lintr is released
+        linter_file <- find_config(path)
+        if (!is.null(linter_file)) {
+            op <- options(lintr.linter_file = linter_file)
+            on.exit(options(op))
+        }
+        text <- paste0(content, collapse = "\n")
+        lints <- lintr::lint(text, cache = lint_cache)
+    }
 
     diagnostics <- lapply(lints, diagnostic_from_lint, content = content)
     names(diagnostics) <- NULL

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -11,7 +11,7 @@ NULL
 lintr_is_new_enough <- function() {
     return(
         utils::packageVersion("lintr") >= "2.0.1.9000" &&
-            "text" %in% methods::formalArgs(lintr::lint)
+            "text" %in% names(formals(lintr::lint))
     )
 }
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ These editors are supported by installing the corresponding package.
 
 ### Linters
 
-With [lintr](https://github.com/jimhester/lintr) v2.0.0, the linters can be specified by creating the `.lintr` file at the project or home directory. Details can be found at lintr [documentation](https://github.com/jimhester/lintr#project-configuration). The option `languageserver.default_linters` is now deprecated in favor of the `.lintr` approach.
+With [lintr](https://github.com/jimhester/lintr) v2.0.0, the linters can be specified by creating the `.lintr` file at the project or home directory. Details can be found at lintr [documentation](https://github.com/jimhester/lintr#project-configuration).
 
 ### Customizing server capbabilities
 


### PR DESCRIPTION
> I just realized that there is no roadmap for the release of new version of lintr. Perhaps we should include your original trick of checking the text parameter for now? Otherwise we won't know how much time they need to make a new release.

related: #284 

I have decided to use `packageVersion` at the end.