### PR TITLE
Remove desc from imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Depends:
 Imports:
     callr (>= 3.0.0),
     collections (>= 0.3.0),
-    desc (>= 1.2.0),
     fs (>= 1.3.1),
     jsonlite (>= 1.6),
     lintr (>= 2.0.1),


### PR DESCRIPTION
Closes #470 

This PR removes `desc` from `Imports` as it is no longer used anywhere.