### PR TITLE
Use code and codeDescription in diagnostic

### DIFF
--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -49,8 +49,12 @@ diagnostic_from_lint <- function(result, content) {
     list(
         range = diagnostic_range(result, content),
         severity = diagnostic_severity(result),
-        source = result$linter,
-        message = result$message
+        source = "lintr",
+        message = result$message,
+        code = result$linter,
+        codeDescription = list(
+            href = sprintf("https://lintr.r-lib.org/reference/%s.html", result$linter)
+        )
     )
 }
 


### PR DESCRIPTION
According to the spec of [Diagnostic](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic), `source` should be something like the name of the provider of diagnostics service, and `code` be the number or name of a specific lint problem. Also, `codeDescription` can be used to provide a url to make it easier for user to learn more about the specific linter.

![image](https://user-images.githubusercontent.com/4662568/233271203-88720e5d-4242-4d34-9c68-6fb3130910af.png)

![image](https://user-images.githubusercontent.com/4662568/233271309-7e3f8043-c671-404d-9904-2626ff2a158d.png)
