### PR TITLE
Disable linters actions

### DIFF
--- a/R/code_action.R
+++ b/R/code_action.R
@@ -37,8 +37,19 @@ document_code_action_reply <- function(id, uri, workspace, document, range, cont
             ))
 
             if (!("*" %in% listed_linters)) {
-                if (grepl("#\\s*nolint\\s*:")) {
+                if (grepl("#\\s*nolint\\s*:", line)) {
                     # modify existing nolint directives
+                    nolint_start <- regexec("#\\s*nolint\\s*:", line)[[1]] - 1
+                    edit <- text_edit(range = range(
+                        start = position(
+                            item_range$end$row,
+                            nolint_start
+                        ),
+                        end = position(
+                            item_range$end$row,
+                            nchar(line)
+                        )
+                    ), "# nolint")
                 } else {
                     position <- document$to_lsp_position(
                         item_range$end$row,
@@ -66,8 +77,20 @@ document_code_action_reply <- function(id, uri, workspace, document, range, cont
             }
 
             if (!(item$source %in% listed_linters)) {
-                if (grepl("#\\s*nolint\\s*:?")) {
+                if (grepl("#\\s*nolint\\s*:.+\\.", line)) {
                     # modify existing nolint directives
+                    nolint_start <- regexec("#\\s*nolint\\s*:.+\\.", line)[[1]] - 1
+                    nolint_end <- nolint_start + attr(nolint_start, "match.length") - 1
+                    edit <- text_edit(range = range(
+                        start = position(
+                            item_range$end$row,
+                            nolint_end
+                        ),
+                        end = position(
+                            item_range$end$row,
+                            nolint_end
+                        )
+                    ), sprintf(", %s", item$source))
                 } else {
                     position <- document$to_lsp_position(
                         item_range$end$row,

--- a/tests/testthat/test-code-action.R
+++ b/tests/testthat/test-code-action.R
@@ -23,18 +23,20 @@ test_that("Code action works", {
   expect_equal(data$diagnostics[[2]]$message, "Put spaces around all infix operators.")
 
   result <- client %>% respond_code_action(temp_file, c(0, 0), c(0, 1))
-  expect_length(result, 1)
-  expect_equal(result[[1]]$title, "Disable all linters for this line")
+  expect_length(result, 2)
+  expect_length(result %>% keep(~ .$title == "Disable all linters for this line"), 1)
+  expect_length(result %>% keep(~ .$title == "Disable infix_spaces_linter for this line"), 1)
 
   result <- client %>% respond_code_action(temp_file, c(1, 0), c(1, 5), retry = FALSE)
   expect_length(result, 0)
 
   result <- client %>% respond_code_action(temp_file, c(2, 3), c(2, 4))
-  expect_length(result, 1)
-  expect_equal(result[[1]]$title, "Disable all linters for this line")
+  expect_length(result, 2)
+  expect_length(result %>% keep(~ .$title == "Disable all linters for this line"), 1)
+  expect_length(result %>% keep(~ .$title == "Disable infix_spaces_linter for this line"), 1)
 
   result <- client %>% respond_code_action(temp_file, c(0, 0), c(3, 0))
   expect_length(result, 2)
-  expect_equal(result[[1]]$title, "Disable all linters for this line")
-  expect_equal(result[[2]]$title, "Disable all linters for this line")
+  expect_length(result %>% keep(~ .$title == "Disable all linters for this line"), 1)
+  expect_length(result %>% keep(~ .$title == "Disable infix_spaces_linter for this line"), 1)
 })


### PR DESCRIPTION
Code actions are improved to support disable relevant linters when diagnostics are present.

<img width="650" alt="image" src="https://user-images.githubusercontent.com/4662568/209693844-1ca74bef-ae37-4120-8ca3-003331a33cd9.png">

When a code action of disabling a linter is chosen, its name will be added after `# nolint:` directive if exists.