### PR TITLE
`xdoc_find_token()` now prefers `STR_CONST` at ambiguous punctuation/string boundaries

### DIFF
--- a/R/type_hierarchy.R
+++ b/R/type_hierarchy.R
@@ -151,7 +151,7 @@ detect_type_definition <- function(uri, workspace, document, point, token_text) 
             "ancestor::expr[.//SYMBOL_FUNCTION_CALL[text() = 'R6Class']]")
         if (length(r6_expr)) {
             class_str <- xml_find_first(r6_expr,
-                ".//SYMBOL_FUNCTION_CALL[text() = 'R6Class']/following-sibling::expr[1]//STR_CONST[1]")
+                ".//SYMBOL_FUNCTION_CALL[text() = 'R6Class']/parent::expr/following-sibling::expr[1]//STR_CONST[1]")
             class_sym <- xml_find_first(r6_expr,
                 ".//LEFT_ASSIGN/preceding-sibling::expr[1]/SYMBOL | .//EQ_ASSIGN/preceding-sibling::expr[1]/SYMBOL")
             class_name_value <- NULL
@@ -239,7 +239,7 @@ detect_r6class <- function(scopes, token_text, document, uri) {
 
     # Pattern: R6Class("ClassName", ...) with cursor on string
     xpath <- glue(
-        "//SYMBOL_FUNCTION_CALL[text() = 'R6Class']/following-sibling::expr[1]//STR_CONST[contains(text(), {dquote}{token_text}{dquote})]",
+        "//SYMBOL_FUNCTION_CALL[text() = 'R6Class']/parent::expr/following-sibling::expr[1]//STR_CONST[contains(text(), {dquote}{token_text}{dquote})]",
         token_text = token_text,
         dquote = '"'
     )
@@ -268,7 +268,7 @@ detect_r6class <- function(scopes, token_text, document, uri) {
 detect_s4class <- function(scopes, token_text, document, uri) {
     # Look for setClass pattern - string containing the class name
     xpath <- glue(
-        "//SYMBOL_FUNCTION_CALL[text() = 'setClass']/following-sibling::expr[1]//STR_CONST[contains(text(), {dquote}{token_text}{dquote})]",
+        "//SYMBOL_FUNCTION_CALL[text() = 'setClass']/parent::expr/following-sibling::expr[1]//STR_CONST[contains(text(), {dquote}{token_text}{dquote})]",
         token_text = token_text,
         dquote = '"'
     )
@@ -298,7 +298,7 @@ detect_s4class <- function(scopes, token_text, document, uri) {
 detect_refclass <- function(scopes, token_text, document, uri) {
     # Look for setRefClass pattern - string containing the class name
     xpath <- glue(
-        "//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/following-sibling::expr[1]//STR_CONST[contains(text(), {dquote}{token_text}{dquote})]",
+        "//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/parent::expr/following-sibling::expr[1]//STR_CONST[contains(text(), {dquote}{token_text}{dquote})]",
         token_text = token_text,
         dquote = '"'
     )
@@ -356,7 +356,7 @@ detect_s3class <- function(scopes, token_text, document, uri) {
 
     # Pattern: setMethod("generic", "ClassName", function(...))
     xpath <- glue(
-        "//SYMBOL_FUNCTION_CALL[text() = 'setMethod']/following-sibling::expr[STR_CONST[contains(text(), {dquote}{token_text}{dquote})]]",
+        "//SYMBOL_FUNCTION_CALL[text() = 'setMethod']/parent::expr/following-sibling::expr[STR_CONST[contains(text(), {dquote}{token_text}{dquote})]]",
         token_text = token_text,
         dquote = '"'
     )
@@ -508,12 +508,12 @@ find_s4_supertypes <- function(doc, xdoc, class_name, uri) {
 
     # Look for setClass calls with this class name
     all_setclass_calls <- xml_find_all(xdoc,
-        "//SYMBOL_FUNCTION_CALL[text() = 'setClass']/ancestor::expr[1]")
+        "//SYMBOL_FUNCTION_CALL[text() = 'setClass']/ancestor::expr[.//OP-LEFT-PAREN][1]")
 
     for (setclass_call in all_setclass_calls) {
         # Get the first string constant (the class name)
         first_str <- xml_find_first(setclass_call,
-            ".//SYMBOL_FUNCTION_CALL[text() = 'setClass']/following-sibling::expr[1]//STR_CONST[1]")
+            ".//SYMBOL_FUNCTION_CALL[text() = 'setClass']/parent::expr/following-sibling::expr[1]//STR_CONST[1]")
 
         if (!length(first_str)) next
         call_class_name <- gsub('["\'`]', "", xml_text(first_str))
@@ -522,7 +522,7 @@ find_s4_supertypes <- function(doc, xdoc, class_name, uri) {
 
         # Now find the contains parameter
         contains_param <- xml_find_first(setclass_call,
-            ".//SYMBOL[text() = 'contains']/following-sibling::*[1][self::EQ_ASSIGN]/following-sibling::expr[1]")
+            "./SYMBOL_SUB[text() = 'contains']/following-sibling::*[1][self::EQ_SUB]/following-sibling::expr[1]")
 
         if (length(contains_param) > 0) {
             # Could contain one or more class names as strings
@@ -553,12 +553,12 @@ find_refclass_supertypes <- function(doc, xdoc, class_name, uri) {
 
     # Look for setRefClass calls with this class name
     all_setrefclass_calls <- xml_find_all(xdoc,
-        "//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/ancestor::expr[1]")
+        "//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/ancestor::expr[.//OP-LEFT-PAREN][1]")
 
     for (setrefclass_call in all_setrefclass_calls) {
         # Get the first string constant (the class name)
         first_str <- xml_find_first(setrefclass_call,
-            ".//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/following-sibling::expr[1]//STR_CONST[1]")
+            ".//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/parent::expr/following-sibling::expr[1]//STR_CONST[1]")
 
         if (!length(first_str)) next
         call_class_name <- gsub('["\'`]', "", xml_text(first_str))
@@ -567,7 +567,7 @@ find_refclass_supertypes <- function(doc, xdoc, class_name, uri) {
 
         # Now find the contains parameter
         contains_param <- xml_find_first(setrefclass_call,
-            ".//SYMBOL[text() = 'contains']/following-sibling::*[1][self::EQ_ASSIGN]/following-sibling::expr[1]")
+            "./SYMBOL_SUB[text() = 'contains']/following-sibling::*[1][self::EQ_SUB]/following-sibling::expr[1]")
 
         if (length(contains_param) > 0) {
             parent_strs <- xml_find_all(contains_param, ".//STR_CONST")
@@ -745,12 +745,12 @@ find_s4_subtypes <- function(doc, xdoc, parent_name, uri) {
 
     # Look for all setClass calls that have contains = parent_name
     all_setclass_calls <- xml_find_all(xdoc,
-        "//SYMBOL_FUNCTION_CALL[text() = 'setClass']/ancestor::expr[1]")
+        "//SYMBOL_FUNCTION_CALL[text() = 'setClass']/ancestor::expr[.//OP-LEFT-PAREN][1]")
 
     for (setclass_call in all_setclass_calls) {
         # Check if this class contains parent_name
         contains_param <- xml_find_first(setclass_call,
-            ".//SYMBOL[text() = 'contains']/following-sibling::*[1][self::EQ_ASSIGN]/following-sibling::expr[1]")
+            "./SYMBOL_SUB[text() = 'contains']/following-sibling::*[1][self::EQ_SUB]/following-sibling::expr[1]")
 
         if (!length(contains_param)) next
 
@@ -768,7 +768,7 @@ find_s4_subtypes <- function(doc, xdoc, parent_name, uri) {
 
         # Get the class name from the first string constant in the setClass call
         class_str <- xml_find_first(setclass_call,
-            ".//SYMBOL_FUNCTION_CALL[text() = 'setClass']/following-sibling::expr[1]//STR_CONST")
+            ".//SYMBOL_FUNCTION_CALL[text() = 'setClass']/parent::expr/following-sibling::expr[1]//STR_CONST[1]")
 
         if (length(class_str)) {
             class_name <- gsub('["\'`]', "", xml_text(class_str))
@@ -795,12 +795,12 @@ find_refclass_subtypes <- function(doc, xdoc, parent_name, uri) {
 
     # Look for all setRefClass calls that have contains = parent_name
     all_setrefclass_calls <- xml_find_all(xdoc,
-        "//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/ancestor::expr[1]")
+        "//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/ancestor::expr[.//OP-LEFT-PAREN][1]")
 
     for (setrefclass_call in all_setrefclass_calls) {
         # Check if this class contains parent_name
         contains_param <- xml_find_first(setrefclass_call,
-            ".//SYMBOL[text() = 'contains']/following-sibling::*[1][self::EQ_ASSIGN]/following-sibling::expr[1]")
+            "./SYMBOL_SUB[text() = 'contains']/following-sibling::*[1][self::EQ_SUB]/following-sibling::expr[1]")
 
         if (!length(contains_param)) next
 
@@ -818,7 +818,7 @@ find_refclass_subtypes <- function(doc, xdoc, parent_name, uri) {
 
         # Get the class name from the first string constant in the setRefClass call
         class_str <- xml_find_first(setrefclass_call,
-            ".//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/following-sibling::expr[1]//STR_CONST")
+            ".//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/parent::expr/following-sibling::expr[1]//STR_CONST[1]")
 
         if (length(class_str)) {
             class_name <- gsub('["\'`]', "", xml_text(class_str))
@@ -862,6 +862,16 @@ get_element_range <- function(document, element) {
 
         if (any(is.na(c(line1, col1, line2, col2)))) {
             return(NULL)
+        }
+
+        if (xml_name(element) == "STR_CONST") {
+            text <- xml_text(element)
+            first_char <- substr(text, 1, 1)
+            last_char <- substr(text, nchar(text), nchar(text))
+            if (first_char %in% c("\"", "'") && last_char == first_char) {
+                col1 <- col1 + 1
+                col2 <- col2 - 1
+            }
         }
 
         range(
@@ -1066,14 +1076,14 @@ extract_s4_members <- function(document, xdoc, def) {
     # Look for setClass calls with this class name
     all_setclass_calls <- xml_find_all(
         xdoc,
-        "//SYMBOL_FUNCTION_CALL[text() = 'setClass']/ancestor::expr[1]"
+        "//SYMBOL_FUNCTION_CALL[text() = 'setClass']/ancestor::expr[.//OP-LEFT-PAREN][1]"
     )
 
     for (setclass_call in all_setclass_calls) {
         # Get the first string constant (the class name)
         first_str <- xml_find_first(
             setclass_call,
-            ".//SYMBOL_FUNCTION_CALL[text() = 'setClass']/following-sibling::expr[1]//STR_CONST[1]"
+            ".//SYMBOL_FUNCTION_CALL[text() = 'setClass']/parent::expr/following-sibling::expr[1]//STR_CONST[1]"
         )
 
         if (!length(first_str)) next
@@ -1084,12 +1094,13 @@ extract_s4_members <- function(document, xdoc, def) {
         # Extract slots/representation
         slots_node <- xml_find_first(
             setclass_call,
-            ".//SYMBOL[text() = 'slots' or text() = 'representation']/following-sibling::*[1][self::EQ_ASSIGN]/following-sibling::expr[1]"
+            "./SYMBOL_SUB[text() = 'slots' or text() = 'representation']/following-sibling::*[1][self::EQ_SUB]/following-sibling::expr[1]"
         )
 
         if (length(slots_node)) {
             # Find all named slots
-            slot_names <- xml_find_all(slots_node, ".//SYMBOL_SUB | .//STR_CONST")
+            slot_names <- xml_find_all(slots_node,
+                ".//SYMBOL_SUB[following-sibling::*[1][self::EQ_SUB]] | .//STR_CONST[following-sibling::*[1][self::EQ_SUB]]")
             for (slot_name_node in slot_names) {
                 slot_name_text <- xml_text(slot_name_node)
                 slot_name <- gsub('["\047`]', "", slot_name_text)
@@ -1113,14 +1124,14 @@ extract_s4_members <- function(document, xdoc, def) {
     # Look for methods defined for this class using setMethod
     all_setmethod_calls <- xml_find_all(
         xdoc,
-        "//SYMBOL_FUNCTION_CALL[text() = 'setMethod']/ancestor::expr[1]"
+        "//SYMBOL_FUNCTION_CALL[text() = 'setMethod']/ancestor::expr[.//OP-LEFT-PAREN][1]"
     )
 
     for (setmethod_call in all_setmethod_calls) {
         # Check if this method is for our class
         class_strs <- xml_find_all(
             setmethod_call,
-            ".//SYMBOL_FUNCTION_CALL[text() = 'setMethod']/following-sibling::expr//STR_CONST"
+            ".//SYMBOL_FUNCTION_CALL[text() = 'setMethod']/parent::expr/following-sibling::expr//STR_CONST"
         )
 
         found_class <- FALSE
@@ -1162,14 +1173,14 @@ extract_refclass_members <- function(document, xdoc, def) {
     # Look for setRefClass calls with this class name
     all_setrefclass_calls <- xml_find_all(
         xdoc,
-        "//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/ancestor::expr[1]"
+        "//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/ancestor::expr[.//OP-LEFT-PAREN][1]"
     )
 
     for (setrefclass_call in all_setrefclass_calls) {
         # Get the first string constant (the class name)
         first_str <- xml_find_first(
             setrefclass_call,
-            ".//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/following-sibling::expr[1]//STR_CONST[1]"
+            ".//SYMBOL_FUNCTION_CALL[text() = 'setRefClass']/parent::expr/following-sibling::expr[1]//STR_CONST[1]"
         )
 
         if (!length(first_str)) next
@@ -1180,13 +1191,14 @@ extract_refclass_members <- function(document, xdoc, def) {
         # Extract fields
         fields_node <- xml_find_first(
             setrefclass_call,
-            ".//SYMBOL[text() = 'fields']/following-sibling::*[1][self::EQ_ASSIGN]/following-sibling::expr[1]"
+            "./SYMBOL_SUB[text() = 'fields']/following-sibling::*[1][self::EQ_SUB]/following-sibling::expr[1]"
         )
 
         if (length(fields_node)) {
-            field_names <- xml_find_all(fields_node, ".//SYMBOL_SUB")
+            field_names <- xml_find_all(fields_node,
+                "./SYMBOL_SUB[following-sibling::*[1][self::EQ_SUB]] | ./STR_CONST[following-sibling::*[1][self::EQ_SUB]]")
             for (field_name_node in field_names) {
-                field_name <- xml_text(field_name_node)
+                field_name <- gsub('["\047`]', "", xml_text(field_name_node))
                 field_range <- get_element_range(document, field_name_node)
 
                 if (!is.null(field_range)) {
@@ -1204,13 +1216,14 @@ extract_refclass_members <- function(document, xdoc, def) {
         # Extract methods
         methods_node <- xml_find_first(
             setrefclass_call,
-            ".//SYMBOL[text() = 'methods']/following-sibling::*[1][self::EQ_ASSIGN]/following-sibling::expr[1]"
+            "./SYMBOL_SUB[text() = 'methods']/following-sibling::*[1][self::EQ_SUB]/following-sibling::expr[1]"
         )
 
         if (length(methods_node)) {
-            method_names <- xml_find_all(methods_node, ".//SYMBOL_SUB")
+            method_names <- xml_find_all(methods_node,
+                "./SYMBOL_SUB[following-sibling::*[1][self::EQ_SUB]] | ./STR_CONST[following-sibling::*[1][self::EQ_SUB]]")
             for (method_name_node in method_names) {
-                method_name <- xml_text(method_name_node)
+                method_name <- gsub('["\047`]', "", xml_text(method_name_node))
                 method_range <- get_element_range(document, method_name_node)
 
                 if (!is.null(method_range)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -659,7 +659,21 @@ xdoc_find_enclosing_scopes <- function(x, line, col, top = FALSE) {
 xdoc_find_token <- function(x, line, col) {
     xpath <- glue("//*[not(*)][(@line1 < {line} or (@line1 = {line} and @col1 <= {col})) and (@line2 > {line} or (@line2 = {line} and @col2 >= {col}-1))]",
         line = line, col = col)
-    xml_find_first(x, xpath)
+    tokens <- xml_find_all(x, xpath)
+    if (!length(tokens)) {
+        return(xml_find_first(x, xpath))
+    }
+
+    # A cursor at the boundary before a string literal can match both the
+    # literal and the preceding punctuation. Prefer the string in this case,
+    # while retaining document order for other token boundaries.
+    token_names <- xml_name(tokens)
+    is_string <- token_names == "STR_CONST"
+    if (any(is_string)) {
+        return(tokens[is_string][[1]])
+    }
+
+    tokens[[1]]
 }
 
 xml_single_quote <- function(x) {

--- a/tests/testthat/test-selection.R
+++ b/tests/testthat/test-selection.R
@@ -47,6 +47,24 @@ test_that("Selection range works with single position", {
   )))))
 })
 
+test_that("Selection range resolves content adjacent to punctuation", {
+  skip_on_cran()
+  client <- language_client()
+
+  defn_file <- withr::local_tempfile(fileext = ".R")
+  writeLines('setClass("BaseEntity")', defn_file)
+
+  client %>% did_open(defn_file)
+  result <- client %>% respond_selection_range(defn_file, list(
+    list(line = 0, character = 9)
+  ))
+
+  expect_equal(result[[1]]$range, list(
+    start = list(line = 0L, character = 9L),
+    end = list(line = 0L, character = 21L)
+  ))
+})
+
 
 test_that("Selection range works with multiple positions", {
   skip_on_cran()

--- a/tests/testthat/test-type-hierarchy-parsing.R
+++ b/tests/testthat/test-type-hierarchy-parsing.R
@@ -1,0 +1,65 @@
+parse_type_hierarchy_xdoc <- function(code) {
+    parsed <- parse(text = code, keep.source = TRUE)
+    xml2::read_xml(xmlparsedata::xml_parse_data(parsed))
+}
+
+test_that("S4 hierarchy parsing handles named arguments", {
+    code <- c(
+        'setClass("BaseEntity")',
+        'setClass("User", contains = "BaseEntity", slots = c(name = "character"))',
+        'setClass("AdminUser", contains = "User")',
+        'setMethod("show", "User", function(object) object)'
+    )
+    document <- Document$new("file:///s4.R", content = code)
+    xdoc <- parse_type_hierarchy_xdoc(code)
+
+    definition <- detect_s4class(xdoc, "User", document, document$uri)
+    expect_equal(definition$range, range(position(1, 10), position(1, 14)))
+
+    supertypes <- find_s4_supertypes(document, xdoc, "User", document$uri)
+    expect_equal(map_chr(supertypes, "name"), "BaseEntity")
+    expect_equal(supertypes[[1]]$range, range(position(1, 29), position(1, 39)))
+
+    subtypes <- find_s4_subtypes(document, xdoc, "User", document$uri)
+    expect_equal(map_chr(subtypes, "name"), "AdminUser")
+    expect_equal(subtypes[[1]]$range, range(position(2, 10), position(2, 19)))
+
+    members <- extract_s4_members(
+        document, xdoc, list(name = "User", type = "S4")
+    )
+    expect_setequal(map_chr(members, "name"), c("name", "show"))
+})
+
+test_that("RefClass hierarchy parsing handles named arguments", {
+    code <- c(
+        'setRefClass("BaseReference")',
+        paste0(
+            'setRefClass("UserReference", contains = "BaseReference", ',
+            'fields = list(name = "character", metadata = list(source = "character")), ',
+            'methods = list(greet = function() paste("hi", sep = "-")))'
+        ),
+        'setRefClass("AdminReference", contains = "UserReference")'
+    )
+    document <- Document$new("file:///refclass.R", content = code)
+    xdoc <- parse_type_hierarchy_xdoc(code)
+
+    definition <- detect_refclass(xdoc, "UserReference", document, document$uri)
+    expect_equal(definition$range, range(position(1, 13), position(1, 26)))
+
+    supertypes <- find_refclass_supertypes(
+        document, xdoc, "UserReference", document$uri
+    )
+    expect_equal(map_chr(supertypes, "name"), "BaseReference")
+    expect_equal(supertypes[[1]]$range, range(position(1, 41), position(1, 54)))
+
+    subtypes <- find_refclass_subtypes(
+        document, xdoc, "UserReference", document$uri
+    )
+    expect_equal(map_chr(subtypes, "name"), "AdminReference")
+    expect_equal(subtypes[[1]]$range, range(position(2, 13), position(2, 27)))
+
+    members <- extract_refclass_members(
+        document, xdoc, list(name = "UserReference", type = "RefClass")
+    )
+    expect_setequal(map_chr(members, "name"), c("name", "metadata", "greet"))
+})

--- a/tests/testthat/test-type-hierarchy.R
+++ b/tests/testthat/test-type-hierarchy.R
@@ -103,6 +103,94 @@ test_that("Type hierarchy returns subtypes for R6Class", {
     expect_setequal(names, c("Dog", "Cat"))
 })
 
+test_that("Type hierarchy returns S4 supertypes and subtypes", {
+    skip_on_cran()
+    client <- language_client()
+
+    single_file <- withr::local_tempfile(fileext = ".R")
+    writeLines(c(
+        'setClass("BaseEntity")',
+        'setClass("User", contains = "BaseEntity")',
+        'setClass("AdminUser", contains = "User")'
+    ), single_file)
+
+    client %>% did_open(single_file)
+    item <- client %>% respond_prepare_type_hierarchy(
+        single_file, c(1, 10), retry_when = function(result) length(result) == 0)
+
+    expect_length(item, 1)
+    expect_equal(item[[1]]$name, "User")
+    expect_equal(item[[1]]$data$classType, "S4")
+    expect_equal(item[[1]]$range, list(
+        start = list(line = 1L, character = 10L),
+        end = list(line = 1L, character = 14L)
+    ))
+
+    supertypes <- client %>% respond_type_hierarchy_supertypes(
+        item[[1]], retry_when = function(result) length(result) == 0)
+
+    expect_length(supertypes, 1)
+    expect_equal(supertypes[[1]]$name, "BaseEntity")
+    expect_equal(supertypes[[1]]$range, list(
+        start = list(line = 1L, character = 29L),
+        end = list(line = 1L, character = 39L)
+    ))
+
+    subtypes <- client %>% respond_type_hierarchy_subtypes(
+        item[[1]], retry_when = function(result) length(result) == 0)
+
+    expect_length(subtypes, 1)
+    expect_equal(subtypes[[1]]$name, "AdminUser")
+    expect_equal(subtypes[[1]]$range, list(
+        start = list(line = 2L, character = 10L),
+        end = list(line = 2L, character = 19L)
+    ))
+})
+
+test_that("Type hierarchy returns RefClass supertypes and subtypes", {
+    skip_on_cran()
+    client <- language_client()
+
+    single_file <- withr::local_tempfile(fileext = ".R")
+    writeLines(c(
+        'setRefClass("BaseReference")',
+        'setRefClass("UserReference", contains = "BaseReference")',
+        'setRefClass("AdminReference", contains = "UserReference")'
+    ), single_file)
+
+    client %>% did_open(single_file)
+    item <- client %>% respond_prepare_type_hierarchy(
+        single_file, c(1, 13), retry_when = function(result) length(result) == 0)
+
+    expect_length(item, 1)
+    expect_equal(item[[1]]$name, "UserReference")
+    expect_equal(item[[1]]$data$classType, "RefClass")
+    expect_equal(item[[1]]$range, list(
+        start = list(line = 1L, character = 13L),
+        end = list(line = 1L, character = 26L)
+    ))
+
+    supertypes <- client %>% respond_type_hierarchy_supertypes(
+        item[[1]], retry_when = function(result) length(result) == 0)
+
+    expect_length(supertypes, 1)
+    expect_equal(supertypes[[1]]$name, "BaseReference")
+    expect_equal(supertypes[[1]]$range, list(
+        start = list(line = 1L, character = 41L),
+        end = list(line = 1L, character = 54L)
+    ))
+
+    subtypes <- client %>% respond_type_hierarchy_subtypes(
+        item[[1]], retry_when = function(result) length(result) == 0)
+
+    expect_length(subtypes, 1)
+    expect_equal(subtypes[[1]]$name, "AdminReference")
+    expect_equal(subtypes[[1]]$range, list(
+        start = list(line = 2L, character = 13L),
+        end = list(line = 2L, character = 27L)
+    ))
+})
+
 test_that("Type hierarchy returns empty for non-class definitions", {
     skip_on_cran()
     client <- language_client()

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,24 @@
+parse_xdoc <- function(code) {
+    parsed <- parse(text = code, keep.source = TRUE)
+    xml2::read_xml(xmlparsedata::xml_parse_data(parsed))
+}
+
+test_that("xdoc_find_token prefers strings at adjacent token boundaries", {
+    xdoc <- parse_xdoc('setClass("BaseEntity",x+y)')
+
+    token <- xdoc_find_token(xdoc, line = 1, col = 10)
+    expect_equal(xml2::xml_name(token), "STR_CONST")
+    expect_equal(xml2::xml_text(token), '"BaseEntity"')
+
+    xdoc <- parse_xdoc('list(x,"Class")')
+    token <- xdoc_find_token(xdoc, line = 1, col = 8)
+    expect_equal(xml2::xml_name(token), "STR_CONST")
+    expect_equal(xml2::xml_text(token), '"Class"')
+})
+
+test_that("xdoc_find_token retains document order for other boundaries", {
+    xdoc <- parse_xdoc("f(x)")
+
+    token <- xdoc_find_token(xdoc, line = 1, col = 3)
+    expect_equal(xml2::xml_name(token), "OP-LEFT-PAREN")
+})


### PR DESCRIPTION
Fixed #738, #739.
* `xdoc_find_token()` now prefers `STR_CONST` at ambiguous punctuation/string boundaries.
* Preserves existing operator/symbol boundary behavior.
* Corrected S4/RefClass parse-tree selectors and member extraction.
* Returned ranges now exclude surrounding quotes.
* Added unit and end-to-end regression tests.