### PR TITLE
feat: add stringr to Suggests for roxygen2 8.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,8 @@ Suggests:
     purrr (>= 0.3.3),
     testthat (>= 2.1.0),
     withr (>= 2.3.0),
-    rmarkdown (>= 2.0)
+    rmarkdown (>= 2.0),
+    stringr
 ByteCompile: yes
 Encoding: UTF-8
 NeedsCompilation: yes


### PR DESCRIPTION
This PR adds stringr to Suggests to fix a failure with roxygen2 8.0.0 on CI.