### PR TITLE
minor refactoring: simplify the version number handling

### DIFF
--- a/tests/testthat/test-unicode-path.R
+++ b/tests/testthat/test-unicode-path.R
@@ -1,7 +1,6 @@
 test_that("Works with unicode path", {
     skip_on_cran()
-    if (.Platform$OS.type == "windows" &&
-          utils::compareVersion(paste0(R.version$major, ".", R.version$minor), "4.2") < 0) {
+    if (.Platform$OS.type == "windows" && getRversion() < R_system_version("4.2.0")) {
         skip_if_not(Sys.getenv("CI", "false") == "true")
         old_locale <- Sys.getlocale("LC_CTYPE")
         Sys.setlocale(locale = "chinese")


### PR DESCRIPTION
I believe this simple expression can be used because the `numeric_version` class object can compare version numbers separated by periods.