### PR TITLE
Require styler >= 1.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     repr (>= 1.1.0),
     roxygen2 (>= 7.0.0),
     stringi (>= 1.1.7),
-    styler (>= 1.4.1),
+    styler (>= 1.5.1),
     tools,
     utils,
     xml2 (>= 1.2.2),

--- a/README.md
+++ b/README.md
@@ -189,10 +189,3 @@ options(languageserver.formatting_style = function(options) {
 ```
 
 To further customize the formatting style, please refer to [Customizing styler](https://styler.r-lib.org/articles/customizing_styler.html).
-
-### Using persistent cache for formatting by styler
-
-With [`styler`](https://github.com/r-lib/styler) v1.3, the formatting of top-level expressions
-can be cached by [`R.cache`](https://github.com/HenrikBengtsson/R.cache), which significantly improves the formatting performance by skipping the expressions that are known in cache to be already formatted. By default, the cache only works within the current session.
-
-To make it work across sessions, set the R option `R.cache.rootPath` or environment variable `R_CACHE_ROOTPATH` to an existent path. For more details, see [styler caching](https://styler.r-lib.org/reference/caching.html).


### PR DESCRIPTION
Closes #457 

This PR makes the package require styler >= 1.5.1 so that the default cache root path (`~/.cache/R/R.cache`) is global to the user rather than per session. No prompt required to use a global cache root. Therefore, there is no need to mention the cache issue in the README.