### PR TITLE
Support arg completion for primitive functions

### DIFF
--- a/R/namespace.R
+++ b/R/namespace.R
@@ -86,7 +86,7 @@ PackageNamespace <- R6::R6Class("PackageNamespace",
             pkgname <- self$package_name
             ns <- asNamespace(pkgname)
             fn <- get(funct, envir = ns)
-            formals(fn)
+            formals(if (is.primitive(fn)) args(fn) else fn)
         },
 
         get_documentation = function(topic) {

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -238,7 +238,8 @@ test_that("Completion of function arguments works", {
         c(
             "str(obj",
             "utils::str(obj",
-            "str(stats::o"
+            "str(stats::o",
+            "seq.int(fr"
         ),
         temp_file)
 
@@ -255,6 +256,10 @@ test_that("Completion of function arguments works", {
     result <- client %>% respond_completion(temp_file, c(2, 12))
     arg_items <- result$items %>% keep(~.$label == "object")
     expect_length(arg_items, 0)
+
+    result <- client %>% respond_completion(temp_file, c(3, 10))
+    arg_items <- result$items %>% keep(~ .$label == "from")
+    expect_length(arg_items, 1)
 })
 
 test_that("Completion of function arguments is case insensitive", {
@@ -321,7 +326,8 @@ test_that("Completion of function arguments preserves the order of arguments", {
         c(
             "eval(",
             "formatC(",
-            "print.default("
+            "print.default(",
+            "seq.int("
         ),
         temp_file)
 
@@ -344,6 +350,12 @@ test_that("Completion of function arguments preserves the order of arguments", {
         keep(~ identical(.$data$type, "parameter")) %>%
         map_chr(~ .$label)
     expect_identical(arg_items, names(formals(print.default)))
+
+    result <- client %>% respond_completion(temp_file, c(3, 8))
+    arg_items <- result$items %>%
+        keep(~ identical(.$data$type, "parameter")) %>%
+        map_chr(~ .$label)
+    expect_identical(arg_items, names(formals(args(seq.int))))
 })
 
 test_that("Completion of local function arguments works", {


### PR DESCRIPTION
Currently, we use `formals()` to extract function arguments for completion. However, it does not work with primitive functions such as `sum` and `seq.int` by returning `NULL`.

Fortunately, `formals(args(primitive_fun))` works. This PR fixes this.