### PR TITLE
Skip incomplete lines in on-type-formatting

### DIFF
--- a/R/formatting.R
+++ b/R/formatting.R
@@ -156,21 +156,24 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
     nexpr <- 0
     res <- tryCatchTimeout({
         while (start_line >= 1) {
-            expr <- tryCatch(parse(
-                text = content[start_line:end_line],
-                keep.source = FALSE),
-            error = function(e) NULL)
-            nexpr1 <- length(expr)
-            # stop backward parsing when
-            # 1. we have at least one expression parsed; and
-            # 2. we are entering the previous expression:
-            #    * if it is one-line expression, then we got 1 more expression.
-            #    * if it is multi-line expression, then we got no expression
-            if (nexpr > 0 && (nexpr1 > nexpr || nexpr1 == 0)) {
-                start_line <- start_line + 1
-                break
+            if (!grepl(incomplete_ending_regex, content[[start_line]])) {
+                expr <- tryCatch(parse(
+                    text = content[start_line:end_line],
+                    keep.source = FALSE),
+                    error = function(e) NULL
+                )
+                nexpr1 <- length(expr)
+                # stop backward parsing when
+                # 1. we have at least one expression parsed; and
+                # 2. we are entering the previous expression:
+                #    * if it is one-line expression, then we got 1 more expression.
+                #    * if it is multi-line expression, then we got no expression
+                if (nexpr > 0 && (nexpr1 > nexpr || nexpr1 == 0)) {
+                    start_line <- start_line + 1
+                    break
+                }
+                nexpr <- nexpr1
             }
-            nexpr <- nexpr1
             start_line <- start_line - 1
         }
         TRUE

--- a/R/section.R
+++ b/R/section.R
@@ -14,19 +14,6 @@ section_level_regex <- paste0(
     "[", paste0("\\", section_level_prefix, collapse = ""), "]*+"
 )
 
-# ?Syntax
-# : can indicate :: :::
-# - can indicate <-
-# > can indicate |>
-binary_opts <- c(
-    ":", "\\$", "@", "\\^",
-    "%[^#]*%", "\\+", "-", "\\*", "/",
-    "<", ">", "=", "!", "&", "\\|", "~",
-    "\\?"
-)
-binary_opts_regex <- paste0(binary_opts, collapse = "|")
-binary_opts_ending_regex <- paste0("^[^#]*(", binary_opts_regex, ")\\s*(#.*)?$")
-
 # options, number of blank lines to break sections or binary ranges
 # default 2L, the same with markdown
 nline_to_break_succession <- 2L

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,17 @@
+# ?Syntax
+# : can indicate :: :::
+# - can indicate <-
+# > can indicate |>
+binary_opts <- c(
+    ":", "\\$", "@", "\\^",
+    "%[^#]*%", "\\+", "-", "\\*", "/",
+    "<", ">", "=", "!", "&", "\\|", "~",
+    "\\?"
+)
+binary_opts_regex <- paste0(binary_opts, collapse = "|")
+binary_opts_ending_regex <- paste0("^[^#]*(", binary_opts_regex, ")\\s*(#.*)?$")
+incomplete_ending_regex <- paste0("^[^#]*(", binary_opts_regex, "|,)\\s*(#.*)?$")
+
 #' Merge two lists
 #'
 #' @noRd


### PR DESCRIPTION
This PR skips incomplete lines in the backward parsing in on-type-formatting.