### PR TITLE
Only call `fs::path_abs` with existing files

### DIFF
--- a/R/definition.R
+++ b/R/definition.R
@@ -66,8 +66,8 @@ definition_reply <- function(id, uri, workspace, document, point, rootPath) {
                     str_text <- tryCatch(as.character(parse(text = str_expr, keep.source = FALSE)),
                         error = function(e) NULL)
                     if (is.character(str_text)) {
-                        path <- fs::path_abs(str_text, rootPath)
-                        if (file.exists(path) && !dir.exists(path) && is_text_file(path)) {
+                        if (with_wd(rootPath, file.exists(str_text) && !dir.exists(str_text) && is_text_file(str_text))) {
+                            path <- fs::path_abs(str_text, rootPath)
                             result <- list(
                                 uri = path_to_uri(path),
                                 range = range(

--- a/R/link.R
+++ b/R/link.R
@@ -25,7 +25,7 @@ document_link_reply <- function(id, uri, workspace, document, rootPath) {
 
         if (length(str_texts)) {
             is_link <- with_wd(rootPath, file.exists(str_texts) & !dir.exists(str_texts))
-            link_paths <- path.expand(fs::path_abs(str_texts[is_link]))
+            link_paths <- path.expand(fs::path_abs(str_texts[is_link], rootPath))
             link_expr <- str_expr[is_link]
             is_raw_string <- grepl("^[rR]", link_expr)
             link_line1 <- str_line1[is_link]

--- a/R/link.R
+++ b/R/link.R
@@ -24,9 +24,8 @@ document_link_reply <- function(id, uri, workspace, document, rootPath) {
             error = function(e) NULL)
 
         if (length(str_texts)) {
-            paths <- fs::path_abs(str_texts, rootPath)
-            is_link <- file.exists(paths) & !dir.exists(paths)
-            link_paths <- path.expand(paths[is_link])
+            is_link <- with_wd(rootPath, file.exists(str_texts) & !dir.exists(str_texts))
+            link_paths <- path.expand(fs::path_abs(str_texts[is_link]))
             link_expr <- str_expr[is_link]
             is_raw_string <- grepl("^[rR]", link_expr)
             link_line1 <- str_line1[is_link]

--- a/R/utils.R
+++ b/R/utils.R
@@ -135,6 +135,15 @@ path_has_parent <- function(x, y) {
     }
 }
 
+with_wd <- function(wd, expr) {
+    if (is.null(wd)) {
+        wd <- getwd()
+    }
+    oldwd <- setwd(wd)
+    on.exit(setwd(oldwd))
+    expr
+}
+
 equal_position <- function(x, y) {
     x$line == y$line && x$character == y$character
 }


### PR DESCRIPTION
Due to https://github.com/r-lib/fs/issues/269, the known limitation of `fs` functions, it might make sense to only call `fs::path_abs` only with existing files so that long strings that are not file paths are not passed to the function.  In #502, it seems that even as we filter the string length, it might be possible that some long strings will still cause a problem. This PR checks the strings first and only call `fs::path_abs()` with existing file paths.

Here, the purpose we use `fs::path_abs()` is that we need to get an absolute path but not follow the symlinks.