### PR TITLE
R universe

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ install.packages("languageserver")
 The latest development build of `languageserver` could be installed from our [r-universe](https://reditorsupport.r-universe.dev) repository:
 
 ```r
-install.packages("languageserver", repos="https://reditorsupport.r-universe.dev")
+install.packages("languageserver", repos = c(
+    reditorsupport = "https://reditorsupport.r-universe.dev",
+    getOption("repos")
+))
 ```
 
 ## Language Clients

--- a/README.md
+++ b/README.md
@@ -40,11 +40,10 @@ apk add --no-cache curl-dev g++ gcc libxml2-dev linux-headers make R R-dev
 install.packages("languageserver")
 ```
 
-The development version of `languageserver` could be installed by
+The latest development build of `languageserver` could be installed from our [r-universe](https://reditorsupport.r-universe.dev) repository:
 
 ```r
-# install.packages("remotes")
-remotes::install_github("REditorSupport/languageserver")
+install.packages("languageserver", repos="https://reditorsupport.r-universe.dev")
 ```
 
 ## Language Clients

--- a/README.md
+++ b/README.md
@@ -40,13 +40,20 @@ apk add --no-cache curl-dev g++ gcc libxml2-dev linux-headers make R R-dev
 install.packages("languageserver")
 ```
 
-The latest development build of `languageserver` could be installed from our [r-universe](https://reditorsupport.r-universe.dev) repository:
+To try the latest features, install the daily development build from our [r-universe](https://reditorsupport.r-universe.dev) repository:
 
 ```r
 install.packages("languageserver", repos = c(
     reditorsupport = "https://reditorsupport.r-universe.dev",
     getOption("repos")
 ))
+```
+
+Or install the latest development version from our GitHub repository:
+
+```r
+# install.packages("remotes")
+remotes::install_github("REditorSupport/languageserver")
 ```
 
 ## Language Clients

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![codecov](https://codecov.io/gh/REditorSupport/languageserver/branch/master/graph/badge.svg)](https://app.codecov.io/gh/REditorSupport/languageserver)
 [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/languageserver)](https://cran.r-project.org/package=languageserver)
 [![CRAN Downloads](http://cranlogs.r-pkg.org/badges/grand-total/languageserver)](https://cran.r-project.org/package=languageserver)
+[![r-universe](https://reditorsupport.r-universe.dev/badges/languageserver)](https://reditorsupport.r-universe.dev)
 
 `languageserver` is an implementation of the Microsoft's [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) for the language of R.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![codecov](https://codecov.io/gh/REditorSupport/languageserver/branch/master/graph/badge.svg)](https://app.codecov.io/gh/REditorSupport/languageserver)
 [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/languageserver)](https://cran.r-project.org/package=languageserver)
 [![CRAN Downloads](http://cranlogs.r-pkg.org/badges/grand-total/languageserver)](https://cran.r-project.org/package=languageserver)
-[![r-universe](https://reditorsupport.r-universe.dev/badges/languageserver)](https://reditorsupport.r-universe.dev)
+[![r-universe](https://reditorsupport.r-universe.dev/badges/languageserver)](https://reditorsupport.r-universe.dev/ui#package:languageserver)
 
 `languageserver` is an implementation of the Microsoft's [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) for the language of R.
 


### PR DESCRIPTION
Closes #536 

I set up a [repo](https://github.com/REditorSupport/universe) to contain the configuration of our [r-universe](https://reditorsupport.r-universe.dev) and updated README accordingly.

The repo that runs Github Actions to update and build the unvierse is <https://github.com/r-universe/reditorsupport>.
