### PR TITLE
Fix several bugs

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -313,17 +313,17 @@ workspace_completion <- function(workspace, token,
 }
 
 scope_completion_symbols_xpath <- paste(
-    "*[self::FUNCTION or self::OP-LAMBDA]/following-sibling::SYMBOL_FORMALS",
+    "(*|exprlist/*)[self::FUNCTION or self::OP-LAMBDA]/following-sibling::SYMBOL_FORMALS",
+    "(*|exprlist/*)/LEFT_ASSIGN[not(following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA])]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    "(*|exprlist/*)/RIGHT_ASSIGN[not(preceding-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA])]/following-sibling::expr[count(*)=1]/SYMBOL",
+    "(*|exprlist/*)/EQ_ASSIGN[not(following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA])]/preceding-sibling::expr[count(*)=1]/SYMBOL",
     "forcond/SYMBOL",
-    "*/LEFT_ASSIGN[not(following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA])]/preceding-sibling::expr[count(*)=1]/SYMBOL",
-    "*/RIGHT_ASSIGN[not(preceding-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA])]/following-sibling::expr[count(*)=1]/SYMBOL",
-    "*/EQ_ASSIGN[not(following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA])]/preceding-sibling::expr[count(*)=1]/SYMBOL",
     sep = "|")
 
 scope_completion_functs_xpath <- paste(
-    "*/LEFT_ASSIGN[following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA]]/preceding-sibling::expr[count(*)=1]/SYMBOL",
-    "*/RIGHT_ASSIGN[preceding-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA]]/following-sibling::expr[count(*)=1]/SYMBOL",
-    "*/EQ_ASSIGN[following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA]]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    "(*|exprlist/*)/LEFT_ASSIGN[following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA]]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    "(*|exprlist/*)/RIGHT_ASSIGN[preceding-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA]]/following-sibling::expr[count(*)=1]/SYMBOL",
+    "(*|exprlist/*)/EQ_ASSIGN[following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA]]/preceding-sibling::expr[count(*)=1]/SYMBOL",
     sep = "|")
 
 scope_completion <- function(uri, workspace, token, point, snippet_support = NULL) {

--- a/R/completion.R
+++ b/R/completion.R
@@ -313,17 +313,17 @@ workspace_completion <- function(workspace, token,
 }
 
 scope_completion_symbols_xpath <- paste(
-    "(*|exprlist/*)[self::FUNCTION or self::OP-LAMBDA]/following-sibling::SYMBOL_FORMALS",
-    "(*|exprlist/*)/LEFT_ASSIGN[not(following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA])]/preceding-sibling::expr[count(*)=1]/SYMBOL",
-    "(*|exprlist/*)/RIGHT_ASSIGN[not(preceding-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA])]/following-sibling::expr[count(*)=1]/SYMBOL",
-    "(*|exprlist/*)/EQ_ASSIGN[not(following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA])]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    "(*|descendant-or-self::exprlist/*)[self::FUNCTION or self::OP-LAMBDA]/following-sibling::SYMBOL_FORMALS",
+    "(*|descendant-or-self::exprlist/*)/LEFT_ASSIGN[not(following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA])]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    "(*|descendant-or-self::exprlist/*)/RIGHT_ASSIGN[not(preceding-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA])]/following-sibling::expr[count(*)=1]/SYMBOL",
+    "(*|descendant-or-self::exprlist/*)/EQ_ASSIGN[not(following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA])]/preceding-sibling::expr[count(*)=1]/SYMBOL",
     "forcond/SYMBOL",
     sep = "|")
 
 scope_completion_functs_xpath <- paste(
-    "(*|exprlist/*)/LEFT_ASSIGN[following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA]]/preceding-sibling::expr[count(*)=1]/SYMBOL",
-    "(*|exprlist/*)/RIGHT_ASSIGN[preceding-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA]]/following-sibling::expr[count(*)=1]/SYMBOL",
-    "(*|exprlist/*)/EQ_ASSIGN[following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA]]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    "(*|descendant-or-self::exprlist/*)/LEFT_ASSIGN[following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA]]/preceding-sibling::expr[count(*)=1]/SYMBOL",
+    "(*|descendant-or-self::exprlist/*)/RIGHT_ASSIGN[preceding-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA]]/following-sibling::expr[count(*)=1]/SYMBOL",
+    "(*|descendant-or-self::exprlist/*)/EQ_ASSIGN[following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA]]/preceding-sibling::expr[count(*)=1]/SYMBOL",
     sep = "|")
 
 scope_completion <- function(uri, workspace, token, point, snippet_support = NULL) {

--- a/R/definition.R
+++ b/R/definition.R
@@ -1,8 +1,8 @@
 definition_xpath <- paste(
-    "(*|exprlist/*)[self::FUNCTION or self::OP-LAMBDA]/following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]",
-    "(*|exprlist/*)[LEFT_ASSIGN[preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and following-sibling::expr[@start > {start} or @end < {end}]]]",
-    "(*|exprlist/*)[RIGHT_ASSIGN[following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and preceding-sibling::expr[@start > {start} or @end < {end}]]]",
-    "(*|exprlist/*)[EQ_ASSIGN[preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and following-sibling::expr[@start > {start} or @end < {end}]]]",
+    "(*|descendant-or-self::exprlist/*)[self::FUNCTION or self::OP-LAMBDA]/following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]",
+    "(*|descendant-or-self::exprlist/*)[LEFT_ASSIGN[preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and following-sibling::expr[@start > {start} or @end < {end}]]]",
+    "(*|descendant-or-self::exprlist/*)[RIGHT_ASSIGN[following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and preceding-sibling::expr[@start > {start} or @end < {end}]]]",
+    "(*|descendant-or-self::exprlist/*)[EQ_ASSIGN[preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and following-sibling::expr[@start > {start} or @end < {end}]]]",
     "forcond/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]",
     sep = "|")
 

--- a/R/definition.R
+++ b/R/definition.R
@@ -1,8 +1,8 @@
 definition_xpath <- paste(
-    "*[self::FUNCTION or self::OP-LAMBDA]/following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]",
-    "*[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and LEFT_ASSIGN/following-sibling::expr[@start > {start} or @end < {end}]]",
-    "*[RIGHT_ASSIGN/following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and RIGHT_ASSIGN/preceding-sibling::expr[@start > {start} or @end < {end}]]",
-    "*[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and EQ_ASSIGN/following-sibling::expr[@start > {start} or @end < {end}]]",
+    "(*|exprlist/*)[self::FUNCTION or self::OP-LAMBDA]/following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]",
+    "(*|exprlist/*)[LEFT_ASSIGN[preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and following-sibling::expr[@start > {start} or @end < {end}]]]",
+    "(*|exprlist/*)[RIGHT_ASSIGN[following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and preceding-sibling::expr[@start > {start} or @end < {end}]]]",
+    "(*|exprlist/*)[EQ_ASSIGN[preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and following-sibling::expr[@start > {start} or @end < {end}]]]",
     "forcond/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]",
     sep = "|")
 

--- a/R/document.R
+++ b/R/document.R
@@ -402,6 +402,8 @@ parse_document <- function(uri, content) {
     if (is_rmarkdown(uri)) {
         content <- purl(content)
     }
+    # replace tab with a space since the width of a tab is 1 in LSP but 8 in getParseData().
+    content <- gsub("\t", " ", content, fixed = TRUE)
     expr <- tryCatch(parse(text = content, keep.source = TRUE), error = function(e) NULL)
     if (!is.null(expr)) {
         parse_env <- function() {

--- a/R/hover.R
+++ b/R/hover.R
@@ -1,8 +1,8 @@
 hover_xpath <- paste(
-    "*[self::FUNCTION or self::OP-LAMBDA][following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]]/parent::expr",
-    "*[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and LEFT_ASSIGN/following-sibling::expr[@start > {start} or @end < {end}]]",
-    "*[RIGHT_ASSIGN/following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and RIGHT_ASSIGN/preceding-sibling::expr[@start > {start} or @end < {end}]]",
-    "*[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and EQ_ASSIGN/following-sibling::expr[@start > {start} or @end < {end}]]",
+    "(*|exprlist/*)[self::FUNCTION or self::OP-LAMBDA][following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]]/parent::expr",
+    "(*|exprlist/*)[LEFT_ASSIGN[preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and following-sibling::expr[@start > {start} or @end < {end}]]]",
+    "(*|exprlist/*)[RIGHT_ASSIGN[following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and preceding-sibling::expr[@start > {start} or @end < {end}]]]",
+    "(*|exprlist/*)[EQ_ASSIGN[preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and following-sibling::expr[@start > {start} or @end < {end}]]]",
     "forcond/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]",
     sep = "|")
 

--- a/R/hover.R
+++ b/R/hover.R
@@ -23,7 +23,7 @@ hover_reply <- function(id, uri, workspace, document, point) {
     resolved <- FALSE
 
     version <- workspace$get_parse_data(uri)$version
-    logger$info("hover:", list(uri = uri, version = version))
+    logger$info("hover:", list(uri = uri, version = version, token = token_result))
 
     xdoc <- workspace$get_parse_data(uri)$xml_doc
 
@@ -205,6 +205,9 @@ hover_reply <- function(id, uri, workspace, document, point) {
                 resolved <- TRUE
             } else if (token_name == "COMMENT") {
                 # comment
+                resolved <- TRUE
+            } else if (startsWith(token_name, "OP-")) {
+                # operators
                 resolved <- TRUE
             }
         }

--- a/R/hover.R
+++ b/R/hover.R
@@ -1,8 +1,8 @@
 hover_xpath <- paste(
-    "(*|exprlist/*)[self::FUNCTION or self::OP-LAMBDA][following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]]/parent::expr",
-    "(*|exprlist/*)[LEFT_ASSIGN[preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and following-sibling::expr[@start > {start} or @end < {end}]]]",
-    "(*|exprlist/*)[RIGHT_ASSIGN[following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and preceding-sibling::expr[@start > {start} or @end < {end}]]]",
-    "(*|exprlist/*)[EQ_ASSIGN[preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and following-sibling::expr[@start > {start} or @end < {end}]]]",
+    "(*|descendant-or-self::exprlist/*)[self::FUNCTION or self::OP-LAMBDA][following-sibling::SYMBOL_FORMALS[text() = '{token_quote}' and @line1 <= {row}]]/parent::expr",
+    "(*|descendant-or-self::exprlist/*)[LEFT_ASSIGN[preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and following-sibling::expr[@start > {start} or @end < {end}]]]",
+    "(*|descendant-or-self::exprlist/*)[RIGHT_ASSIGN[following-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and preceding-sibling::expr[@start > {start} or @end < {end}]]]",
+    "(*|descendant-or-self::exprlist/*)[EQ_ASSIGN[preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}] and following-sibling::expr[@start > {start} or @end < {end}]]]",
     "forcond/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]",
     sep = "|")
 

--- a/R/signature.R
+++ b/R/signature.R
@@ -1,6 +1,6 @@
 signature_xpath <- paste(
-    "*[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]/expr[FUNCTION | OP-LAMBDA]",
-    "*[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]/expr[FUNCTION | OP-LAMBDA]",
+    "(*|exprlist/*)[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]/expr[FUNCTION|OP-LAMBDA]",
+    "(*|exprlist/*)[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]/expr[FUNCTION|OP-LAMBDA]",
     sep = "|")
 
 #' the response to a textDocument/signatureHelp Request

--- a/R/signature.R
+++ b/R/signature.R
@@ -1,6 +1,6 @@
 signature_xpath <- paste(
-    "(*|exprlist/*)[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]/expr[FUNCTION|OP-LAMBDA]",
-    "(*|exprlist/*)[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]/expr[FUNCTION|OP-LAMBDA]",
+    "(*|descendant-or-self::exprlist/*)[LEFT_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]/expr[FUNCTION|OP-LAMBDA]",
+    "(*|descendant-or-self::exprlist/*)[EQ_ASSIGN/preceding-sibling::expr[count(*)=1]/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]]/expr[FUNCTION|OP-LAMBDA]",
     sep = "|")
 
 #' the response to a textDocument/signatureHelp Request

--- a/tests/testthat/test-definition.R
+++ b/tests/testthat/test-definition.R
@@ -161,6 +161,56 @@ test_that("Go to Definition works in scope with different assignment operators",
     expect_equal(result$range$end, list(line = 4, character = 11))
 })
 
+test_that("Go to Definition works in scope with semi-colons", {
+    skip_on_cran()
+    client <- language_client()
+
+    single_file <- withr::local_tempfile(fileext = ".R")
+    writeLines(c(
+        "my_fn <- function(var1) {",
+        "  var2 <- 1;",
+        "  var3 = 2;",
+        "  3 -> var4;",
+        "  for (var5 in 1:10) {",
+        "    var1 + var2 + var3 + var4 + var5;",
+        "  }",
+        "}",
+        "my_fn(1)"
+    ), single_file)
+
+    client %>% did_save(single_file)
+
+    # first query a known function to make sure the file is processed
+    result <- client %>% respond_definition(single_file, c(8, 0))
+
+    expect_equal(result$range$start, list(line = 0, character = 0))
+    expect_equal(result$range$end, list(line = 7, character = 1))
+
+    result <- client %>% respond_definition(single_file, c(5, 5))
+
+    expect_equal(result$range$start, list(line = 0, character = 18))
+    expect_equal(result$range$end, list(line = 0, character = 22))
+
+    result <- client %>% respond_definition(single_file, c(5, 12))
+
+    expect_equal(result$range$start, list(line = 1, character = 2))
+    expect_equal(result$range$end, list(line = 1, character = 11))
+
+    result <- client %>% respond_definition(single_file, c(5, 20))
+
+    expect_equal(result$range$start, list(line = 2, character = 2))
+    expect_equal(result$range$end, list(line = 2, character = 10))
+
+    result <- client %>% respond_definition(single_file, c(5, 26))
+
+    expect_equal(result$range$start, list(line = 3, character = 2))
+    expect_equal(result$range$end, list(line = 3, character = 11))
+
+    result <- client %>% respond_definition(single_file, c(5, 34))
+
+    expect_equal(result$range$start, list(line = 4, character = 7))
+    expect_equal(result$range$end, list(line = 4, character = 11))
+})
 
 test_that("Go to Definition works on both sides of assignment", {
     skip_on_cran()

--- a/tests/testthat/test-hover.R
+++ b/tests/testthat/test-hover.R
@@ -340,6 +340,33 @@ test_that("Hover works with local function", {
     ))
 })
 
+test_that("Hover on operator is ignored", {
+    skip_on_cran()
+    client <- language_client()
+
+    temp_file <- withr::local_tempfile(fileext = ".R")
+    writeLines(
+        c(
+            "for (ll in 1:3){",
+            " p = ll",
+            " I = array(0:0, dim=c(p,p))",
+            "}"
+        ),
+        temp_file
+    )
+
+    client %>% did_save(temp_file)
+
+    result <- client %>% respond_hover(temp_file, c(2, 22),
+        retry_when = function(result) length(result) > 0)
+    expect_equal(result, NULL)
+
+    result <- client %>% respond_hover(temp_file, c(2, 23))
+    expect_equal(result$range$start, list(line = 2, character = 22))
+    expect_equal(result$range$end, list(line = 2, character = 23))
+    expect_equal(result$contents, "```r\np = ll\n```")
+})
+
 test_that("Hover works across multiple files", {
     skip_on_cran()
     client <- language_client()

--- a/tests/testthat/test-hover.R
+++ b/tests/testthat/test-hover.R
@@ -92,6 +92,38 @@ test_that("Hover on variable works", {
     expect_equal(result$contents, "```r\nvar1 <- 0\n```")
 })
 
+test_that("Hover on variable with leading tabs works", {
+    skip_on_cran()
+    client <- language_client()
+
+    temp_file <- withr::local_tempfile(fileext = ".R")
+    writeLines(
+        c(
+            "index1 <- 1:10",
+            "\tindex1 + 1",
+            "\t\tindex1 + 2"
+        ),
+        temp_file
+    )
+
+    client %>% did_save(temp_file)
+
+    result <- client %>% respond_hover(temp_file, c(0, 1))
+    expect_equal(result$range$start, list(line = 0, character = 0))
+    expect_equal(result$range$end, list(line = 0, character = 6))
+    expect_equal(result$contents, "```r\nindex1 <- 1:10\n```")
+
+    result <- client %>% respond_hover(temp_file, c(1, 4))
+    expect_equal(result$range$start, list(line = 1, character = 1))
+    expect_equal(result$range$end, list(line = 1, character = 7))
+    expect_equal(result$contents, "```r\nindex1 <- 1:10\n```")
+
+    result <- client %>% respond_hover(temp_file, c(2, 7))
+    expect_equal(result$range$start, list(line = 2, character = 2))
+    expect_equal(result$range$end, list(line = 2, character = 8))
+    expect_equal(result$contents, "```r\nindex1 <- 1:10\n```")
+})
+
 test_that("Hover works in scope with different assignment operators", {
     skip_on_cran()
     client <- language_client()

--- a/tests/testthat/test-hover.R
+++ b/tests/testthat/test-hover.R
@@ -347,7 +347,7 @@ test_that("Hover on operator is ignored", {
     temp_file <- withr::local_tempfile(fileext = ".R")
     writeLines(
         c(
-            "for (ll in 1:3){",
+            "for (ll in 1:3) {",
             " p = ll",
             " I = array(0:0, dim=c(p,p))",
             "}"

--- a/tests/testthat/test-signature.R
+++ b/tests/testthat/test-signature.R
@@ -46,6 +46,25 @@ test_that("Signature of user function works", {
     expect_equal(result$signatures[[1]]$label, "foo(x, y = 3)")
 })
 
+test_that("Signature of user function works with semi-colon", {
+    skip_on_cran()
+    client <- language_client()
+
+    defn_file <- withr::local_tempfile(fileext = ".R")
+    temp_file <- withr::local_tempfile(fileext = ".R")
+
+    writeLines(c("foo <- function(x, y = 3) { x + y };"), defn_file)
+    writeLines(c("foo(3, "), temp_file)
+
+    client %>% did_save(defn_file) %>% did_save(temp_file)
+
+    result <- client %>% respond_signature(
+        temp_file, c(0, 7),
+        retry_when = function(result) length(result) == 0 || length(result$signatures) == 0)
+    expect_length(result$signatures, 1)
+    expect_equal(result$signatures[[1]]$label, "foo(x, y = 3)")
+})
+
 test_that("Signature in Rmarkdown works", {
     skip_on_cran()
     client <- language_client()


### PR DESCRIPTION
Closes #463 

Hovering on the left part of a symbol might capture the symbol token with `document$detect_token()` while the XPath captures the token on the left of the cursor, e.g. an operator, and thus shows the workspace definition of the captured token rather than the scope definition.

This PR:

* Ignores the operator captured by XPath.
* Replaces all `\t` with a space in `parse_document()` to make the width of tab consistent between LSP and `getParseData()`.
* Improves the XPaths of hover, definition, signature, and scope completion to support code with semi-colons where nested `exprlist` nodes appear in the XML syntax tree.