### PR TITLE
Added missing libuv dependency to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ A few dependencies are required beforehand:
 
 ```bash
 # On Debian, Ubuntu, etc.
-apt install --assume-yes --no-install-recommends build-essential libcurl4-openssl-dev libssl-dev libxml2-dev r-base
+apt install --assume-yes --no-install-recommends build-essential libcurl4-openssl-dev libssl-dev libxml2-dev libuv1-dev r-base
 
 # On Fedora, Centos, etc.
-dnf install --assumeyes --setopt=install_weak_deps=False @development-tools libcurl-devel libxml2-devel openssl-devel R
+dnf install --assumeyes --setopt=install_weak_deps=False @development-tools libcurl-devel libxml2-devel openssl-devel libuv-devel R
 
 # On Alpine
 apk add --no-cache curl-dev g++ gcc libxml2-dev linux-headers make R R-dev


### PR DESCRIPTION
An error occurred while installing on Fedora 44 due to the missing libuv dependency.
After the dependency installation everything worked fine.
See error below.

Command used for the installation: `install.packages("languageserver")`

```
* installing *source* package ‘fs’ ...
** this is package ‘fs’ version ‘2.1.0’
** package ‘fs’ successfully unpacked and MD5 sums checked
** using staged installation
Package libuv was not found in the pkg-config search path.
Perhaps you should add the directory containing `libuv.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libuv' not found
Using PKG_CFLAGS=
Using PKG_LIBS=-luv
--------------------------- [CONFIGURE] --------------------------------
Configuration failed because libuv was not found. Try installing:
 * deb: libuv1-dev (Debian, Ubuntu, etc)
 * rpm: libuv-devel (Fedora, EPEL)
 * brew: libuv (OSX)
Alternatively set environment variable USE_BUNDLED_LIBUV=1 to build a static
version of libuv that is included with this package.
-------------------------- [ERROR MESSAGE] ---------------------------
<stdin>:1:10: fatal error: uv.h: File o directory non esistente
compilation terminated.
--------------------------------------------------------------------
ERROR: configuration failed for package ‘fs’
* removing ‘/home/alessandro/R/x86_64-redhat-linux-gnu-library/4.6/fs’
ERROR: dependency ‘fs’ is not available for package ‘pkgload’
Perhaps try a variation of:
install.packages('fs')
* removing ‘/home/alessandro/R/x86_64-redhat-linux-gnu-library/4.6/pkgload’
ERROR: dependency ‘pkgload’ is not available for package ‘roxygen2’
Perhaps try a variation of:
install.packages('pkgload')
* removing ‘/home/alessandro/R/x86_64-redhat-linux-gnu-library/4.6/roxygen2’
ERROR: dependencies ‘fs’, ‘roxygen2’ are not available for package ‘languageserver’
Perhaps try a variation of:
install.packages(c('fs', 'roxygen2'))
* removing ‘/home/alessandro/R/x86_64-redhat-linux-gnu-library/4.6/languageserver’
```