### PR TITLE
Fix handling null workspace folder and untitled document

### DIFF
--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -55,7 +55,7 @@ text_document_definition  <- function(self, id, params) {
     uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
     point <- document$from_lsp_position(params$position)
-    rootPath <- if (length(self$rootPath)) self$rootPath else dirname(path_from_uri(uri))
+    rootPath <- get_root_path_for_uri(uri, self$rootPath)
     self$deliver(definition_reply(id, uri, self$workspace, document, point, rootPath))
 }
 
@@ -164,7 +164,7 @@ text_document_document_link  <- function(self, id, params) {
     textDocument <- params$textDocument
     uri <- uri_escape_unicode(textDocument$uri)
     document <- self$workspace$documents$get(uri)
-    rootPath <- if (length(self$rootPath)) self$rootPath else dirname(path_from_uri(uri))
+    rootPath <- get_root_path_for_uri(uri, self$rootPath)
     reply <- document_link_reply(id, uri, self$workspace, document, rootPath)
     if (is.null(reply)) {
         queue <- self$pending_replies$get(uri)[["textDocument/documentLink"]]

--- a/R/utils.R
+++ b/R/utils.R
@@ -462,6 +462,19 @@ is_package <- function(rootPath) {
     file.exists(file) && !dir.exists(file)
 }
 
+get_root_path_for_uri <- function(uri, rootPath) {
+    if (length(rootPath)) {
+        # valid workspace folder
+        rootPath
+    } else if (nzchar(path <- path_from_uri(uri))) {
+        # null workspace folder
+        dirname(path)
+    } else {
+        # untitled document
+        getwd()
+    }
+}
+
 #' read a character from stdin
 #'
 #' @noRd

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -65,14 +65,17 @@ notify <- function(client, method, params = NULL) {
 }
 
 
-did_open <- function(client, path) {
-    text <- paste0(stringi::stri_read_lines(path), collapse = "\n")
+did_open <- function(client, path, uri = path_to_uri(path), text = NULL) {
+    if (is.null(text)) {
+        text <- stringi::stri_read_lines(path)
+    }
+    text <- paste0(text, collapse = "\n")
     notify(
         client,
         "textDocument/didOpen",
         list(
             textDocument = list(
-                uri = path_to_uri(path),
+                uri = uri,
                 languageId = "R",
                 version = 1,
                 text = text
@@ -83,16 +86,19 @@ did_open <- function(client, path) {
 }
 
 
-did_save <- function(client, path) {
+did_save <- function(client, path, uri = path_to_uri(path), text = NULL) {
     includeText <- tryCatch(
         client$ServerCapabilities$textDocumentSync$save$includeText,
         error = function(e) FALSE
     )
     if (includeText) {
-        text <- paste0(stringi::stri_read_lines(path), collapse = "\n")
-        params <- list(textDocument = list(uri = path_to_uri(path)), text = text)
+        if (is.null(text)) {
+            text <- stringi::stri_read_lines(path)
+        }
+        text <- paste0(text, collapse = "\n")
+        params <- list(textDocument = list(uri = uri), text = text)
     } else {
-        params <- list(textDocument = list(uri = path_to_uri(path)))
+        params <- list(textDocument = list(uri = uri))
     }
     notify(
         client,
@@ -154,12 +160,12 @@ respond <- function(client, method, params, timeout, allow_error = FALSE,
 }
 
 
-respond_completion <- function(client, path, pos, ...) {
+respond_completion <- function(client, path, pos, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/completion",
         list(
-            textDocument = list(uri = path_to_uri(path)),
+            textDocument = list(uri = uri),
             position = list(line = pos[1], character = pos[2])
         ),
         ...
@@ -175,60 +181,60 @@ respond_completion_item_resolve <- function(client, params, ...) {
     )
 }
 
-respond_signature <- function(client, path, pos, ...) {
+respond_signature <- function(client, path, pos, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/signatureHelp",
         list(
-            textDocument = list(uri = path_to_uri(path)),
+            textDocument = list(uri = uri),
             position = list(line = pos[1], character = pos[2])
         ),
         ...
     )
 }
 
-respond_hover <- function(client, path, pos, ...) {
+respond_hover <- function(client, path, pos, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/hover",
         list(
-            textDocument = list(uri = path_to_uri(path)),
+            textDocument = list(uri = uri),
             position = list(line = pos[1], character = pos[2])
         ),
         ...
     )
 }
 
-respond_definition <- function(client, path, pos, ...) {
+respond_definition <- function(client, path, pos, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/definition",
         list(
-            textDocument = list(uri = path_to_uri(path)),
+            textDocument = list(uri = uri),
             position = list(line = pos[1], character = pos[2])
         ),
         ...
     )
 }
 
-respond_references <- function(client, path, pos, ...) {
+respond_references <- function(client, path, pos, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/references",
         list(
-            textDocument = list(uri = path_to_uri(path)),
+            textDocument = list(uri = uri),
             position = list(line = pos[1], character = pos[2])
         ),
         ...
     )
 }
 
-respond_rename <- function(client, path, pos, newName, ...) {
+respond_rename <- function(client, path, pos, newName, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/rename",
         list(
-            textDocument = list(uri = path_to_uri(path)),
+            textDocument = list(uri = uri),
             position = list(line = pos[1], character = pos[2]),
             newName = newName
         ),
@@ -236,12 +242,12 @@ respond_rename <- function(client, path, pos, newName, ...) {
     )
 }
 
-respond_prepare_rename <- function(client, path, pos, ...) {
+respond_prepare_rename <- function(client, path, pos, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/prepareRename",
         list(
-            textDocument = list(uri = path_to_uri(path)),
+            textDocument = list(uri = uri),
             position = list(line = pos[1], character = pos[2])
         ),
         ...
@@ -249,24 +255,24 @@ respond_prepare_rename <- function(client, path, pos, ...) {
 }
 
 
-respond_formatting <- function(client, path, ...) {
+respond_formatting <- function(client, path, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/formatting",
         list(
-            textDocument = list(uri = path_to_uri(path)),
+            textDocument = list(uri = uri),
             options = list(tabSize = 4, insertSpaces = TRUE)
         ),
         ...
     )
 }
 
-respond_range_formatting <- function(client, path, start_pos, end_pos, ...) {
+respond_range_formatting <- function(client, path, start_pos, end_pos, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/rangeFormatting",
         list(
-            textDocument = list(uri = path_to_uri(path)),
+            textDocument = list(uri = uri),
             range = range(
                 start = position(start_pos[1], start_pos[2]),
                 end = position(end_pos[1], end_pos[2])
@@ -277,33 +283,33 @@ respond_range_formatting <- function(client, path, start_pos, end_pos, ...) {
     )
 }
 
-respond_folding_range <- function(client, path, ...) {
+respond_folding_range <- function(client, path, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/foldingRange",
         list(
-            textDocument = list(uri = path_to_uri(path))),
+            textDocument = list(uri = uri)),
         ...
     )
 }
 
-respond_selection_range <- function(client, path, positions, ...) {
+respond_selection_range <- function(client, path, positions, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/selectionRange",
         list(
-            textDocument = list(uri = path_to_uri(path)),
+            textDocument = list(uri = uri),
             positions = positions),
         ...
     )
 }
 
-respond_on_type_formatting <- function(client, path, pos, ch, ...) {
+respond_on_type_formatting <- function(client, path, pos, ch, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/onTypeFormatting",
         list(
-            textDocument = list(uri = path_to_uri(path)),
+            textDocument = list(uri = uri),
             position = position(pos[1], pos[2]),
             ch = ch,
             options = list(tabSize = 4, insertSpaces = TRUE)
@@ -313,24 +319,24 @@ respond_on_type_formatting <- function(client, path, pos, ch, ...) {
 }
 
 
-respond_document_highlight <- function(client, path, pos, ...) {
+respond_document_highlight <- function(client, path, pos, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/documentHighlight",
         list(
-            textDocument = list(uri = path_to_uri(path)),
+            textDocument = list(uri = uri),
             position = list(line = pos[1], character = pos[2])
         ),
         ...
     )
 }
 
-respond_document_symbol <- function(client, path, ...) {
+respond_document_symbol <- function(client, path, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/documentSymbol",
         list(
-            textDocument = list(uri = path_to_uri(path))
+            textDocument = list(uri = uri)
         ),
         ...
     )
@@ -347,12 +353,12 @@ respond_workspace_symbol <- function(client, query, ...) {
     )
 }
 
-respond_document_link <- function(client, path, ...) {
+respond_document_link <- function(client, path, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/documentLink",
         list(
-            textDocument = list(uri = path_to_uri(path))
+            textDocument = list(uri = uri)
         ),
         ...
     )
@@ -367,34 +373,34 @@ respond_document_link_resolve <- function(client, params, ...) {
     )
 }
 
-respond_document_color <- function(client, path, ...) {
+respond_document_color <- function(client, path, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/documentColor",
         list(
-            textDocument = list(uri = path_to_uri(path))
+            textDocument = list(uri = uri)
         ),
         ...
     )
 }
 
-respond_document_folding_range <- function(client, path, ...) {
+respond_document_folding_range <- function(client, path, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/foldingRange",
         list(
-            textDocument = list(uri = path_to_uri(path))
+            textDocument = list(uri = uri)
         ),
         ...
     )
 }
 
-respond_prepare_call_hierarchy <- function(client, path, pos, ...) {
+respond_prepare_call_hierarchy <- function(client, path, pos, ..., uri = path_to_uri(path)) {
     respond(
         client,
         "textDocument/prepareCallHierarchy",
         list(
-            textDocument = list(uri = path_to_uri(path)),
+            textDocument = list(uri = uri),
             position = list(line = pos[1], character = pos[2])
         ),
         ...
@@ -423,8 +429,7 @@ respond_call_hierarchy_outgoing_calls <- function(client, item, ...) {
     )
 }
 
-respond_code_action <- function(client, path, start_pos, end_pos, ...) {
-    uri <- path_to_uri(path)
+respond_code_action <- function(client, path, start_pos, end_pos, ..., uri = path_to_uri(path)) {
     diagnostics <- client$diagnostics$get(uri)
     range <- range(
         start = position(start_pos[1], start_pos[2]),

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -376,6 +376,33 @@ test_that("Completion of local function arguments works", {
     expect_length(arg_items, 1)
 })
 
+test_that("Completion of local function arguments works in untitled documents", {
+    skip_on_cran()
+    client <- language_client()
+
+    uri <- "untitled:Untitled-1"
+
+    client %>% did_open(uri = uri, text = c(
+        "local({",
+        "  test <- function(vararg1, vararg2=1) {",
+        "    vararg1 + vararg2",
+        "  }",
+        "  test(vararg",
+        "  )",
+        "})"
+    ))
+
+    result <- client %>% respond_completion(
+        NULL, c(4, 13), uri = uri,
+        retry_when = function(result) length(result) == 0 || length(result$items) == 0
+    )
+    arg_items <- result$items %>% keep(~ .$label == "vararg1")
+    expect_length(arg_items, 1)
+
+    arg_items <- result$items %>% keep(~ .$label == "vararg2")
+    expect_length(arg_items, 1)
+})
+
 test_that("Completion of user function arguments preserves the order of arguments", {
     skip_on_cran()
     client <- language_client()

--- a/tests/testthat/test-definition.R
+++ b/tests/testthat/test-definition.R
@@ -86,6 +86,30 @@ test_that("Go to Definition works in single file", {
     expect_equal(length(result), 0)
 })
 
+test_that("Go to Definition works in untilted documents", {
+    skip_on_cran()
+    client <- language_client()
+
+    uri <- "untitled:Untitled-1"
+
+    client %>% did_open(uri = uri, text = c(
+        "my_fn <- function(x) {x + 1}",
+        "my_fn",
+        ".nonexistent"
+    ))
+
+    # first query a known function to make sure the file is processed
+    result <- client %>% respond_definition(NULL, c(1, 0), uri = uri)
+
+    expect_equal(result$range$start, list(line = 0, character = 0))
+    expect_equal(result$range$end, list(line = 0, character = 28))
+
+    # then query the missing function. The file is processed, don't need to retry
+    result <- client %>% respond_definition(NULL, c(2, 0), uri = uri, retry = FALSE)
+
+    expect_equal(length(result), 0)
+})
+
 test_that("Go to Definition works in scope with different assignment operators", {
     skip_on_cran()
     client <- language_client()

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -217,3 +217,71 @@ test_that("Document link works in Rmarkdown", {
     resolve <- client %>% respond_document_link_resolve(result[[4]])
     expect_equal(resolve$target, path_to_uri(src_file2))
 })
+
+test_that("Document link works with null workspace folder", {
+    skip_on_cran()
+
+    dir <- tempdir()
+    client <- language_client(NULL)
+
+    src_file1 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
+    src_file2 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
+    temp_file <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
+    src_file1 <- format(fs::path(src_file1))
+    src_file2 <- format(fs::path(src_file2))
+
+    writeLines(
+        c(
+            "x <- 1"
+        ),
+        src_file1
+    )
+
+    writeLines(
+        c(
+            "x <- 2"
+        ),
+        src_file2
+    )
+
+    writeLines(c(
+        sprintf("source('%s')", src_file1),
+        sprintf("source('%s')", basename(src_file1)),
+        sprintf("source('%s')", src_file2),
+        sprintf("source('%s')", basename(src_file2)),
+        "source('non_exist_file.R')"
+    ), temp_file)
+
+    client %>% did_save(temp_file)
+
+    result <- client %>% respond_document_link(temp_file)
+
+    expect_length(result, 4)
+    expect_equal(result[[1]]$range$start, list(line = 0, character = 8))
+    expect_equal(result[[1]]$range$end, list(line = 0, character = 8 + nchar(src_file1)))
+    expect_equal(result[[1]]$data$path, src_file1)
+
+    expect_equal(result[[2]]$range$start, list(line = 1, character = 8))
+    expect_equal(result[[2]]$range$end, list(line = 1, character = 8 + nchar(basename(src_file1))))
+    expect_equal(result[[2]]$data$path, src_file1)
+
+    expect_equal(result[[3]]$range$start, list(line = 2, character = 8))
+    expect_equal(result[[3]]$range$end, list(line = 2, character = 8 + nchar(src_file2)))
+    expect_equal(result[[3]]$data$path, src_file2)
+
+    expect_equal(result[[4]]$range$start, list(line = 3, character = 8))
+    expect_equal(result[[4]]$range$end, list(line = 3, character = 8 + nchar(basename(src_file2))))
+    expect_equal(result[[4]]$data$path, src_file2)
+
+    resolve <- client %>% respond_document_link_resolve(result[[1]])
+    expect_equal(resolve$target, path_to_uri(src_file1))
+
+    resolve <- client %>% respond_document_link_resolve(result[[2]])
+    expect_equal(resolve$target, path_to_uri(src_file1))
+
+    resolve <- client %>% respond_document_link_resolve(result[[3]])
+    expect_equal(resolve$target, path_to_uri(src_file2))
+
+    resolve <- client %>% respond_document_link_resolve(result[[4]])
+    expect_equal(resolve$target, path_to_uri(src_file2))
+})

--- a/tests/testthat/test-link.R
+++ b/tests/testthat/test-link.R
@@ -285,3 +285,71 @@ test_that("Document link works with null workspace folder", {
     resolve <- client %>% respond_document_link_resolve(result[[4]])
     expect_equal(resolve$target, path_to_uri(src_file2))
 })
+
+test_that("Document link works with untitled document", {
+    skip_on_cran()
+
+    dir <- tempdir()
+    client <- language_client(dir)
+
+    src_file1 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
+    src_file2 <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
+    temp_file <- withr::local_tempfile(tmpdir = dir, fileext = ".R")
+    src_file1 <- format(fs::path(src_file1))
+    src_file2 <- format(fs::path(src_file2))
+
+    writeLines(
+        c(
+            "x <- 1"
+        ),
+        src_file1
+    )
+
+    writeLines(
+        c(
+            "x <- 2"
+        ),
+        src_file2
+    )
+
+    uri <- "untitled:Untitled-1"
+
+    client %>% did_save(uri = uri, text = c(
+        sprintf("source('%s')", src_file1),
+        sprintf("source('%s')", basename(src_file1)),
+        sprintf("source('%s')", src_file2),
+        sprintf("source('%s')", basename(src_file2)),
+        "source('non_exist_file.R')"
+    ))
+
+    result <- client %>% respond_document_link(uri = uri)
+
+    expect_length(result, 4)
+    expect_equal(result[[1]]$range$start, list(line = 0, character = 8))
+    expect_equal(result[[1]]$range$end, list(line = 0, character = 8 + nchar(src_file1)))
+    expect_equal(result[[1]]$data$path, src_file1)
+
+    expect_equal(result[[2]]$range$start, list(line = 1, character = 8))
+    expect_equal(result[[2]]$range$end, list(line = 1, character = 8 + nchar(basename(src_file1))))
+    expect_equal(result[[2]]$data$path, src_file1)
+
+    expect_equal(result[[3]]$range$start, list(line = 2, character = 8))
+    expect_equal(result[[3]]$range$end, list(line = 2, character = 8 + nchar(src_file2)))
+    expect_equal(result[[3]]$data$path, src_file2)
+
+    expect_equal(result[[4]]$range$start, list(line = 3, character = 8))
+    expect_equal(result[[4]]$range$end, list(line = 3, character = 8 + nchar(basename(src_file2))))
+    expect_equal(result[[4]]$data$path, src_file2)
+
+    resolve <- client %>% respond_document_link_resolve(result[[1]])
+    expect_equal(resolve$target, path_to_uri(src_file1))
+
+    resolve <- client %>% respond_document_link_resolve(result[[2]])
+    expect_equal(resolve$target, path_to_uri(src_file1))
+
+    resolve <- client %>% respond_document_link_resolve(result[[3]])
+    expect_equal(resolve$target, path_to_uri(src_file2))
+
+    resolve <- client %>% respond_document_link_resolve(result[[4]])
+    expect_equal(resolve$target, path_to_uri(src_file2))
+})

--- a/tests/testthat/test-workspace.R
+++ b/tests/testthat/test-workspace.R
@@ -1,4 +1,4 @@
-test_that("Null-root workspace works", {
+test_that("Null workspace folder works", {
   skip_on_cran()
   client <- language_client(NULL)
 


### PR DESCRIPTION
Closes #460 

This PR makes handling null workspace folder and untitled document with the following logic:

1. If the workspace folder is not null, then use it as the root path.
2. Otherwise, if path from uri is not empty, use the directory of the path.
3. Otherwise, the uri is not a `file://` uri, then use the working directory of the language server process.
