### PR TITLE
Include all exports in namespace objects

### DIFF
--- a/R/namespace.R
+++ b/R/namespace.R
@@ -21,7 +21,7 @@ PackageNamespace <- R6::R6Class("PackageNamespace",
             objects <- union(names(ns), exports)
             private$objects <- sanitize_names(objects)
             is_function <- vapply(private$objects, function(x) {
-                is.function(get(x, envir = ns))
+                is.function(ns[[x]])
             }, logical(1L), USE.NAMES = FALSE)
             is_exported <- private$objects %in% exports
             private$functs <- private$objects[is_function]

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -21,7 +21,7 @@ PackageNamespace <- R6::R6Class("PackageNamespace",
             objects <- union(names(ns), exports)
             private$objects <- sanitize_names(objects)
             is_function <- vapply(private$objects, function(x) {
-                is.function(ns[[x]])
+                is.function(get0(x, ns))
             }, logical(1L), USE.NAMES = FALSE)
             is_exported <- private$objects %in% exports
             private$functs <- private$objects[is_function]

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -17,12 +17,13 @@ PackageNamespace <- R6::R6Class("PackageNamespace",
         initialize = function(pkgname) {
             self$package_name <- pkgname
             ns <- asNamespace(pkgname)
-            private$objects <- sanitize_names(objects(ns, all.names = TRUE))
+            exports <- getNamespaceExports(ns)
+            objects <- union(names(ns), exports)
+            private$objects <- sanitize_names(objects)
             is_function <- vapply(private$objects, function(x) {
-                obj <- tryCatch(get(x, envir = ns), error = function(e) NULL)
-                is.function(obj)
+                is.function(get(x, envir = ns))
             }, logical(1L), USE.NAMES = FALSE)
-            is_exported <- private$objects %in% sanitize_names(getNamespaceExports(ns))
+            is_exported <- private$objects %in% exports
             private$functs <- private$objects[is_function]
             private$nonfuncts <- private$objects[!is_function]
             private$exports <- private$objects[is_exported]

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -625,6 +625,24 @@ test_that("Completion of imported objects works inside a package", {
     expect_length(result$items %>% keep(~.$label == "lint_package"), 1)
 })
 
+test_that("Completion of re-exported objects works", {
+    skip_on_cran()
+    client <- language_client()
+
+    temp_file <- withr::local_tempfile(fileext = ".R")
+    writeLines(
+        c(
+            "purrr::set_names"
+        ),
+        temp_file)
+
+    client %>% did_save(temp_file)
+
+    result <- client %>% respond_completion(temp_file, c(0, 16))
+
+    expect_length(result$items %>% keep(~ .$label == "set_names"), 1)
+})
+
 test_that("Completion of tokens in document works", {
     skip_on_cran()
     client <- language_client()


### PR DESCRIPTION
Closes #590 

`objects(ns)` does not include all exports such as `rvest::read_html()` (from `xml2`) and `purrr:set_names()` (from `rlang`). This PR makes the `Namespace` object include all namespace objects and all exports (not necessarily live in the same namespace).