### PR TITLE
Support completion item labelDetails

### DIFF
--- a/R/completion.R
+++ b/R/completion.R
@@ -534,7 +534,7 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
 
 #' The response to a completionItem/resolve request
 #' @noRd
-completion_item_resolve_reply <- function(id, workspace, params) {
+completion_item_resolve_reply <- function(id, workspace, params, capabilities) {
     resolved <- FALSE
     if (is.null(params$data) || is.null(params$data$type)) {
     } else {
@@ -570,6 +570,17 @@ completion_item_resolve_reply <- function(id, workspace, params) {
                 }
             }
         } else if (params$data$type %in% c("constant", "function", "nonfunction", "lazydata")) {
+            if (isTRUE(capabilities$completionItem$labelDetailsSupport)) {
+                if (params$data$type == "function") {
+                    sig <- workspace$get_signature(params$label, params$data$package)
+                    if (!is.null(sig)) {
+                        params$labelDetails <- list(
+                            detail = substr(sig, nchar(params$label) + 1, nchar(sig))
+                        )
+                    }
+                }
+            }
+
             doc <- NULL
             doc_string <- NULL
             if (is.null(params$data$uri)) {

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -17,7 +17,8 @@ text_document_completion  <- function(self, id, params) {
 #' @noRd
 completion_item_resolve  <- function(self, id, params) {
     self$deliver(completion_item_resolve_reply(
-        id, self$workspace, params))
+        id, self$workspace, params,
+        self$ClientCapabilities$textDocument$completion))
 }
 
 #' `textDocument/hover` request handler


### PR DESCRIPTION
This PR adds support for [completionItemLabelDetails](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemLabelDetails) by showing function signature in completion list on resolve.

<img width="905" alt="image" src="https://user-images.githubusercontent.com/4662568/189411638-2681c930-181a-425d-a8b1-f3de29821211.png">
