### PR TITLE
Update GItHub Actions version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,10 +38,10 @@ jobs:
       R_LANGSVR_POOL_SIZE: 1
       R_LANGSVR_TEST_FAST: NO
     steps:
-      - uses: actions/checkout@v1
-      - uses: r-lib/actions/setup-r@v1
+      - uses: actions/checkout@v3
+      - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: latest
+          r-version: release
       - name: Create log directory on Linux or macOS
         if: runner.os != 'Windows'
         run: mkdir -p $(dirname ${{ env.R_LANGSVR_LOG }})

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     container: rocker/tidyverse
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install apt-get dependencies
         run: |
           apt-get update

--- a/.github/workflows/rcmdcheck.yml
+++ b/.github/workflows/rcmdcheck.yml
@@ -37,10 +37,10 @@ jobs:
       R_LANGSVR_LOG: ${{ matrix.log_file }}
       R_LANGSVR_POOL_SIZE: 1
     steps:
-      - uses: actions/checkout@v1
-      - uses: r-lib/actions/setup-r@v1
+      - uses: actions/checkout@v3
+      - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: latest
+          r-version: release
       - name: Create log directory on Linux or macOS
         if: runner.os != 'Windows'
         run: mkdir -p $(dirname ${{ env.R_LANGSVR_LOG }})

--- a/.github/workflows/tagbot.yml
+++ b/.github/workflows/tagbot.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     container: rtagbot/tagbot:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: fetch all tags and branches
         run: git fetch --prune --unshallow --tags
       - name: check and publish release


### PR DESCRIPTION
It seems that the versions of `r-lib/actions/setup-r` and others are out of date.

Setting up dependabot will detect new releases and create PRs to help keep track of the latest versions.
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot