### PR TITLE
Fix hover on function defined with `EQ_ASSIGN`

### DIFF
--- a/R/hover.R
+++ b/R/hover.R
@@ -50,7 +50,7 @@ hover_reply <- function(id, uri, workspace, document, point) {
                     if (length(all_defs)) {
                         last_def <- all_defs[[length(all_defs)]]
                         def_func <- xml_find_first(last_def,
-                            "self::expr[LEFT_ASSIGN | RIGHT_ASSIGN | EQ_ASSIGN]/expr[FUNCTION | OP-LAMBDA]")
+                            "self::*[LEFT_ASSIGN | RIGHT_ASSIGN | EQ_ASSIGN]/expr[FUNCTION | OP-LAMBDA]")
                         if (length(def_func)) {
                             func_line1 <- as.integer(xml_attr(def_func, "line1"))
                             func_col1 <- as.integer(xml_attr(def_func, "col1"))

--- a/tests/testthat/test-hover.R
+++ b/tests/testthat/test-hover.R
@@ -32,7 +32,9 @@ test_that("Hover on user function works", {
     writeLines(
         c(
             "test1 <- function(x, y) x + 1",
-            "test1"
+            "test1",
+            "test2 = function(x, y) x - 1",
+            "test2"
         ),
         temp_file
     )
@@ -40,6 +42,37 @@ test_that("Hover on user function works", {
     client %>% did_save(temp_file)
 
     result <- client %>% respond_hover(temp_file, c(1, 3))
+    expect_length(result$contents, 1)
+    expect_equal(result$contents[1], "```r\ntest1(x, y)\n```")
+    expect_equal(result$range$end$character, 5)
+
+    result <- client %>% respond_hover(temp_file, c(3, 3))
+    expect_length(result$contents, 1)
+    expect_equal(result$contents[1], "```r\ntest2(x, y)\n```")
+    expect_equal(result$range$end$character, 5)
+})
+
+test_that("Hover on user function with multi-lined arguments works", {
+    skip_on_cran()
+    client <- language_client()
+
+    temp_file <- withr::local_tempfile(fileext = ".R")
+    writeLines(
+        c(
+            "test1 <- function(",
+            "  x, # arg 1",
+            "  y  # arg 2",
+            ") {",
+            "    x + y",
+            "}",
+            "test1"
+        ),
+        temp_file
+    )
+
+    client %>% did_save(temp_file)
+
+    result <- client %>% respond_hover(temp_file, c(6, 3))
     expect_length(result$contents, 1)
     expect_equal(result$contents[1], "```r\ntest1(x, y)\n```")
     expect_equal(result$range$end$character, 5)

--- a/tests/testthat/test-hover.R
+++ b/tests/testthat/test-hover.R
@@ -65,7 +65,14 @@ test_that("Hover on user function with multi-lined arguments works", {
             ") {",
             "    x + y",
             "}",
-            "test1"
+            "test1",
+            "test2 = function(",
+            "  x, # arg 1",
+            "  y  # arg 2",
+            ") {",
+            "    x + y",
+            "}",
+            "test2"
         ),
         temp_file
     )
@@ -75,6 +82,11 @@ test_that("Hover on user function with multi-lined arguments works", {
     result <- client %>% respond_hover(temp_file, c(6, 3))
     expect_length(result$contents, 1)
     expect_equal(result$contents[1], "```r\ntest1(x, y)\n```")
+    expect_equal(result$range$end$character, 5)
+
+    result <- client %>% respond_hover(temp_file, c(13, 3))
+    expect_length(result$contents, 1)
+    expect_equal(result$contents[1], "```r\ntest2(x, y)\n```")
     expect_equal(result$range$end$character, 5)
 })
 


### PR DESCRIPTION
Closes #466 

This PR fixes the XPath to extract function signature from the definition with `EQ_ASSIGN` by matching `expr/LEFT_ASSIGN` and `expr_or_assign_or_help/EQ_ASSIGN` in the XML parse tree.