### PR TITLE
fix: avoid rlang formatting crash in callr subprocess (#723)

### DIFF
--- a/R/task.R
+++ b/R/task.R
@@ -261,9 +261,10 @@ TaskManager <- R6::R6Class("TaskManager",
 )
 
 package_call <- function(target) {
-    func <- call(":::", as.name("languageserver"), substitute(target))
-    target <- eval(substitute(function(...) func(...), list(func = func)))
-    target
+    target_name <- as.character(substitute(target))
+    eval(bquote(
+        function(...) get(.(target_name), envir = asNamespace("languageserver"))(...)
+    ), envir = baseenv())
 }
 
 create_task <- function(target, args, callback = NULL, error = NULL, delay = 0) {


### PR DESCRIPTION
Fixes #723.

**Description:**

When launching a project, users experienced an error in all `.R` files:
```
Failed to run diagnostics: ! in callr subprocess.
Caused by error in `call[[1L]]`:
! object of type 'symbol' is not subsettable
```

This crash occurred because `rlang` error formatting fails when trying to subset a call object containing the `:::` symbol (which was previously constructed by `package_call` to run tasks in the `callr` subprocess).

To avoid this, `package_call` has been updated to use `bquote` and `get()` to resolve the target function from the `languageserver` namespace directly at evaluation time, instead of building an explicit `:::` call. Furthermore, by evaluating the `bquote` expression within `baseenv()`, we prevent the returned closure from capturing the caller's environment. This avoids massive memory overhead and test timeouts during `R CMD check` serialization via `callr`.