### PR TITLE
Drop diagnostics on callback if disabled

### DIFF
--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -97,7 +97,8 @@ diagnose_file <- function(uri, content, is_rmarkdown = FALSE, globals = NULL, ca
 }
 
 diagnostics_callback <- function(self, uri, version, diagnostics) {
-    if (is.null(diagnostics) || !self$workspace$documents$has(uri)) return(NULL)
+    if (is.null(diagnostics) || !self$workspace$documents$has(uri) || !lsp_settings$get("diagnostics")) return(NULL)
+
     logger$info("diagnostics_callback called:", list(
         uri = uri,
         version = version,

--- a/R/handlers-workspace.R
+++ b/R/handlers-workspace.R
@@ -20,8 +20,8 @@ workspace_did_change_configuration <- function(self, params) {
     settings <- params$settings
 
     # flatten vscode r-lsp settings
-    vscode_setting <- tryCatch(settings$r$lsp, error = function(e) NULL)
-    settings <- if (is.null(vscode_setting)) settings else vscode_setting
+    vscode_settings <- settings$r$lsp
+    settings <- if (is.null(vscode_settings)) settings else vscode_settings
 
     logger$info("settings ", settings)
 


### PR DESCRIPTION
Closes https://github.com/REditorSupport/vscode-R/issues/1196

If the client opens a document before the language server receives settings from the client, diagnostics will be triggered (which is default). If diagnostics is disabled, `diagnostics_callback` will still publish the diagnostics results, which is undesirable.

This PR corrects this behavior by checking diagnostics settings again before publishing results. At this point, it is most likely for the server to have already received the settings from the client.