### PR TITLE
Add link to R-Nova extension for Nova

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ The following editors are supported by installing the corresponding extensions:
 
 - [BBEdit](https://www.barebones.com/products/bbedit/): preconfigured in version 14.0 and later; see the [BBEdit LSP support page](https://www.barebones.com/support/bbedit/lsp-notes.html) for complete details.
 
+- [Nova](https://nova.app): [R-Nova](https://github.com/jonclayden/R-Nova)
+
 ## Services Implemented
 
 `languageserver` is still under active development, the following services have been implemented:


### PR DESCRIPTION
This simple PR adds a link to the [R-Nova](https://github.com/jonclayden/R-Nova) extension for [Nova](https://nova.app) to the README, which uses the package for language server support in that editor.