### PR TITLE
Avoid emitting a negative activeSignature

### DIFF
--- a/R/signature.R
+++ b/R/signature.R
@@ -18,7 +18,7 @@ signature_reply <- function(id, uri, workspace, document, point) {
     result <- document$detect_call(point)
 
     SignatureInformation <- list()
-    activeSignature <- -1
+    activeSignature <- NULL
     sig <- NULL
 
     if (nzchar(result$token)) {
@@ -107,11 +107,8 @@ signature_reply <- function(id, uri, workspace, document, point) {
         }
     }
 
-    Response$new(
-        id,
-        result = list(
-            signatures = SignatureInformation,
-            activeSignature = activeSignature
-        )
-    )
+    response_result <- list(signatures = SignatureInformation)
+    response_result$activeSignature <- activeSignature
+
+    Response$new(id, result = response_result)
 }


### PR DESCRIPTION
Discovered in https://github.com/helix-editor/helix/issues/5023, `languageserver` was emitting a `-1` to a field that has the type `uinteger`. 

Specifically, a negative `activeSignature` was being emitted by default when no signatures are provided to a `signatureHelp` request. The spec covers cases where an "out of range" value is emitted, but I don't think this is intended to cover negative values.

As `activeSignature` is an optional field, I changed it so that the default is to leave the field unspecified. This has resolved the issue in the helix text editor's LSP listener. 