### PR TITLE
Support unscoped functions and library functions

### DIFF
--- a/R/document.R
+++ b/R/document.R
@@ -223,43 +223,96 @@ is_top_level <- function(arg_env, ...) {
     any(vapply(top_level_envs, identical, x = arg_env, FUN.VALUE = logical(1L)))
 }
 
-parse_config <- new.env()
-parse_config$unscoped_functions <- list(
-    system.time = "expr",
-    try = "expr",
-    tryCatch = c("expr", "finally"),
-    withCallingHandlers = "expr",
-    withRestarts = "expr",
-    allowInterrupts = "expr",
-    suspendInterrupts = "expr",
-    suppressPackageStartupMessages = "expr",
-    suppressMessages = "expr",
-    suppressWarnings = "expr"
-)
-
-parse_config$library_functions <- list(
-    "library" = function(call) {
-        call <- match.call(base::library, call)
-        if (!isTRUE(call$character.only)) {
-            as.character(call$package)
+parser_hooks <- list(
+    "{" = function(expr, action) {
+        action$recall(as.list(expr)[-1L])
+    },
+    "(" = function(expr, action) {
+        action$recall(as.list(expr)[-1L])
+    },
+    "if" = function(expr, action) {
+        action$recall(as.list(expr)[2:4])
+    },
+    "for" = function(expr, action) {
+        if (is.symbol(e <- expr[[2L]])) {
+            action$update(nonfuncts = as.character(e))
+        }
+        action$recall(expr[[4L]])
+    },
+    "while" = function(expr, action) {
+        action$recall(as.list(expr)[2:3])
+    },
+    "repeat" = function(expr, action) {
+        action$recall(expr[[2L]])
+    },
+    "<-" = function(expr, action) {
+        if (length(expr) == 3L && is.symbol(expr[[2L]])) {
+            action$assign(symbol = as.character(expr[[2L]]), value = expr[[3L]])
+            action$recall(expr[[3L]])
         }
     },
-    "require" = function(call) {
-        call <- match.call(base::require, call)
-        if (!isTRUE(call$character.only)) {
-            as.character(call$package)
+    "=" = function(expr, action) {
+        if (length(expr) == 3L && is.symbol(expr[[2L]])) {
+            action$assign(symbol = as.character(expr[[2L]]), value = expr[[3L]])
+            action$recall(expr[[3L]])
         }
     },
-    "pacman::p_load" = function(call) {
+    "assign" = function(expr, action) {
+        call <- match.call(base::assign, expr)
+        if (is.character(call$x) && is_top_level(call$pos, -1L, -1) && is_top_level(call$envir)) {
+            action$assign(symbol = call$x, value = call$value)
+            action$recall(call$value)
+        }
+    },
+    "delayedAssign" = function(expr, action) {
+        call <- match.call(base::delayedAssign, expr)
+        if (is.character(call$x) && is_top_level(call$assign.env)) {
+            action$assign(symbol = call$x, value = call$value)
+            action$recall(call$value)
+        }
+    },
+    "makeActiveBinding" = function(expr, action) {
+        call <- match.call(base::makeActiveBinding, expr)
+        if (is.character(call$sym) && is_top_level(call$env)) {
+            action$assign(symbol = call$sym, value = call$fun, type = "variable")
+        }
+    },
+    "library" = function(expr, action) {
+        call <- match.call(base::library, expr)
+        if (!isTRUE(call$character.only)) {
+            action$update(packages = as.character(call$package))
+        }
+        NULL
+    },
+    "require" = function(expr, action) {
+        call <- match.call(base::require, expr)
+        if (!isTRUE(call$character.only)) {
+            action$update(packages = as.character(call$package))
+        }
+        NULL
+    },
+    "pacman::p_load" = function(expr, action) {
         fun <- if (requireNamespace("pacman")) pacman::p_load else
             function(..., char, install = TRUE,
                      update = getOption("pac_update"),
                      character.only = FALSE) NULL
-        call <- match.call(fun, call, expand.dots = FALSE)
+        call <- match.call(fun, expr, expand.dots = FALSE)
         if (!isTRUE(call$character.only)) {
-            vapply(call[["..."]], as.character, character(1L))
+            packages <- vapply(call[["..."]], as.character, character(1L))
+            action$update(packages = packages)
         }
-    }
+        NULL
+    },
+    "system.time" = function(expr, action) action$recall("expr"),
+    "try" = function(expr, action) action$recall("expr"),
+    "tryCatch" = function(expr, action) action$recall(c("expr", "finally")),
+    "withCallingHandlers" = function(expr, action) action$recall("expr"),
+    "withRestarts" = function(expr, action) action$recall("expr"),
+    "allowInterrupts" = function(expr, action) action$recall("expr"),
+    "suspendInterrupts" = function(expr, action) action$recall("expr"),
+    "suppressPackageStartupMessages" = function(expr, action) action$recall("expr"),
+    "suppressMessages" = function(expr, action) action$recall("expr"),
+    "suppressWarnings" = function(expr, action) action$recall("expr")
 )
 
 parse_expr <- function(content, expr, env, srcref = attr(expr, "srcref")) {
@@ -278,111 +331,57 @@ parse_expr <- function(content, expr, env, srcref = attr(expr, "srcref")) {
             Recall(content, e, env, srcref)
         }
     } else if (is_simple_call(expr)) {
-        e <- expr
-        f <- fun_string(e[[1]])
-        if (f %in% c("{", "(")) {
-            Recall(content, as.list(e)[-1L], env, srcref)
-        } else if (f == "if") {
-            Recall(content, e[[2L]], env, srcref)
-            Recall(content, e[[3L]], env, srcref)
-            if (length(e) == 4L) {
-                Recall(content, e[[4L]], env, srcref)
-            }
-        } else if (f == "for") {
-            if (is.symbol(e[[2L]])) {
-                env$nonfuncts <- c(env$nonfuncts, as.character(e[[2L]]))
-            }
-            Recall(content, e[[4L]], env, srcref)
-        } else if (f == "while") {
-            Recall(content, e[[2L]], env, srcref)
-            Recall(content, e[[3L]], env, srcref)
-        } else if (f == "repeat") {
-            Recall(content, e[[2L]], env, srcref)
-        } else if (f %in% names(parse_config$unscoped_functions)) {
-            if (length(e) >= 2L) {
-                fun <- tryCatch(eval(e[[1L]], globalenv()), error = function(e) NULL)
-                if (is.function(fun)) {
-                    call <- match.call(fun, e, expand.dots = FALSE)
-                    captures <- parse_config$unscoped_functions[[f]]
-                    for (capture in captures) {
-                        if (is.call(call[[capture]])) {
-                            Recall(content, call[[capture]], env, srcref)
+        f <- fun_string(expr[[1L]])
+        fun <- parser_hooks[[f]]
+        if (is.function(fun)) {
+            action <- list(
+                update = function(...) {
+                    updates <- list(...)
+                    for (name in names(updates)) {
+                        env[[name]] <- union(env[[name]], updates[[name]])
+                    }
+                },
+                assign = function(symbol, value, type = get_expr_type(value)) {
+                    env$objects <- c(env$objects, symbol)
+
+                    expr_range <- expr_range(srcref)
+                    env$definitions[[symbol]] <- list(
+                        name = symbol,
+                        type = type,
+                        range = expr_range
+                    )
+
+                    doc_line1 <- detect_comments(content, expr_range$start$line) + 1
+                    if (doc_line1 <= expr_range$start$line) {
+                        comment <- content[seq.int(doc_line1, expr_range$start$line)]
+                        env$documentation[[symbol]] <- convert_comment_to_documentation(comment)
+                    }
+
+                    if (type == "function") {
+                        env$functs <- c(env$functs, symbol)
+                        env$formals[[symbol]] <- value[[2L]]
+                        env$signatures[[symbol]] <- get_signature(symbol, value)
+                    } else {
+                        env$nonfuncts <- c(env$nonfuncts, symbol)
+                    }
+                },
+                recall = function(value) {
+                    if (is.character(value)) {
+                        fn <- tryCatch(eval(expr[[1L]], globalenv()), error = function(e) NULL)
+                        if (is.function(fn)) {
+                            call <- match.call(fn, expr, expand.dots = FALSE)
+                            for (arg in value) {
+                                if (is.call(call[[arg]])) {
+                                    parse_expr(content, call[[arg]], env, srcref)
+                                }
+                            }
                         }
+                    } else {
+                        parse_expr(content, value, env, srcref)
                     }
                 }
-            }
-        } else if (f %in% c("<-", "=", "delayedAssign", "makeActiveBinding", "assign")) {
-            type <- NULL
-            recall <- FALSE
-
-            if (f %in% c("<-", "=")) {
-                if (length(e) != 3L || !is.symbol(e[[2L]])) return(env)
-                symbol <- as.character(e[[2L]])
-                value <- e[[3L]]
-                recall <- TRUE
-            } else if (f == "delayedAssign") {
-                call <- match.call(base::delayedAssign, as.call(e))
-                if (!is.character(call$x)) return(env)
-                if (!is_top_level(call$assign.env)) return(env)
-                symbol <- call$x
-                value <- call$value
-                recall <- TRUE
-            } else if (f == "assign") {
-                call <- match.call(base::assign, as.call(e))
-                if (!is.character(call$x)) return(env)
-                if (!is_top_level(call$pos, -1L, -1)) return(env) # -1 is the default
-                if (!is_top_level(call$envir)) return(env)
-                symbol <- call$x
-                value <- call$value
-                recall <- TRUE
-            } else if (f == "makeActiveBinding") {
-                call <- match.call(base::makeActiveBinding, as.call(e))
-                if (!is.character(call$sym)) return(env)
-                if (!is_top_level(call$env)) return(env)
-                symbol <- call$sym
-                value <- call$fun
-                type <- "variable"
-            }
-
-            if (is.null(type)) {
-                type <- get_expr_type(value)
-            }
-
-            env$objects <- c(env$objects, symbol)
-
-            expr_range <- expr_range(srcref)
-            env$definitions[[symbol]] <- list(
-                name = symbol,
-                type = type,
-                range = expr_range
             )
-
-            doc_line1 <- detect_comments(content, expr_range$start$line) + 1
-            if (doc_line1 <= expr_range$start$line) {
-                comment <- content[seq.int(doc_line1, expr_range$start$line)]
-                env$documentation[[symbol]] <- convert_comment_to_documentation(comment)
-            }
-
-            if (type == "function") {
-                env$functs <- c(env$functs, symbol)
-                env$formals[[symbol]] <- value[[2L]]
-                env$signatures[[symbol]] <- get_signature(symbol, value)
-            } else {
-                env$nonfuncts <- c(env$nonfuncts, symbol)
-            }
-
-            if (recall && is.call(value)) {
-                Recall(content, value, env, srcref)
-            }
-        } else if (f %in% names(parse_config$library_functions) && length(e) >= 2L) {
-            pkgs <- tryCatch(
-                parse_config$library_functions[[f]](e),
-                error = function(e) NULL
-            )
-            pkgs <- pkgs[nzchar(pkgs)]
-            if (length(pkgs)) {
-                env$packages <- union(env$packages, pkgs)
-            }
+            fun(expr, action)
         }
     }
     env

--- a/R/document.R
+++ b/R/document.R
@@ -251,11 +251,13 @@ parse_config$library_functions <- c(
         }
     },
     "pacman::p_load" = function(call) {
-        if (requireNamespace("pacman")) {
-            call <- match.call(pacman::p_load, call, expand.dots = FALSE)
-            if (!isTRUE(call$character.only)) {
-                vapply(call[["..."]], as.character, character(1L))
-            }
+        fun <- if (requireNamespace("pacman")) pacman::p_load else
+            function(..., char, install = TRUE,
+                     update = getOption("pac_update"),
+                     character.only = FALSE) NULL
+        call <- match.call(fun, call, expand.dots = FALSE)
+        if (!isTRUE(call$character.only)) {
+            vapply(call[["..."]], as.character, character(1L))
         }
     }
 )

--- a/R/document.R
+++ b/R/document.R
@@ -282,14 +282,12 @@ parser_hooks <- list(
         if (!isTRUE(call$character.only)) {
             action$update(packages = as.character(call$package))
         }
-        NULL
     },
     "require" = function(expr, action) {
         call <- match.call(base::require, expr)
         if (!isTRUE(call$character.only)) {
             action$update(packages = as.character(call$package))
         }
-        NULL
     },
     "pacman::p_load" = function(expr, action) {
         fun <- if (requireNamespace("pacman")) pacman::p_load else
@@ -301,7 +299,6 @@ parser_hooks <- list(
             packages <- vapply(call[["..."]], as.character, character(1L))
             action$update(packages = packages)
         }
-        NULL
     },
     "system.time" = function(expr, action) action$parse_args("expr"),
     "try" = function(expr, action) action$parse_args("expr"),

--- a/R/document.R
+++ b/R/document.R
@@ -330,7 +330,7 @@ parse_expr <- function(content, expr, env, srcref = attr(expr, "srcref")) {
             } else if (f == "assign") {
                 call <- match.call(base::assign, as.call(e))
                 if (!is.character(call$x)) return(env)
-                if (!is_top_level(call$pos, -1, -1)) return(env) # -1 is the default
+                if (!is_top_level(call$pos, -1L, -1)) return(env) # -1 is the default
                 if (!is_top_level(call$envir)) return(env)
                 symbol <- call$x
                 value <- call$value

--- a/R/document.R
+++ b/R/document.R
@@ -237,7 +237,7 @@ parse_config$unscoped_functions <- list(
     suppressWarnings = "expr"
 )
 
-parse_config$library_functions <- c(
+parse_config$library_functions <- list(
     "library" = function(call) {
         call <- match.call(base::library, call)
         if (!isTRUE(call$character.only)) {

--- a/R/document.R
+++ b/R/document.R
@@ -338,10 +338,16 @@ parse_expr <- function(content, expr, env, srcref = attr(expr, "srcref")) {
                 update = function(...) {
                     updates <- list(...)
                     for (name in names(updates)) {
-                        env[[name]] <- union(env[[name]], updates[[name]])
+                        values <- updates[[name]]
+                        values <- values[nzchar(values)]
+                        if (length(values)) {
+                            env[[name]] <- union(env[[name]], values)
+                        }
                     }
                 },
                 assign = function(symbol, value, type = get_expr_type(value)) {
+                    if (!nzchar(symbol)) return(NULL)
+
                     env$objects <- c(env$objects, symbol)
 
                     expr_range <- expr_range(srcref)

--- a/R/document.R
+++ b/R/document.R
@@ -231,7 +231,7 @@ parser_hooks <- list(
         action$recall(as.list(expr)[-1L])
     },
     "if" = function(expr, action) {
-        action$recall(as.list(expr)[2:4])
+        action$recall(as.list(expr)[-1L])
     },
     "for" = function(expr, action) {
         if (is.symbol(e <- expr[[2L]])) {
@@ -240,7 +240,7 @@ parser_hooks <- list(
         action$recall(expr[[4L]])
     },
     "while" = function(expr, action) {
-        action$recall(as.list(expr)[2:3])
+        action$recall(as.list(expr)[-1L])
     },
     "repeat" = function(expr, action) {
         action$recall(expr[[2L]])

--- a/R/document.R
+++ b/R/document.R
@@ -262,120 +262,132 @@ parse_config$library_functions <- c(
     }
 )
 
-parse_expr <- function(content, expr, env, level = 0L, srcref = attr(expr, "srcref")) {
-    if (length(expr) == 0L || is.symbol(expr)) {
+parse_expr <- function(content, expr, env, srcref = attr(expr, "srcref")) {
+    if (length(expr) == 0L || is.symbol(expr) || is.atomic(expr)) {
         return(env)
     }
 
-    for (i in seq_along(expr)) {
-        e <- expr[[i]]
-        if (missing(e) || !is_simple_call(e)) next
-        f <- fun_string(e[[1L]])
-        cur_srcref <- if (level == 0L) srcref[[i]] else srcref
-        if (f %in% c("{", "(")) {
-            Recall(content, e[-1L], env, level + 1L, cur_srcref)
-        } else if (f == "if") {
-            Recall(content, e[[2L]], env, level + 1L, cur_srcref)
-            Recall(content, e[[3L]], env, level + 1L, cur_srcref)
-            if (length(e) == 4L) {
-                Recall(content, e[[4L]], env, level + 1L, cur_srcref)
-            }
-        } else if (f == "for") {
-            if (is.symbol(e[[2L]])) {
-                env$nonfuncts <- c(env$nonfuncts, as.character(e[[2L]]))
-            }
-            Recall(content, e[[4L]], env, level + 1L, cur_srcref)
-        } else if (f == "while") {
-            Recall(content, e[[2L]], env, level + 1L, cur_srcref)
-            Recall(content, e[[3L]], env, level + 1L, cur_srcref)
-        } else if (f == "repeat") {
-            Recall(content, e[[2L]], env, level + 1L, cur_srcref)
-        } else if (f %in% names(parse_config$unscoped_functions)) {
-            if (length(e) >= 2L) {
-                fun <- tryCatch(eval(e[[1L]], globalenv()), error = function(e) NULL)
-                if (is.function(fun)) {
-                    call <- match.call(fun, e, expand.dots = FALSE)
-                    captures <- parse_config$unscoped_functions[[f]]
-                    for (capture in captures) {
-                        if (is.call(call[[capture]])) {
-                            Recall(content, call[[capture]], env, level + 1L, cur_srcref)
+    if (is.expression(expr)) {
+        for (i in seq_along(expr)) {
+            Recall(content, expr[[i]], env, srcref[[i]])
+        }
+    } else if (is.list(expr)) {
+        for (i in seq_along(expr)) {
+            e <- expr[[i]]
+            if (missing(e)) next
+            Recall(content, e, env, srcref)
+        }
+    } else if (is.call(expr)) {
+        if (is_simple_call(expr)) {
+            e <- expr
+            f <- fun_string(e[[1]])
+            if (f %in% c("{", "(")) {
+                Recall(content, as.list(e)[-1L], env, srcref)
+            } else if (f == "if") {
+                Recall(content, e[[2L]], env, srcref)
+                Recall(content, e[[3L]], env, srcref)
+                if (length(e) == 4L) {
+                    Recall(content, e[[4L]], env, srcref)
+                }
+            } else if (f == "for") {
+                if (is.symbol(e[[2L]])) {
+                    env$nonfuncts <- c(env$nonfuncts, as.character(e[[2L]]))
+                }
+                Recall(content, e[[4L]], env, srcref)
+            } else if (f == "while") {
+                Recall(content, e[[2L]], env, srcref)
+                Recall(content, e[[3L]], env, srcref)
+            } else if (f == "repeat") {
+                Recall(content, e[[2L]], env, srcref)
+            } else if (f %in% names(parse_config$unscoped_functions)) {
+                if (length(e) >= 2L) {
+                    fun <- tryCatch(eval(e[[1L]], globalenv()), error = function(e) NULL)
+                    if (is.function(fun)) {
+                        call <- match.call(fun, e, expand.dots = FALSE)
+                        captures <- parse_config$unscoped_functions[[f]]
+                        for (capture in captures) {
+                            if (is.call(call[[capture]])) {
+                                Recall(content, call[[capture]], env, srcref)
+                            }
                         }
                     }
                 }
-            }
-        } else if (f %in% c("<-", "=", "delayedAssign", "makeActiveBinding", "assign")) {
-            type <- NULL
-            recall <- FALSE
+            } else if (f %in% c("<-", "=", "delayedAssign", "makeActiveBinding", "assign")) {
+                type <- NULL
+                recall <- FALSE
 
-            if (f %in% c("<-", "=")) {
-                if (length(e) != 3L || !is.symbol(e[[2L]])) next
-                symbol <- as.character(e[[2L]])
-                value <- e[[3L]]
-                recall <- TRUE
-            } else if (f == "delayedAssign") {
-                call <- match.call(base::delayedAssign, as.call(e))
-                if (!is.character(call$x)) next
-                if (!is_top_level(call$assign.env)) next
-                symbol <- call$x
-                value <- call$value
-                recall <- TRUE
-            } else if (f == "assign") {
-                call <- match.call(base::assign, as.call(e))
-                if (!is.character(call$x)) next
-                if (!is_top_level(call$pos, -1L, -1)) next # -1 is the default
-                if (!is_top_level(call$envir)) next
-                symbol <- call$x
-                value <- call$value
-                recall <- TRUE
-            } else if (f == "makeActiveBinding") {
-                call <- match.call(base::makeActiveBinding, as.call(e))
-                if (!is.character(call$sym)) next
-                if (!is_top_level(call$env)) next
-                symbol <- call$sym
-                value <- call$fun
-                type <- "variable"
-            }
+                if (f %in% c("<-", "=")) {
+                    if (length(e) != 3L || !is.symbol(e[[2L]])) return(env)
+                    symbol <- as.character(e[[2L]])
+                    value <- e[[3L]]
+                    recall <- TRUE
+                } else if (f == "delayedAssign") {
+                    call <- match.call(base::delayedAssign, as.call(e))
+                    if (!is.character(call$x)) return(env)
+                    if (!is_top_level(call$assign.env)) return(env)
+                    symbol <- call$x
+                    value <- call$value
+                    recall <- TRUE
+                } else if (f == "assign") {
+                    call <- match.call(base::assign, as.call(e))
+                    if (!is.character(call$x)) return(env)
+                    if (!is_top_level(call$pos, -1, -1)) return(env) # -1 is the default
+                    if (!is_top_level(call$envir)) return(env)
+                    symbol <- call$x
+                    value <- call$value
+                    recall <- TRUE
+                } else if (f == "makeActiveBinding") {
+                    call <- match.call(base::makeActiveBinding, as.call(e))
+                    if (!is.character(call$sym)) return(env)
+                    if (!is_top_level(call$env)) return(env)
+                    symbol <- call$sym
+                    value <- call$fun
+                    type <- "variable"
+                }
 
-            if (is.null(type)) {
-                type <- get_expr_type(value)
-            }
+                if (is.null(type)) {
+                    type <- get_expr_type(value)
+                }
 
-            env$objects <- c(env$objects, symbol)
+                env$objects <- c(env$objects, symbol)
 
-            expr_range <- expr_range(cur_srcref)
-            env$definitions[[symbol]] <- list(
-                name = symbol,
-                type = type,
-                range = expr_range
-            )
+                expr_range <- expr_range(srcref)
+                env$definitions[[symbol]] <- list(
+                    name = symbol,
+                    type = type,
+                    range = expr_range
+                )
 
-            doc_line1 <- detect_comments(content, expr_range$start$line) + 1
-            if (doc_line1 <= expr_range$start$line) {
-                comment <- content[seq.int(doc_line1, expr_range$start$line)]
-                env$documentation[[symbol]] <- convert_comment_to_documentation(comment)
-            }
+                doc_line1 <- detect_comments(content, expr_range$start$line) + 1
+                if (doc_line1 <= expr_range$start$line) {
+                    comment <- content[seq.int(doc_line1, expr_range$start$line)]
+                    env$documentation[[symbol]] <- convert_comment_to_documentation(comment)
+                }
 
-            if (type == "function") {
-                env$functs <- c(env$functs, symbol)
-                env$formals[[symbol]] <- value[[2L]]
-                env$signatures[[symbol]] <- get_signature(symbol, value)
-            } else {
-                env$nonfuncts <- c(env$nonfuncts, symbol)
-            }
+                if (type == "function") {
+                    env$functs <- c(env$functs, symbol)
+                    env$formals[[symbol]] <- value[[2L]]
+                    env$signatures[[symbol]] <- get_signature(symbol, value)
+                } else {
+                    env$nonfuncts <- c(env$nonfuncts, symbol)
+                }
 
-            if (recall && is.call(value)) {
-                Recall(content, value, env, level + 1L, cur_srcref)
-            }
-        } else if (f %in% names(parse_config$library_functions) && length(e) >= 2L) {
-            pkgs <- tryCatch(
-                parse_config$library_functions[[f]](e),
-                error = function(e) NULL
-            )
-            pkgs <- pkgs[nzchar(pkgs)]
-            if (length(pkgs)) {
-                env$packages <- union(env$packages, pkgs)
+                if (recall && is.call(value)) {
+                    Recall(content, value, env, srcref)
+                }
+            } else if (f %in% names(parse_config$library_functions) && length(e) >= 2L) {
+                pkgs <- tryCatch(
+                    parse_config$library_functions[[f]](e),
+                    error = function(e) NULL
+                )
+                pkgs <- pkgs[nzchar(pkgs)]
+                if (length(pkgs)) {
+                    env$packages <- union(env$packages, pkgs)
+                }
             }
         }
+    } else {
+        stop("Invalid type")
     }
     env
 }

--- a/R/document.R
+++ b/R/document.R
@@ -387,7 +387,7 @@ parse_expr <- function(content, expr, env, srcref = attr(expr, "srcref")) {
                     }
                 }
             )
-            fun(expr, action)
+            tryCatch(fun(expr, action), error = function(e) NULL)
         }
     }
     env

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,7 +1,5 @@
 .onLoad <- function(...) {
-  unscoped_functions <- getOption("languageserver.unscoped_functions")
-  parse_config$unscoped_functions[names(unscoped_functions)] <- unscoped_functions
-
-  library_functions <- getOption("languageserver.library_functions")
-  parse_config$library_functions[names(library_functions)] <- library_functions
+  user_parser_hooks <- getOption("languageserver.parser_hooks")
+  parser_hooks[names(user_parser_hooks)] <<- user_parser_hooks
+  invisible()
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,11 +1,7 @@
 .onLoad <- function(...) {
-  parse_config$unscoped_functions <- union(
-    parse_config$unscoped_functions,
-    getOption("languageserver.extra_unscoped_functions")
-  )
+  extra_unscoped_functions <- getOption("languageserver.extra_unscoped_functions")
+  parse_config$unscoped_functions[names(extra_unscoped_functions)] <- extra_unscoped_functions
 
-  parse_config$library_functions <- union(
-    parse_config$library_functions,
-    getOption("languageserver.extra_library_functions")
-  )
+  extra_library_functions <- getOption("languageserver.extra_library_functions")
+  parse_config$library_functions[names(extra_library_functions)] <- extra_library_functions
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,11 @@
+.onLoad <- function(...) {
+  parse_config$unscoped_functions <- union(
+    parse_config$unscoped_functions,
+    getOption("languageserver.extra_unscoped_functions")
+  )
+
+  parse_config$library_functions <- union(
+    parse_config$library_functions,
+    getOption("languageserver.extra_library_functions")
+  )
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,7 +1,7 @@
 .onLoad <- function(...) {
-  extra_unscoped_functions <- getOption("languageserver.extra_unscoped_functions")
-  parse_config$unscoped_functions[names(extra_unscoped_functions)] <- extra_unscoped_functions
+  unscoped_functions <- getOption("languageserver.unscoped_functions")
+  parse_config$unscoped_functions[names(unscoped_functions)] <- unscoped_functions
 
-  extra_library_functions <- getOption("languageserver.extra_library_functions")
-  parse_config$library_functions[names(extra_library_functions)] <- extra_library_functions
+  library_functions <- getOption("languageserver.library_functions")
+  parse_config$library_functions[names(library_functions)] <- library_functions
 }

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -168,7 +168,7 @@ test_that("Completion of package functions attached in unscoped functions works"
     writeLines(
         c(
             "suppressPackageStartupMessages(library(jsonlite))",
-            "fromJS",
+            "fromJS"
         ),
         temp_file)
 

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -118,7 +118,7 @@ test_that("Simple completion is case insensitive", {
     expect_length(result$items %>% keep(~ .$label == "mtcars"), 1)
 })
 
-test_that("Completion of functions in attached packages work", {
+test_that("Completion of attached package functions works", {
     skip_on_cran()
     client <- language_client()
 
@@ -133,12 +133,56 @@ test_that("Completion of functions in attached packages work", {
         temp_file)
 
     client %>% did_save(temp_file)
+    Sys.sleep(1)
 
     result <- client %>% respond_completion(temp_file, c(2, 6))
-
     expect_length(result$items %>% keep(~ .$label == "fromJSON"), 1)
 
     result <- client %>% respond_completion(temp_file, c(3, 7))
+    expect_length(result$items %>% keep(~ .$label == "read_xml"), 1)
+
+    temp_file <- withr::local_tempfile(fileext = ".R")
+    writeLines(
+        c(
+            "pacman::p_load(jsonlite, xml2)",
+            "fromJS",
+            "read_xm"
+        ),
+        temp_file)
+
+    client %>% did_save(temp_file)
+    Sys.sleep(1)
+
+    result <- client %>% respond_completion(temp_file, c(1, 6))
+    expect_length(result$items %>% keep(~ .$label == "fromJSON"), 1)
+
+    result <- client %>% respond_completion(temp_file, c(2, 7))
+    expect_length(result$items %>% keep(~ .$label == "read_xml"), 1)
+})
+
+test_that("Completion of package functions attached in unscoped functions works", {
+    skip_on_cran()
+    client <- language_client()
+
+    temp_file <- withr::local_tempfile(fileext = ".R")
+    writeLines(
+        c(
+            "suppressPackageStartupMessages({",
+            "  library(jsonlite)",
+            "  require('xml2')",
+            "})",
+            "fromJS",
+            "read_xm"
+        ),
+        temp_file)
+
+    client %>% did_save(temp_file)
+    Sys.sleep(1)
+
+    result <- client %>% respond_completion(temp_file, c(4, 6))
+    expect_length(result$items %>% keep(~ .$label == "fromJSON"), 1)
+
+    result <- client %>% respond_completion(temp_file, c(5, 7))
     expect_length(result$items %>% keep(~ .$label == "read_xml"), 1)
 })
 

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -151,12 +151,13 @@ test_that("Completion of attached package functions works", {
         temp_file)
 
     client %>% did_save(temp_file)
-    Sys.sleep(1)
 
-    result <- client %>% respond_completion(temp_file, c(1, 6))
+    result <- client %>% respond_completion(temp_file, c(1, 6),
+        retry_when = function(result) result$items %>% keep(~ .$label == "fromJSON") %>% length() == 0)
     expect_length(result$items %>% keep(~ .$label == "fromJSON"), 1)
 
-    result <- client %>% respond_completion(temp_file, c(2, 7))
+    result <- client %>% respond_completion(temp_file, c(2, 7),
+        retry_when = function(result) result$items %>% keep(~ .$label == "read_xml") %>% length() == 0)
     expect_length(result$items %>% keep(~ .$label == "read_xml"), 1)
 })
 
@@ -173,9 +174,9 @@ test_that("Completion of package functions attached in unscoped functions works"
         temp_file)
 
     client %>% did_save(temp_file)
-    Sys.sleep(1)
 
-    result <- client %>% respond_completion(temp_file, c(1, 6))
+    result <- client %>% respond_completion(temp_file, c(1, 6),
+        retry_when = function(result) result$items %>% keep(~ .$label == "fromJSON") %>% length() == 0)
     expect_length(result$items %>% keep(~ .$label == "fromJSON"), 1)
 
     writeLines(
@@ -192,10 +193,12 @@ test_that("Completion of package functions attached in unscoped functions works"
     client %>% did_save(temp_file)
     Sys.sleep(1)
 
-    result <- client %>% respond_completion(temp_file, c(4, 6))
+    result <- client %>% respond_completion(temp_file, c(4, 6),
+        retry_when = function(result) result$items %>% keep(~ .$label == "fromJSON") %>% length() == 0)
     expect_length(result$items %>% keep(~ .$label == "fromJSON"), 1)
 
-    result <- client %>% respond_completion(temp_file, c(5, 7))
+    result <- client %>% respond_completion(temp_file, c(5, 7),
+        retry_when = function(result) result$items %>% keep(~ .$label == "read_xml") %>% length() == 0)
     expect_length(result$items %>% keep(~ .$label == "read_xml"), 1)
 })
 

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -167,6 +167,19 @@ test_that("Completion of package functions attached in unscoped functions works"
     temp_file <- withr::local_tempfile(fileext = ".R")
     writeLines(
         c(
+            "suppressPackageStartupMessages(library(jsonlite))",
+            "fromJS",
+        ),
+        temp_file)
+
+    client %>% did_save(temp_file)
+    Sys.sleep(1)
+
+    result <- client %>% respond_completion(temp_file, c(1, 6))
+    expect_length(result$items %>% keep(~ .$label == "fromJSON"), 1)
+
+    writeLines(
+        c(
             "suppressPackageStartupMessages({",
             "  library(jsonlite)",
             "  require('xml2')",

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -133,12 +133,13 @@ test_that("Completion of attached package functions works", {
         temp_file)
 
     client %>% did_save(temp_file)
-    Sys.sleep(1)
 
-    result <- client %>% respond_completion(temp_file, c(2, 6))
+    result <- client %>% respond_completion(temp_file, c(2, 6),
+        retry_when = function(result) result$items %>% keep(~ .$label == "fromJSON") %>% length() == 0)
     expect_length(result$items %>% keep(~ .$label == "fromJSON"), 1)
 
-    result <- client %>% respond_completion(temp_file, c(3, 7))
+    result <- client %>% respond_completion(temp_file, c(3, 7),
+        retry_when = function(result) result$items %>% keep(~ .$label == "read_xml") %>% length() == 0)
     expect_length(result$items %>% keep(~ .$label == "read_xml"), 1)
 
     temp_file <- withr::local_tempfile(fileext = ".R")
@@ -191,7 +192,6 @@ test_that("Completion of package functions attached in unscoped functions works"
         temp_file)
 
     client %>% did_save(temp_file)
-    Sys.sleep(1)
 
     result <- client %>% respond_completion(temp_file, c(4, 6),
         retry_when = function(result) result$items %>% keep(~ .$label == "fromJSON") %>% length() == 0)

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -118,6 +118,30 @@ test_that("Simple completion is case insensitive", {
     expect_length(result$items %>% keep(~ .$label == "mtcars"), 1)
 })
 
+test_that("Completion of functions in attached packages work", {
+    skip_on_cran()
+    client <- language_client()
+
+    temp_file <- withr::local_tempfile(fileext = ".R")
+    writeLines(
+        c(
+            "library(jsonlite)",
+            "require('xml2')",
+            "fromJS",
+            "read_xm"
+        ),
+        temp_file)
+
+    client %>% did_save(temp_file)
+
+    result <- client %>% respond_completion(temp_file, c(2, 6))
+
+    expect_length(result$items %>% keep(~ .$label == "fromJSON"), 1)
+
+    result <- client %>% respond_completion(temp_file, c(3, 7))
+    expect_length(result$items %>% keep(~ .$label == "read_xml"), 1)
+})
+
 test_that("Completion of function arguments works", {
     skip_on_cran()
     client <- language_client()

--- a/tests/testthat/test-symbol.R
+++ b/tests/testthat/test-symbol.R
@@ -59,7 +59,7 @@ test_that("Recognize symbols created by delayedAssign()/assign()/makeActiveBindi
         "makeActiveBinding('a5', function() 5, .GlobalEnv)",
         "makeActiveBinding('a6', function() 6, new.env())",
         "assign(value = '1', x = 'assign1')",
-        "assign('assign2', 2, pos = -1L)",
+        "assign('assign2', 2, pos = -1)",
         "assign('assign3', 3, pos = environment())",
         "assign('assign4', 4, pos = new.env())"
     ), defn_file)


### PR DESCRIPTION
Closes #257
Closes #426 
Closes #451

This PR introduces customizable ~~unscoped~~ parser hook functions ~~and library functions~~ so that the following code could be supported:

```r
suppressPackageStartupMessages({
  pacman::p_load(dplyr)
})
```

~~The unscoped functions (e.g. `try`, `suppressPackageStartupMessages`, `system.time`) evaluate an expression in its calling environment as if the `expr` is directly evaluated but with some other things done.~~

~~The library functions (e.g. `library`, `require`) are a list of functions recognized as equivalent with `library`. An example is `pacman::p_load`.~~

~~User could add more functions via the option `languageserver.unscoped_functions` and `languageserver.library_functions` respectively in `.Rprofile`.~~

The `parse_expr` function is rewritten with unified parser hooks defined in the package and could be modified by user via `languageserver.parser_hooks` option.

A parser hook is a function of `expr`(input expression currently processing), and an `action` (a list of action functions). For example, the for loop is handled by the following parser hook:

```r
"for" = function(expr, action) {
        if (is.symbol(e <- expr[[2L]])) {
            action$update(nonfuncts = as.character(e))
        }
        action$parse(expr[[4L]])
    }
```

In this function, it adds the iteration variable (`expr[[2L]]`) to `nonfuncts` as a non-function global variable, and continue to parse the for loop body (`expr[[4L]]`).

The pre-defined action functions include

* `update(...)`: update the character vector of `functs`, `nonfuncts`, `packages`, etc. For example, `for (i in 1:10) { }` adds `i` to `nonfuncts`.
* `assign(symbol, value, type)`: create an assignment which adds new symbol definition and associated comment lines as its documentation.
* `parse(expr)`: continue to parse the given expression.
* `parse_args(args)`: continue to parse the expressions of the given matched function arguments. For example, some functions (e.g. `system.time`, `suppressPackageStartupMessages`) or arguments (e.g. `tryCatch(expr=, finally=)`) evaluate expressions in the current scope so that we would like to capture these arguments of the function to continue to parse the expressions as being evaluated in the global scope.

* [x] Implementation
* [x] Test cases