### PR TITLE
Fix path_from_uri

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -97,13 +97,17 @@ path_from_uri <- function(uri) {
     if (startsWith(uri, "file:///")) {
         start_char <- if (.Platform$OS.type == "windows") 9 else 8
         path <- substr(uri, start_char, nchar(uri))
-    } else if (startsWith(uri, "vscode-notebook-cell://")) {
-        # Windows: vscode-notebook-cell://C:/Users/Username/Documents/Notebooks/MyNotebook.ipynb#MyCellId
-        # Unix: vscode-notebook-cell:///home/username/Documents/Notebooks/MyNotebook.ipynb#MyCellId
+    } else if (startsWith(uri, "vscode-notebook-cell:")) {
+        # Windows: vscode-notebook-cell:/c:/Users/Username/Documents/Notebooks/MyNotebook.ipynb#MyCellId
+        # Unix: vscode-notebook-cell:/home/username/Documents/Notebooks/MyNotebook.ipynb#MyCellId
         # WSL: vscode-notebook-cell://wsl+ubuntu-20.04/home/username/Documents/Notebooks/MyNotebook.ipynb#MyCellId
-        path <- sub("^vscode-notebook-cell://(.+)#.*$", "\\1", uri)
-        if (.Platform$OS.type != "windows" && !startsWith(path, "/")) {
-            path <- sub("^[^/]+(/.+)$", "\\1", path)
+        if (.Platform$OS.type == "windows") {
+            path <- sub("^vscode-notebook-cell:/(.+)#.*$", "\\1", uri)
+        } else {
+            path <- sub("^vscode-notebook-cell:(.+)#.*$", "\\1", uri)
+            if (startsWith(path, "//")) {
+                path <- sub("^//[^/]+(/.+)$", "\\1", path)
+            }
         }
     } else {
         return("")


### PR DESCRIPTION
Looks like the vscode-notebook-cell uris look like the following on different platforms:

```
# Windows: vscode-notebook-cell:/c:/Users/Username/Documents/Notebooks/MyNotebook.ipynb#MyCellId
# Unix: vscode-notebook-cell:/home/username/Documents/Notebooks/MyNotebook.ipynb#MyCellId
# WSL: vscode-notebook-cell://wsl+ubuntu-20.04/home/username/Documents/Notebooks/MyNotebook.ipynb#MyCellId
```