### PR TITLE
Fix regex pattern to match chunk label after comma

### DIFF
--- a/R/section.R
+++ b/R/section.R
@@ -370,7 +370,7 @@ get_rmd_document_sections <- function(content, type = c("section", "chunk")) {
             end_line <- block_lines[[2 * i]]
             label <- stringi::stri_match_first_regex(
                 content[[start_line]],
-                "^\\s*```+\\s*\\{[a-zA-Z0-9_]+\\s*(([^,='\"]+)|'(.+)'|\"(.+)\")\\s*(,.+)?\\}\\s*$"
+                "^\\s*```+\\s*\\{[a-zA-Z0-9_]+[\\s,]*(([^,='\"]+)|'(.+)'|\"(.+)\")\\s*(,.+)?\\}\\s*$"
             )[1, 3:5]
             name <- label[!is.na(label)]
 

--- a/tests/testthat/test-symbol.R
+++ b/tests/testthat/test-symbol.R
@@ -271,6 +271,9 @@ test_that("Document section symbol works in Rmarkdown", {
         "```",
         "```{r eval=FALSE}",
         "test",
+        "```",
+        "```{r, chunk5}",
+        "test",
         "```"
     ), defn_file)
 
@@ -352,5 +355,9 @@ test_that("Document section symbol works in Rmarkdown", {
     expect_equivalent(
         result %>% detect(~ .$name == "unnamed-chunk-4") %>% pluck("location", "range"),
         range(position(40, 0), position(42, 3))
+    )
+    expect_equivalent(
+        result %>% detect(~ .$name == "chunk5") %>% pluck("location", "range"),
+        range(position(43, 0), position(45, 3))
     )
 })

--- a/tests/testthat/test-symbol.R
+++ b/tests/testthat/test-symbol.R
@@ -285,7 +285,7 @@ test_that("Document section symbol works in Rmarkdown", {
         c("section1", "subsection1", "unnamed-chunk-1",
             "f", "section2", "unnamed-chunk-2", "g",
             "unnamed-chunk-3", "chunk1", "p", "chunk1a", "chunk2", "chunk2a",
-            "chunk3", "chunk3a", "chunk4, new", "unnamed-chunk-4"
+            "chunk3", "chunk3a", "chunk4, new", "unnamed-chunk-4", "chunk5"
         )
     )
     expect_equivalent(
@@ -302,7 +302,7 @@ test_that("Document section symbol works in Rmarkdown", {
     )
     expect_equivalent(
         result %>% detect(~ .$name == "section2") %>% pluck("location", "range"),
-        range(position(12, 0), position(42, 3))
+        range(position(12, 0), position(45, 3))
     )
     expect_equivalent(
         result %>% detect(~ .$name == "g") %>% pluck("location", "range"),


### PR DESCRIPTION
Now '```{r, chunklabel}' is recognized.