### PR TITLE
Unpublish diagnostics when disabled

### DIFF
--- a/R/handlers-general.R
+++ b/R/handlers-general.R
@@ -6,7 +6,7 @@
 on_initialize <- function(self, id, params) {
     trace <- params$trace
     if (!is.null(trace) && trace %in% c("messages", "verbose")) {
-        lsp_settings$set("debug", TRUE)
+        lsp_settings$set("trace", TRUE)
     }
 
     logger$info("session: ", list(

--- a/R/handlers-protocol.R
+++ b/R/handlers-protocol.R
@@ -1,8 +1,8 @@
-protocol_set_trace <- function(self, id, params) {
+protocol_set_trace <- function(self, params) {
     value <- params$value
     if (value == "off") {
-        lsp_settings$set("debug", FALSE)
+        lsp_settings$set("trace", FALSE)
     } else {
-        lsp_settings$set("debug", TRUE)
+        lsp_settings$set("trace", TRUE)
     }
 }

--- a/R/handlers-workspace.R
+++ b/R/handlers-workspace.R
@@ -26,6 +26,12 @@ workspace_did_change_configuration <- function(self, params) {
     logger$info("settings ", settings)
 
     lsp_settings$update_from_workspace(settings)
+
+    if (!lsp_settings$get("diagnostics")) {
+        for (uri in self$workspace$documents$keys()) {
+            diagnostics_callback(self, uri, NULL, list())
+        }
+    }
 }
 
 #' `workspace/didChangeWatchedFiles` notification handler

--- a/R/languagebase.R
+++ b/R/languagebase.R
@@ -158,6 +158,7 @@ LanguageBase <- R6::R6Class("LanguageBase",
         },
 
         handle_notification = function(notification) {
+            logger$info("receive notification: ", notification)
             method <- notification$method
             params <- notification$params
             if (method %in% names(self$notification_handlers)) {

--- a/R/log.R
+++ b/R/log.R
@@ -54,7 +54,14 @@ Logger <- R6::R6Class("Logger",
             log_write(..., log_file = lsp_settings$get("log_file"))
         },
         info = function(...) {
-            if (lsp_settings$get("debug")) log_write(..., log_file = lsp_settings$get("log_file"))
+            if (lsp_settings$get("debug") || lsp_settings$get("trace")) {
+                log_write(..., log_file = lsp_settings$get("log_file"))
+            }
+        },
+        trace = function(...) {
+            if (lsp_settings$get("trace")) {
+                log_write(..., log_file = lsp_settings$get("log_file"))
+            }
         }
     )
 )

--- a/R/settings.R
+++ b/R/settings.R
@@ -2,6 +2,7 @@ Settings <- R6::R6Class("Settings",
     private = list(
         settings = list(
             debug = FALSE,
+            trace = FALSE,
             log_file = NULL,
             diagnostics = TRUE,
             rich_documentation = TRUE,


### PR DESCRIPTION
Closes #497 

This PR unpublishes diagnostics of all workspace documents when diagnostics is disabled from client settings.

Also, this PR corrects the signature of `protocol_set_trace` to `protocol_set_trace(self, params)`. This handler turns on/off `debug` previously, which might cause conflicts with `r.lsp.debug` since if it is `true` but the language server trace is not turnoed on, then on the server side the debug will be enabled on startup but then disabled due to `setTrace` notification says `off`.

I add a new `trace` setting parallel with `debug` as well as `logger$trace` so that they have no conflicts.

`logger$info` works if either `debug` or `trace` is on, and `logger$trace` only works if `trace` is on.