### PR TITLE
[WIP] an option to disable rich documentation

### DIFF
--- a/R/workspace.R
+++ b/R/workspace.R
@@ -154,8 +154,9 @@ Workspace <- R6::R6Class("Workspace",
                 } else {
                     result <- NULL
 
-                    if (requireNamespace("rmarkdown", quietly = TRUE) &&
-                        rmarkdown::pandoc_available()) {
+                    if (isTRUE(getOption("languageserver.rich_documentation", TRUE)) &&
+                            requireNamespace("rmarkdown", quietly = TRUE) &&
+                            rmarkdown::pandoc_available()) {
                         html <- enc2utf8(repr::repr_html(hfile))
                         # Make header look prettier:
                         pattern <- "<table.*?<td>(.*?)\\s*{(.*?)}<\\/td>.*?<\\/table>\\n*<h2>\\s*(.*?)\\s*<\\/h2>"


### PR DESCRIPTION
it is needed for editor with less fancy markdown renderer.

Shall we actually turn it off as default and only provide the rich markdown if client to specify via
[MarkdownClientCapabilities](
https://microsoft.github.io/language-server-protocol/specifications//specification-3-17/#markdownClientCapabilities)? I imagine vscode-r-lsp could enable it by default.