### PR TITLE
Use internal `get_help` instead of repr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,6 @@ Imports:
     lintr (>= 2.0.1),
     parallel,
     R6 (>= 2.4.1),
-    repr (>= 1.1.0),
     roxygen2 (>= 7.0.0),
     stringi (>= 1.1.7),
     styler (>= 1.5.1),

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -97,7 +97,7 @@ PackageNamespace <- R6::R6Class("PackageNamespace",
             hfile <- utils::help((topic), (pkgname))
 
             if (length(hfile) > 0) {
-                doc <- utils:::.getHelpFile(hfile)
+                doc <- get_help_rd(hfile)
                 title_item <- find_doc_item(doc, "\\title")
                 description_item <- find_doc_item(doc, "\\description")
                 arguments_item <- find_doc_item(doc, "\\arguments")

--- a/R/utils.R
+++ b/R/utils.R
@@ -652,7 +652,7 @@ get_help <- function(hfile, format = c("html", "text")) {
         stop("Invalid format")
     }
 
-    result
+    enc2utf8(result)
 }
 
 convert_doc_to_markdown <- function(doc) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -623,10 +623,14 @@ find_doc_item <- function(doc, tag) {
     }
 }
 
+get_help_rd <- function(hfile) {
+    getNamespace("utils")$.getHelpFile(hfile)
+}
+
 get_help <- function(hfile, format = c("html", "text")) {
     format <- match.arg(format)
 
-    rd <- utils:::.getHelpFile(hfile)
+    rd <- get_help_rd(hfile)
     paths <- as.character(hfile)
 
     if (length(paths) == 0) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -636,12 +636,14 @@ get_help <- function(hfile, format = c("html", "text")) {
     pkgname <- basename(dirname(dirname(paths[[1]])))
 
     if (format == "html") {
-        result <- paste0(capture.output(
+        result <- paste0(utils::capture.output(
             tools::Rd2HTML(rd, package = pkgname, outputEncoding = "UTF-8")
         ), collapse = "\n")
         result <- gsub(".*<body>\n*(.*)\n*</body>.*", "\\1", result)
     } else if (format == "text") {
-        result <- tools::Rd2txt(rd, package = pkgname, outputEncoding = "UTF-8")
+        result <- paste0(utils::capture.output(
+            tools::Rd2txt(rd, package = pkgname, outputEncoding = "UTF-8")
+        ), collapse = "\n")
     } else {
         stop("Invalid format")
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -623,6 +623,32 @@ find_doc_item <- function(doc, tag) {
     }
 }
 
+get_help <- function(hfile, format = c("html", "text")) {
+    format <- match.arg(format)
+
+    rd <- utils:::.getHelpFile(hfile)
+    paths <- as.character(hfile)
+
+    if (length(paths) == 0) {
+        return(NULL)
+    }
+
+    pkgname <- basename(dirname(dirname(paths[[1]])))
+
+    if (format == "html") {
+        result <- paste0(capture.output(
+            tools::Rd2HTML(rd, package = pkgname, outputEncoding = "UTF-8")
+        ), collapse = "\n")
+        result <- gsub(".*<body>\n*(.*)\n*</body>.*", "\\1", result)
+    } else if (format == "text") {
+        result <- tools::Rd2txt(rd, package = pkgname, outputEncoding = "UTF-8")
+    } else {
+        stop("Invalid format")
+    }
+
+    result
+}
+
 convert_doc_to_markdown <- function(doc) {
     unlist(lapply(doc, function(item) {
         tag <- attr(item, "Rd_tag")

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -157,7 +157,7 @@ Workspace <- R6::R6Class("Workspace",
                     if (lsp_settings$get("rich_documentation") &&
                             requireNamespace("rmarkdown", quietly = TRUE) &&
                             rmarkdown::pandoc_available()) {
-                        html <- enc2utf8(repr::repr_html(hfile))
+                        html <- get_help(hfile, "html")
                         # Make header look prettier:
                         pattern <- "<table.*?<td>(.*?)\\s*{(.*?)}<\\/td>.*?<\\/table>\\n*<h2>\\s*(.*?)\\s*<\\/h2>"
                         replacement <- "<b>\\1</b> <i>{\\2}</i><p>\\3</p><hr/>"
@@ -166,7 +166,7 @@ Workspace <- R6::R6Class("Workspace",
                     }
 
                     if (is.null(result)) {
-                        result <- enc2utf8(repr::repr_text(hfile))
+                        result <- get_help(hfile, "text")
                     }
 
                     if (!is.null(result)) {


### PR DESCRIPTION
Closes #468 

This PR implements an internal `get_help()` to produce HTML or text from Rd. Then, repr is no longer imported.