### PR TITLE
Update LSP 3.18 providers and improve responsiveness

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # languageserver 0.3.18
 
+- Add LSP 3.18 capability updates, including multiple-range formatting,
+  explicit UTF-16 position encoding, and the semantic token `label` type.
+- Add R-focused code lenses for function call counts, linked editing between
+  roxygen parameters and function formals, debugger inline values, and
+  parameter-name inlay hints.
+- Make parameter-name inlay hints conservative by default and open VS Code's
+  semantic call hierarchy when a function call-count lens is clicked.
+- Use incremental document synchronization, reject stale background results,
+  cache workspace routing, and reduce event-loop latency for more responsive
+  editing.
+
 **Closed issues:**
 
 - Failed to run diagnostics: ! in callr subprocess. Caused by error in `call[[1L]]` (#723)

--- a/R/capabilities.R
+++ b/R/capabilities.R
@@ -10,7 +10,7 @@ TextDocumentSyncKind <- list(
 
 TextDocumentSyncOptions <- list(
     openClose = TRUE,
-    change = TextDocumentSyncKind$Full,
+    change = TextDocumentSyncKind$Incremental,
     willSave = FALSE,
     willSaveWaitUntil = FALSE,
     save = SaveOptions
@@ -26,7 +26,15 @@ SignatureHelpOptions <- list(
 )
 
 CodeLensOptions <- list(
-    resolveProvider = FALSE
+    resolveProvider = TRUE
+)
+
+InlayHintOptions <- list(
+    resolveProvider = TRUE
+)
+
+DocumentRangeFormattingOptions <- list(
+    rangesSupport = TRUE
 )
 
 DocumentOnTypeFormattingOptions <- list(
@@ -52,7 +60,8 @@ SemanticTokensOptions <- list(
             "namespace", "type", "class", "enum", "interface", "struct",
             "typeParameter", "parameter", "variable", "property", "enumMember",
             "event", "function", "method", "macro", "keyword", "modifier",
-            "comment", "string", "number", "regexp", "operator", "decorator"
+            "comment", "string", "number", "regexp", "operator", "decorator",
+            "label"
         ),
         tokenModifiers = c(
             "declaration", "definition", "readonly", "static", "deprecated",
@@ -64,6 +73,7 @@ SemanticTokensOptions <- list(
 )
 
 ServerCapabilities <- list(
+    positionEncoding = "utf-16",
     textDocumentSync = TextDocumentSyncOptions,
     hoverProvider = TRUE,
     completionProvider = CompletionOptions,
@@ -76,9 +86,9 @@ ServerCapabilities <- list(
     documentSymbolProvider = TRUE,
     workspaceSymbolProvider = TRUE,
     codeActionProvider = TRUE,
-    # codeLensProvider = CodeLensOptions,
+    codeLensProvider = CodeLensOptions,
     documentFormattingProvider = TRUE,
-    documentRangeFormattingProvider = TRUE,
+    documentRangeFormattingProvider = DocumentRangeFormattingOptions,
     documentOnTypeFormattingProvider = DocumentOnTypeFormattingOptions,
     renameProvider = TRUE,
     documentLinkProvider = DocumentLinkOptions,
@@ -88,7 +98,9 @@ ServerCapabilities <- list(
     callHierarchyProvider = TRUE,
     typeHierarchyProvider = TRUE,
     semanticTokensProvider = SemanticTokensOptions,
-    # linkedEditingRangeProvider = FALSE,
+    linkedEditingRangeProvider = TRUE,
+    inlineValueProvider = TRUE,
+    inlayHintProvider = InlayHintOptions,
     # monikerProvider = FALSE,
     # executeCommandProvider = ExecuteCommandOptions,
     workspace = list(

--- a/R/code_lens.R
+++ b/R/code_lens.R
@@ -1,0 +1,119 @@
+#' Return parse data only when it describes the current document version
+#' @noRd
+current_parse_data <- function(uri, workspace, document) {
+    parse_data <- workspace$get_parse_data(uri)
+    if (is.null(parse_data) ||
+        (!is.null(parse_data$version) &&
+            !isTRUE(parse_data$version == document$version))) {
+        return(NULL)
+    }
+    parse_data
+}
+
+#' Find calls to a workspace function without resolving every symbol
+#' @noRd
+function_call_locations <- function(workspace, symbol) {
+    token_quote <- xml_single_quote(symbol)
+    locations <- list()
+
+    for (doc_uri in workspace$documents$keys()) {
+        document <- workspace$documents$get(doc_uri)
+        parse_data <- workspace$get_parse_data(doc_uri)
+        xdoc <- parse_data$xml_doc
+        if (is.null(xdoc)) next
+
+        nodes <- xml_find_all(
+            xdoc,
+            glue(paste0(
+                "//SYMBOL_FUNCTION_CALL[text() = '{token_quote}' and ",
+                "not(preceding-sibling::NS_GET or ",
+                "preceding-sibling::NS_GET_INT)]"
+            ),
+                token_quote = token_quote)
+        )
+        if (!length(nodes)) next
+
+        line1 <- as.integer(xml_attr(nodes, "line1"))
+        col1 <- as.integer(xml_attr(nodes, "col1"))
+        line2 <- as.integer(xml_attr(nodes, "line2"))
+        col2 <- as.integer(xml_attr(nodes, "col2"))
+
+        doc_locations <- lapply(seq_along(nodes), function(i) {
+            location(
+                doc_uri,
+                range(
+                    start = document$to_lsp_position(line1[[i]] - 1L, col1[[i]] - 1L),
+                    end = document$to_lsp_position(line2[[i]] - 1L, col2[[i]])
+                )
+            )
+        })
+        locations <- c(locations, doc_locations)
+    }
+
+    locations
+}
+
+#' Resolve a function-reference code lens
+#' @noRd
+resolve_function_code_lens <- function(workspace, lens) {
+    symbol <- lens$data$symbol
+    uri <- lens$data$uri
+    if (is.null(symbol) || is.null(uri)) return(lens)
+
+    locations <- function_call_locations(workspace, symbol)
+    count <- length(locations)
+    title <- sprintf("%d call%s", count, if (count == 1L) "" else "s")
+    lens$command <- list(
+        title = title,
+        tooltip = sprintf("Show the semantic call hierarchy for %s()", symbol),
+        command = "editor.showCallHierarchy"
+    )
+    lens
+}
+
+#' The response to a textDocument/codeLens request
+#' @noRd
+code_lens_reply <- function(id, uri, workspace, document, client_capabilities = NULL) {
+    parse_data <- current_parse_data(uri, workspace, document)
+    if (is.null(parse_data)) return(NULL)
+
+    definitions <- parse_data$definitions
+    if (!length(definitions)) return(Response$new(id, result = list()))
+
+    resolve_options <- client_capabilities$textDocument$codeLens$resolveSupport
+    # Clients predating 3.18 use the server's resolveProvider flag. A 3.18
+    # client can explicitly omit "command" from the properties it resolves.
+    resolve_command <- is.null(resolve_options) ||
+        "command" %in% resolve_options$properties
+
+    lenses <- list()
+    for (symbol in names(definitions)) {
+        definition <- definitions[[symbol]]
+        if (!identical(definition$type, "function")) next
+
+        start <- definition$range$start
+        lens <- list(
+            range = range(
+                position(start$line, start$character),
+                position(start$line, start$character)
+            ),
+            data = list(
+                uri = uri,
+                symbol = symbol,
+                version = document$version
+            )
+        )
+        if (!resolve_command) {
+            lens <- resolve_function_code_lens(workspace, lens)
+        }
+        lenses[[length(lenses) + 1L]] <- lens
+    }
+
+    Response$new(id, result = lenses)
+}
+
+#' The response to a codeLens/resolve request
+#' @noRd
+code_lens_resolve_reply <- function(id, workspace, lens) {
+    Response$new(id, result = resolve_function_code_lens(workspace, lens))
+}

--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -131,6 +131,15 @@ diagnose_file <- function(uri, content, is_rmarkdown = FALSE, globals = NULL, ca
 diagnostics_callback <- function(self, uri, version, diagnostics) {
     workspace <- self$get_workspace(uri)
     if (is.null(diagnostics) || !workspace$documents$has(uri) || !lsp_settings$get("diagnostics")) return(NULL)
+    document <- workspace$documents$get(uri)
+    if (!is.null(version) && !identical(document$version, version)) {
+        logger$info("diagnostics_callback: discarded stale result", list(
+            uri = uri,
+            result_version = version,
+            document_version = document$version
+        ))
+        return(NULL)
+    }
 
     logger$info("diagnostics_callback called:", list(
         uri = uri,

--- a/R/document.R
+++ b/R/document.R
@@ -34,6 +34,58 @@ Document <- R6::R6Class(
             self$content <- content
         },
 
+        apply_content_changes = function(version, content_changes) {
+            for (change in content_changes) {
+                if (is.null(change$range)) {
+                    self$set_content(
+                        version,
+                        stringi::stri_split_lines(change$text)[[1]]
+                    )
+                    next
+                }
+
+                start <- self$from_lsp_position(change$range$start)
+                end <- self$from_lsp_position(change$range$end)
+                replacement <- stringi::stri_split_lines(change$text)[[1]]
+
+                start_line <- self$line0(start$row)
+                end_line <- self$line0(end$row)
+                prefix <- if (start$col > 0L) {
+                    stringi::stri_sub(start_line, 1L, start$col)
+                } else {
+                    ""
+                }
+                suffix <- stringi::stri_sub(end_line, end$col + 1L)
+
+                if (length(replacement) == 1L) {
+                    changed <- paste0(prefix, replacement, suffix)
+                } else {
+                    middle <- if (length(replacement) > 2L) {
+                        replacement[seq.int(2L, length(replacement) - 1L)]
+                    } else {
+                        character()
+                    }
+                    changed <- c(
+                        paste0(prefix, replacement[[1L]]),
+                        middle,
+                        paste0(replacement[[length(replacement)]], suffix)
+                    )
+                }
+
+                before <- if (start$row > 0L) {
+                    self$content[seq_len(start$row)]
+                } else {
+                    character()
+                }
+                after <- if (end$row + 1L < length(self$content)) {
+                    self$content[seq.int(end$row + 2L, length(self$content))]
+                } else {
+                    character()
+                }
+                self$set_content(version, c(before, changed, after))
+            }
+        },
+
         update_parse_data = function(parse_data) {
             self$parse_data <- parse_data
         },
@@ -479,6 +531,14 @@ parse_callback <- function(self, uri, version, parse_data) {
     if (is.null(parse_data) || !workspace$documents$has(uri)) return(NULL)
     logger$info("parse_callback called:", list(uri = uri, version = version))
     doc <- workspace$documents$get(uri)
+    if (!is.null(version) && !identical(doc$version, version)) {
+        logger$info("parse_callback: discarded stale result", list(
+            uri = uri,
+            result_version = version,
+            document_version = doc$version
+        ))
+        return(NULL)
+    }
 
     parse_data$version <- version
     old_parse_data <- doc$parse_data

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -131,6 +131,52 @@ range_formatting_reply <- function(id, uri, document, range, options) {
     Response$new(id, TextEditList)
 }
 
+#' Format several non-overlapping document ranges (LSP 3.18)
+#' @noRd
+ranges_formatting_reply <- function(id, uri, document, ranges, options) {
+    if (!length(ranges)) return(Response$new(id, result = list()))
+
+    # range_formatting_reply expands edits to whole lines. Merge requested
+    # ranges that would therefore produce overlapping edits.
+    normalized <- lapply(ranges, function(item) {
+        end_row <- item$end$row
+        if (item$end$col == 0L && item$start$row < end_row) {
+            end_row <- end_row - 1L
+        }
+        list(start = item$start, end = list(row = end_row, col = item$end$col))
+    })
+    order_index <- order(
+        vapply(normalized, function(item) item$start$row, numeric(1L)),
+        vapply(normalized, function(item) item$start$col, numeric(1L))
+    )
+    normalized <- normalized[order_index]
+
+    merged <- list()
+    for (item in normalized) {
+        if (!length(merged)) {
+            merged[[1L]] <- item
+            next
+        }
+        last <- merged[[length(merged)]]
+        if (item$start$row <= last$end$row) {
+            if (item$end$row > last$end$row ||
+                (item$end$row == last$end$row && item$end$col > last$end$col)) {
+                last$end <- item$end
+            }
+            merged[[length(merged)]] <- last
+        } else {
+            merged[[length(merged) + 1L]] <- item
+        }
+    }
+
+    edits <- list()
+    for (item in merged) {
+        reply <- range_formatting_reply(NULL, uri, document, item, options)
+        if (length(reply$result)) edits <- c(edits, reply$result)
+    }
+    Response$new(id, result = edits)
+}
+
 #' Format on type
 #' @noRd
 on_type_formatting_reply <- function(id, uri, document, point, ch, options) {

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -165,7 +165,19 @@ text_document_code_action  <- function(self, id, params) {
 #' Handler to the `textDocument/codeLens` [Request].
 #' @noRd
 text_document_code_lens  <- function(self, id, params) {
+    uri <- uri_escape_unicode(params$textDocument$uri)
+    workspace <- self$get_workspace(uri)
+    document <- workspace$documents$get(uri)
+    if (is.null(document)) return(self$deliver(Response$new(id = id, result = NULL)))
 
+    reply <- code_lens_reply(
+        id, uri, workspace, document, self$ClientCapabilities)
+    if (is.null(reply)) {
+        queue <- self$pending_replies$get(uri)[["textDocument/codeLens"]]
+        queue$push(list(id = id, version = document$version, params = params))
+    } else {
+        self$deliver(reply)
+    }
 }
 
 #' `codeLens/resolve` request handler
@@ -173,7 +185,9 @@ text_document_code_lens  <- function(self, id, params) {
 #' Handler to the `codeLens/resolve` [Request].
 #' @noRd
 code_lens_resolve  <- function(self, id, params) {
-
+    uri <- params$data$uri
+    workspace <- self$get_workspace(uri)
+    self$deliver(code_lens_resolve_reply(id, workspace, params))
 }
 
 
@@ -293,6 +307,24 @@ text_document_range_formatting  <- function(self, id, params) {
     )
     options <- params$options
     self$deliver(range_formatting_reply(id, uri, document, range, options))
+}
+
+#' `textDocument/rangesFormatting` request handler (LSP 3.18)
+#' @noRd
+text_document_ranges_formatting <- function(self, id, params) {
+    uri <- uri_escape_unicode(params$textDocument$uri)
+    workspace <- self$get_workspace(uri)
+    document <- workspace$documents$get(uri)
+    if (is.null(document)) return(self$deliver(Response$new(id = id, result = NULL)))
+
+    ranges <- lapply(params$ranges, function(item) {
+        list(
+            start = document$from_lsp_position(item$start),
+            end = document$from_lsp_position(item$end)
+        )
+    })
+    self$deliver(ranges_formatting_reply(
+        id, uri, document, ranges, params$options))
 }
 
 
@@ -460,7 +492,59 @@ type_hierarchy_subtypes <- function(self, id, params) {
 #' Handler to the `textDocument/linkedEditingRange` [Request].
 #' @noRd
 text_document_linked_editing_range <- function(self, id, params) {
+    uri <- uri_escape_unicode(params$textDocument$uri)
+    workspace <- self$get_workspace(uri)
+    document <- workspace$documents$get(uri)
+    if (is.null(document)) return(self$deliver(Response$new(id = id, result = NULL)))
 
+    reply <- linked_editing_range_reply(
+        id, uri, workspace, document, params$position)
+    if (is.null(reply)) {
+        queue <- self$pending_replies$get(uri)[["textDocument/linkedEditingRange"]]
+        queue$push(list(id = id, version = document$version, params = params))
+    } else {
+        self$deliver(reply)
+    }
+}
+
+#' `textDocument/inlineValue` request handler
+#' @noRd
+text_document_inline_value <- function(self, id, params) {
+    uri <- uri_escape_unicode(params$textDocument$uri)
+    workspace <- self$get_workspace(uri)
+    document <- workspace$documents$get(uri)
+    if (is.null(document)) return(self$deliver(Response$new(id = id, result = NULL)))
+
+    reply <- inline_value_reply(id, uri, workspace, document, params$range)
+    if (is.null(reply)) {
+        queue <- self$pending_replies$get(uri)[["textDocument/inlineValue"]]
+        queue$push(list(id = id, version = document$version, params = params))
+    } else {
+        self$deliver(reply)
+    }
+}
+
+#' `textDocument/inlayHint` request handler
+#' @noRd
+text_document_inlay_hint <- function(self, id, params) {
+    uri <- uri_escape_unicode(params$textDocument$uri)
+    workspace <- self$get_workspace(uri)
+    document <- workspace$documents$get(uri)
+    if (is.null(document)) return(self$deliver(Response$new(id = id, result = NULL)))
+
+    reply <- inlay_hint_reply(id, uri, workspace, document, params$range)
+    if (is.null(reply)) {
+        queue <- self$pending_replies$get(uri)[["textDocument/inlayHint"]]
+        queue$push(list(id = id, version = document$version, params = params))
+    } else {
+        self$deliver(reply)
+    }
+}
+
+#' `inlayHint/resolve` request handler
+#' @noRd
+inlay_hint_resolve <- function(self, id, params) {
+    self$deliver(inlay_hint_resolve_reply(id, params))
 }
 
 #' `textDocument/semanticTokens/full` request handler

--- a/R/handlers-textsync.R
+++ b/R/handlers-textsync.R
@@ -39,16 +39,22 @@ text_document_did_change <- function(self, params) {
     contentChanges <- params$contentChanges
     uri <- uri_escape_unicode(textDocument$uri)
     version <- textDocument$version
-    text <- contentChanges[[1]]$text
     logger$info("did change:", list(uri = uri, version = version))
-    content <- stringi::stri_split_lines(text)[[1]]
     
     workspace <- self$get_workspace(uri)
 
     if (workspace$documents$has(uri)) {
         doc <- workspace$documents$get(uri)
-        doc$set_content(version, content)
+        doc$apply_content_changes(version, contentChanges)
     } else {
+        # Incremental changes are only valid for an open document. Be
+        # tolerant of a client that sends a full replacement before didOpen.
+        full_change <- Filter(function(change) is.null(change$range), contentChanges)
+        content <- if (length(full_change)) {
+            stringi::stri_split_lines(full_change[[length(full_change)]]$text)[[1]]
+        } else {
+            ""
+        }
         doc <- Document$new(uri, language = NULL, version = version, content = content)
         workspace$documents$set(uri, doc)
     }

--- a/R/inlay_hint.R
+++ b/R/inlay_hint.R
@@ -1,0 +1,185 @@
+#' Split the direct children of a call expression into argument groups
+#' @noRd
+call_argument_groups <- function(call_node) {
+    children <- xml_children(call_node)
+    child_names <- xml_name(children)
+    open_indices <- which(child_names == "OP-LEFT-PAREN")
+    close_indices <- which(child_names == "OP-RIGHT-PAREN")
+    if (!length(open_indices) || !length(close_indices)) return(list())
+    open <- open_indices[[1L]]
+    close <- max(close_indices)
+    if (close <= open) return(list())
+
+    indices <- if (close > open + 1L) {
+        seq.int(open + 1L, close - 1L)
+    } else {
+        integer()
+    }
+    argument_nodes <- children[indices]
+    argument_names <- xml_name(argument_nodes)
+    comma <- which(argument_names == "OP-COMMA")
+    boundaries <- c(0L, comma, length(argument_nodes) + 1L)
+
+    groups <- vector("list", length(boundaries) - 1L)
+    for (i in seq_len(length(groups))) {
+        first <- boundaries[[i]] + 1L
+        last <- boundaries[[i + 1L]] - 1L
+        nodes <- if (first <= last) argument_nodes[seq.int(first, last)] else NULL
+        names <- if (length(nodes)) xml_name(nodes) else character()
+        subscript <- which(
+            names == "SYMBOL_SUB" &
+                c(names[-1L], "") == "EQ_SUB"
+        )
+        groups[[i]] <- list(
+            nodes = nodes,
+            name = if (length(subscript)) xml_text(nodes[[subscript[[1L]]]]) else NULL
+        )
+    }
+    groups
+}
+
+#' Match an R named argument using exact and unique partial matching
+#' @noRd
+match_named_formal <- function(name, formal_names) {
+    exact <- match(name, formal_names)
+    if (!is.na(exact)) return(exact)
+    partial <- which(startsWith(formal_names, name))
+    if (length(partial) == 1L) partial else NA_integer_
+}
+
+#' Extract parameter-name inlay hints for calls in a requested range
+#' @noRd
+inlay_hint_reply <- function(id, uri, workspace, document, request_range) {
+    parse_data <- current_parse_data(uri, workspace, document)
+    if (is.null(parse_data)) return(NULL)
+    xdoc <- parse_data$xml_doc
+    if (is.null(xdoc)) return(Response$new(id, result = list()))
+
+    calls <- xml_find_all(
+        xdoc,
+        paste0(
+            "//expr[expr[1][following-sibling::*[1]",
+            "[self::OP-LEFT-PAREN]] and ",
+            "expr[1]//SYMBOL_FUNCTION_CALL]"
+        )
+    )
+    if (!length(calls)) return(Response$new(id, result = list()))
+
+    minimum_arguments <- lsp_settings$get("inlay_hints_minimum_arguments")
+    if (!is.numeric(minimum_arguments) || length(minimum_arguments) != 1L ||
+        is.na(minimum_arguments) || minimum_arguments < 0L) {
+        minimum_arguments <- 2L
+    }
+    minimum_argument_length <- lsp_settings$get(
+        "inlay_hints_minimum_argument_length"
+    )
+    if (!is.numeric(minimum_argument_length) ||
+        length(minimum_argument_length) != 1L ||
+        is.na(minimum_argument_length) || minimum_argument_length < 0L) {
+        minimum_argument_length <- 2L
+    }
+
+    formals_cache <- new.env(parent = emptyenv())
+    hints <- list()
+    for (call_node in calls) {
+        callee <- xml_find_first(call_node, "expr[1]")
+        member_operator <- xml_find_first(
+            callee,
+            ".//*[self::OP-DOLLAR or self::OP-AT]"
+        )
+        if (!inherits(member_operator, "xml_missing")) next
+
+        function_node <- xml_find_first(callee, ".//SYMBOL_FUNCTION_CALL[1]")
+        if (inherits(function_node, "xml_missing")) next
+
+        function_name <- xml_text(function_node)
+        package_node <- xml_find_first(callee, ".//SYMBOL_PACKAGE[1]")
+        package <- if (inherits(package_node, "xml_missing")) NULL else xml_text(package_node)
+        cache_key <- paste(if (is.null(package)) "" else package, function_name, sep = "::")
+        if (exists(cache_key, envir = formals_cache, inherits = FALSE)) {
+            function_formals <- get(cache_key, envir = formals_cache, inherits = FALSE)
+        } else {
+            function_formals <- tryCatch(
+                workspace$get_formals(function_name, package),
+                error = function(e) NULL
+            )
+            assign(cache_key, function_formals, envir = formals_cache)
+        }
+
+        formal_names <- names(function_formals)
+        if (!length(formal_names)) next
+        groups <- call_argument_groups(call_node)
+        if (!length(groups)) next
+
+        supplied_arguments <- sum(vapply(
+            groups, function(group) length(group$nodes) > 0L, logical(1L)))
+        if (supplied_arguments < minimum_arguments) next
+
+        named_formals <- vapply(groups, function(group) {
+            if (is.null(group$name)) return(NA_integer_)
+            match_named_formal(group$name, formal_names)
+        }, integer(1L))
+        unavailable <- unique(named_formals[!is.na(named_formals)])
+        available <- setdiff(seq_along(formal_names), unavailable)
+        next_available <- 1L
+
+        for (group in groups) {
+            if (!is.null(group$name)) next
+            if (next_available > length(available)) break
+
+            formal_index <- available[[next_available]]
+            next_available <- next_available + 1L
+            formal_name <- formal_names[[formal_index]]
+            if (identical(formal_name, "...")) break
+            if (!length(group$nodes)) next
+            argument_name_for_length <- sub("^\\.", "", formal_name)
+            if (nchar(argument_name_for_length) < minimum_argument_length) next
+
+            first_node <- group$nodes[[1L]]
+            row <- as.integer(xml_attr(first_node, "line1")) - 1L
+            col <- as.integer(xml_attr(first_node, "col1")) - 1L
+            if (!position_is_in_lsp_range(document, row, col, request_range)) next
+
+            argument_text <- trimws(paste(xml_text(group$nodes), collapse = ""))
+            if (identical(argument_text, formal_name)) next
+
+            hints[[length(hints) + 1L]] <- list(
+                position = document$to_lsp_position(row, col),
+                label = paste0(formal_name, " ="),
+                kind = 2L,
+                paddingRight = TRUE,
+                data = list(
+                    functionName = function_name,
+                    package = package,
+                    parameter = formal_name
+                )
+            )
+            if (length(hints) >= 200L) break
+        }
+        if (length(hints) >= 200L) break
+    }
+
+    Response$new(id, result = hints)
+}
+
+#' Resolve explanatory text for an inlay hint
+#' @noRd
+inlay_hint_resolve_reply <- function(id, hint) {
+    function_name <- hint$data$functionName
+    parameter <- hint$data$parameter
+    package <- hint$data$package
+    if (is.null(function_name) || is.null(parameter)) {
+        return(Response$new(id, result = hint))
+    }
+
+    qualified_name <- if (is.null(package) || !nzchar(package)) {
+        function_name
+    } else {
+        paste0(package, "::", function_name)
+    }
+    hint$tooltip <- list(
+        kind = "markdown",
+        value = sprintf("Parameter `%s` of `%s()`.", parameter, qualified_name)
+    )
+    Response$new(id, result = hint)
+}

--- a/R/inline_value.R
+++ b/R/inline_value.R
@@ -1,0 +1,59 @@
+#' Compare an internal code-point position with an LSP range
+#' @noRd
+position_is_in_lsp_range <- function(document, row, col, request_range) {
+    point <- document$to_lsp_position(row, col)
+    start <- request_range$start
+    end <- request_range$end
+
+    after_start <- point$line > start$line ||
+        (point$line == start$line && point$character >= start$character)
+    before_end <- point$line < end$line ||
+        (point$line == end$line && point$character < end$character)
+    after_start && before_end
+}
+
+#' The response to a textDocument/inlineValue request
+#' @noRd
+inline_value_reply <- function(id, uri, workspace, document, request_range) {
+    parse_data <- current_parse_data(uri, workspace, document)
+    if (is.null(parse_data)) return(NULL)
+    xdoc <- parse_data$xml_doc
+    if (is.null(xdoc)) return(Response$new(id, result = list()))
+
+    nodes <- xml_find_all(xdoc, "//*[self::SYMBOL or self::SYMBOL_FORMALS]")
+    if (!length(nodes)) return(Response$new(id, result = list()))
+
+    line1 <- as.integer(xml_attr(nodes, "line1"))
+    col1 <- as.integer(xml_attr(nodes, "col1"))
+    line2 <- as.integer(xml_attr(nodes, "line2"))
+    col2 <- as.integer(xml_attr(nodes, "col2"))
+    names <- xml_text(nodes)
+
+    values <- list()
+    seen <- new.env(parent = emptyenv())
+    for (i in seq_along(nodes)) {
+        row <- line1[[i]] - 1L
+        col <- col1[[i]] - 1L
+        if (!position_is_in_lsp_range(document, row, col, request_range)) next
+
+        name <- names[[i]]
+        if (!nzchar(name) || identical(name, "...")) next
+
+        # Debug adapters render lookup results at the end of the source line;
+        # one lookup per variable and line avoids noisy duplicate values.
+        key <- paste(row, name, sep = ":")
+        if (exists(key, envir = seen, inherits = FALSE)) next
+        assign(key, TRUE, envir = seen)
+
+        values[[length(values) + 1L]] <- list(
+            range = range(
+                document$to_lsp_position(row, col),
+                document$to_lsp_position(line2[[i]] - 1L, col2[[i]])
+            ),
+            variableName = name,
+            caseSensitiveLookup = TRUE
+        )
+    }
+
+    Response$new(id, result = values)
+}

--- a/R/languageserver.R
+++ b/R/languageserver.R
@@ -27,6 +27,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
         exit_flag = NULL,
         documents = NULL,
         workspaces = NULL,
+        workspace_cache = NULL,
         processId = NULL,
         rootUri = NULL,
         rootPath = NULL,
@@ -70,6 +71,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
 
             self$pending_replies <- collections::dict()
             self$workspaces <- collections::dict()
+            self$workspace_cache <- collections::dict()
             self$workspaces$set(DEFAULT_WORKSPACE, Workspace$new(NULL))
 
             super$initialize()
@@ -102,6 +104,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
                         }
                     }
                 }
+                self$workspace_cache$clear()
             }
         },
         remove_workspace = function(uri) {
@@ -119,6 +122,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
                     }
                 }
                 self$workspaces$remove(key)
+                self$workspace_cache$clear()
             }
         },
         get_workspace = function(uri) {
@@ -131,6 +135,10 @@ LanguageServer <- R6::R6Class("LanguageServer",
 
             if (length(uri) == 0) {
                 return(fallback)
+            }
+
+            if (self$workspace_cache$has(uri)) {
+                return(self$workspace_cache$get(uri))
             }
 
             path <- path_from_uri(uri)
@@ -149,9 +157,11 @@ LanguageServer <- R6::R6Class("LanguageServer",
             }
 
             if (is.null(best_match)) {
+                self$workspace_cache$set(uri, fallback)
                 return(fallback)
             }
 
+            self$workspace_cache$set(uri, best_match)
             best_match
         },
         load_workspace = function(workspace) {
@@ -183,6 +193,10 @@ LanguageServer <- R6::R6Class("LanguageServer",
                     `textDocument/foldingRange` = collections::queue(),
                     `textDocument/documentLink` = collections::queue(),
                     `textDocument/documentColor` = collections::queue(),
+                    `textDocument/codeLens` = collections::queue(),
+                    `textDocument/linkedEditingRange` = collections::queue(),
+                    `textDocument/inlineValue` = collections::queue(),
+                    `textDocument/inlayHint` = collections::queue(),
                     `textDocument/semanticTokens/full` = collections::queue(),
                     `textDocument/semanticTokens/range` = collections::queue()
                 ))
@@ -262,7 +276,7 @@ LanguageServer <- R6::R6Class("LanguageServer",
 
                         data <- self$fetch(blocking = FALSE)
                         if (is.null(data)) {
-                            Sys.sleep(0.1)
+                            Sys.sleep(0.01)
                             next
                         }
                         self$handle_raw(data)
@@ -290,6 +304,7 @@ LanguageServer$set("public", "register_handlers", function() {
         `textDocument/signatureHelp` = text_document_signature_help,
         `textDocument/formatting` = text_document_formatting,
         `textDocument/rangeFormatting` = text_document_range_formatting,
+        `textDocument/rangesFormatting` = text_document_ranges_formatting,
         `textDocument/onTypeFormatting` = text_document_on_type_formatting,
         `textDocument/documentSymbol` = text_document_document_symbol,
         `textDocument/documentHighlight` = text_document_document_highlight,
@@ -297,6 +312,8 @@ LanguageServer$set("public", "register_handlers", function() {
         `documentLink/resolve` = document_link_resolve,
         `textDocument/documentColor` = text_document_document_color,
         `textDocument/codeAction` = text_document_code_action,
+        `textDocument/codeLens` = text_document_code_lens,
+        `codeLens/resolve` = code_lens_resolve,
         `textDocument/colorPresentation` = text_document_color_presentation,
         `textDocument/foldingRange` = text_document_folding_range,
         `textDocument/references` = text_document_references,
@@ -310,6 +327,9 @@ LanguageServer$set("public", "register_handlers", function() {
         `typeHierarchy/supertypes` = type_hierarchy_supertypes,
         `typeHierarchy/subtypes` = type_hierarchy_subtypes,
         `textDocument/linkedEditingRange` = text_document_linked_editing_range,
+        `textDocument/inlineValue` = text_document_inline_value,
+        `textDocument/inlayHint` = text_document_inlay_hint,
+        `inlayHint/resolve` = inlay_hint_resolve,
         `textDocument/semanticTokens/full` = text_document_semantic_tokens_full,
         `textDocument/semanticTokens/range` = text_document_semantic_tokens_range,
         `workspace/symbol` = workspace_symbol

--- a/R/linked_editing.R
+++ b/R/linked_editing.R
@@ -1,0 +1,107 @@
+#' Test whether an LSP position is inside a range
+#' @noRd
+lsp_range_contains <- function(target_range, point) {
+    after_start <- point$line > target_range$start$line ||
+        (point$line == target_range$start$line &&
+            point$character >= target_range$start$character)
+    before_end <- point$line < target_range$end$line ||
+        (point$line == target_range$end$line &&
+            point$character <= target_range$end$character)
+    after_start && before_end
+}
+
+#' Extract documented parameter ranges from a contiguous roxygen block
+#' @noRd
+roxygen_parameter_ranges <- function(document, definition_row) {
+    rows <- integer()
+    row <- definition_row - 1L
+    while (row >= 0L && grepl("^\\s*#'", document$line0(row))) {
+        rows <- c(row, rows)
+        row <- row - 1L
+    }
+
+    result <- list()
+    pattern <- "^\\s*#'\\s*@param\\s+([^[:space:]]+)"
+    for (row in rows) {
+        line <- document$line0(row)
+        match <- regexec(pattern, line, perl = TRUE)[[1]]
+        if (match[[1L]] == -1L) next
+
+        lengths <- attr(match, "match.length")
+        capture_start <- match[[2L]]
+        capture <- substr(
+            line,
+            capture_start,
+            capture_start + lengths[[2L]] - 1L
+        )
+        pieces <- strsplit(capture, ",", fixed = TRUE)[[1]]
+        offset <- 0L
+        for (piece in pieces) {
+            name <- trimws(piece)
+            if (!nzchar(name)) next
+            local_start <- regexpr(name, piece, fixed = TRUE)[[1L]] - 1L
+            start_col <- capture_start - 1L + offset + local_start
+            result[[name]] <- c(result[[name]], list(range(
+                document$to_lsp_position(row, start_col),
+                document$to_lsp_position(row, start_col + nchar(name))
+            )))
+            offset <- offset + nchar(piece) + 1L
+        }
+    }
+    result
+}
+
+#' The response to a textDocument/linkedEditingRange request
+#'
+#' Links roxygen @param names with the corresponding R function formal. This
+#' makes correcting a parameter name update its documentation at the same time.
+#' @noRd
+linked_editing_range_reply <- function(id, uri, workspace, document, point) {
+    parse_data <- current_parse_data(uri, workspace, document)
+    if (is.null(parse_data)) return(NULL)
+    xdoc <- parse_data$xml_doc
+    if (is.null(xdoc)) return(Response$new(id, result = NULL))
+
+    definitions <- parse_data$definitions
+    for (symbol in names(definitions)) {
+        definition <- definitions[[symbol]]
+        if (!identical(definition$type, "function")) next
+
+        definition_row <- definition$range$start$line
+        xpath <- glue(
+            signature_xpath,
+            row = definition_row + 1L,
+            token_quote = xml_single_quote(symbol)
+        )
+        function_nodes <- xml_find_all(xdoc, xpath)
+        if (!length(function_nodes)) next
+        function_node <- function_nodes[[length(function_nodes)]]
+        formal_nodes <- xml_find_all(function_node, "SYMBOL_FORMALS")
+        if (!length(formal_nodes)) next
+
+        documented <- roxygen_parameter_ranges(document, definition_row)
+        if (!length(documented)) next
+
+        for (formal_node in formal_nodes) {
+            name <- xml_text(formal_node)
+            documentation_ranges <- documented[[name]]
+            if (!length(documentation_ranges)) next
+
+            line1 <- as.integer(xml_attr(formal_node, "line1"))
+            col1 <- as.integer(xml_attr(formal_node, "col1"))
+            line2 <- as.integer(xml_attr(formal_node, "line2"))
+            col2 <- as.integer(xml_attr(formal_node, "col2"))
+            formal_range <- range(
+                document$to_lsp_position(line1 - 1L, col1 - 1L),
+                document$to_lsp_position(line2 - 1L, col2)
+            )
+            ranges <- c(list(formal_range), documentation_ranges)
+
+            if (any(vapply(ranges, lsp_range_contains, logical(1L), point = point))) {
+                return(Response$new(id, result = list(ranges = ranges)))
+            }
+        }
+    }
+
+    Response$new(id, result = NULL)
+}

--- a/R/protocol.R
+++ b/R/protocol.R
@@ -133,5 +133,6 @@ MessageType <- list(
     Error = 1,
     Warning = 2,
     Info = 3,
-    Log = 4
+    Log = 4,
+    Debug = 5
 )

--- a/R/semantic.R
+++ b/R/semantic.R
@@ -27,7 +27,8 @@ SemanticTokenTypes <- list(
     number = 19L,
     regexp = 20L,
     operator = 21L,
-    decorator = 22L
+    decorator = 22L,
+    label = 23L
 )
 
 # Token modifiers

--- a/R/settings.R
+++ b/R/settings.R
@@ -12,7 +12,9 @@ Settings <- R6::R6Class("Settings",
             diagnostics_cache_ttl = 5,
             server_capabilities = list(),
             link_file_size_limit = 16L * 1024L^2,
-            nline_to_break_succession = 2L
+            nline_to_break_succession = 2L,
+            inlay_hints_minimum_arguments = 2L,
+            inlay_hints_minimum_argument_length = 2L
         )
     ),
     public = list(

--- a/R/task.R
+++ b/R/task.R
@@ -176,7 +176,10 @@ TaskManager <- R6::R6Class("TaskManager",
             private$process_recent_first <- process_recent_first
             
             private$session_idle_timeout <- session_idle_timeout
-            cpus <- min(parallel::detectCores())
+            cpus <- suppressWarnings(parallel::detectCores())
+            if (length(cpus) != 1L || is.na(cpus) || cpus < 1L) {
+                cpus <- 1L
+            }
             max_running_tasks <- min(cpus, max_running_tasks)
             private$max_running_tasks <- max(min(max_running_tasks, round(cpus * cpu_load)), 1)
             if (use_session) {

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The following editors are supported by installing the corresponding extensions:
 - [x] [documentSymbolProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentSymbol)
 - [x] [workspaceSymbolProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_symbol)
 - [x] [codeActionProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction)
-- [ ] [codeLensProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeLens)
+- [x] [codeLensProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeLens)
 - [x] [documentFormattingProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting)
 - [x] [documentRangeFormattingProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rangeFormatting)
 - [x] [documentOnTypeFormattingProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_onTypeFormatting)
@@ -159,10 +159,17 @@ The following editors are supported by installing the corresponding extensions:
 - [x] [typeHierarchySupertypes](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#typeHierarchy_supertypes)
 - [x] [typeHierarchySubtypes](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#typeHierarchy_subtypes)
 - [x] [semanticTokens](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_semanticTokens)
-- [ ] [linkedEditingRange](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_linkedEditingRange)
+- [x] [linkedEditingRange](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_linkedEditingRange)
 - [ ] [executeCommandProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_executeCommand)
-- [ ] [inlineValueProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_inlineValue)
-- [ ] [inlayHintProivder](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_inlayHint)
+- [x] [inlineValueProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_inlineValue)
+- [x] [inlayHintProvider](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_inlayHint)
+
+Inline values are a debugger-facing feature rather than normal editor
+annotations. When execution is paused, a compatible editor and debug adapter
+request variable lookup ranges from the language server, evaluate them in the
+selected stack frame, and render the resulting values beside the source. They
+have no visible effect when the client or R debug adapter does not request
+`textDocument/inlineValue`.
 
 ## Settings
 
@@ -173,6 +180,8 @@ settings | default | description
 `r.lsp.debug`  | `false` | increase verbosity for debug purpose
 `r.lsp.log_file` | `null` | file to log debug messages, fallback to stderr if empty
 `r.lsp.diagnostics` | `true` | enable file diagnostics via [lintr](https://github.com/r-lib/lintr)
+`r.lsp.inlay_hints_minimum_arguments` | `2` | minimum supplied arguments before parameter-name inlay hints are shown
+`r.lsp.inlay_hints_minimum_argument_length` | `2` | minimum argument-name length for an inlay hint, excluding an initial `.`
 `r.lsp.rich_documentation` | `true` | rich documentation with enhanced markdown features
 `r.lsp.snippet_support` | `true` | enable snippets in auto completion
 `r.lsp.max_completions` | 200 | maximum number of completion items

--- a/tests/testthat/helper-provider.R
+++ b/tests/testthat/helper-provider.R
@@ -1,0 +1,19 @@
+provider_fixture <- function(content, formals_resolver = function(...) NULL) {
+    uri <- "file:///provider-fixture.R"
+    document <- Document$new(uri, language = "r", version = 1L, content = content)
+    parse_data <- parse_document(uri, content)
+    parse_data$version <- document$version
+    parse_data$xml_doc <- xml2::read_xml(parse_data$xml_data)
+    document$update_parse_data(parse_data)
+
+    documents <- collections::dict()
+    documents$set(uri, document)
+    workspace <- new.env(parent = baseenv())
+    workspace$documents <- documents
+    workspace$get_parse_data <- function(request_uri) {
+        documents$get(request_uri, NULL)$parse_data
+    }
+    workspace$get_formals <- formals_resolver
+
+    list(uri = uri, document = document, workspace = workspace)
+}

--- a/tests/testthat/test-code-lens.R
+++ b/tests/testthat/test-code-lens.R
@@ -1,0 +1,68 @@
+test_that("code lenses lazily resolve R function call counts", {
+    expect_true(ServerCapabilities$codeLensProvider$resolveProvider)
+    fixture <- provider_fixture(c(
+        "foo <- function(x) x + 1",
+        "foo(1)",
+        "foo(2)",
+        "other::foo(3)"
+    ))
+    capabilities <- list(textDocument = list(codeLens = list(
+        resolveSupport = list(properties = list("command"))
+    )))
+
+    reply <- code_lens_reply(
+        1L, fixture$uri, fixture$workspace, fixture$document, capabilities)
+    expect_length(reply$result, 1L)
+    expect_null(reply$result[[1L]]$command)
+
+    resolved <- code_lens_resolve_reply(
+        2L, fixture$workspace, reply$result[[1L]])$result
+    expect_equal(resolved$command$title, "2 calls")
+    expect_equal(
+        resolved$command$command,
+        "editor.showCallHierarchy"
+    )
+    expect_null(resolved$command$arguments)
+})
+
+test_that("code lenses work through the language server after incremental edits", {
+    skip_on_cran()
+    client <- language_client(capabilities = list(textDocument = list(
+        codeLens = list(resolveSupport = list(properties = list("command")))
+    )))
+    path <- withr::local_tempfile(fileext = ".R")
+    writeLines(c(
+        "foo <- function(x) x + 1",
+        "foo(1)"
+    ), path)
+    client %>% did_open(path)
+    uri <- path_to_uri(path)
+
+    lenses <- respond(
+        client,
+        "textDocument/codeLens",
+        list(textDocument = list(uri = uri))
+    )
+    expect_length(lenses, 1L)
+    resolved <- respond(client, "codeLens/resolve", lenses[[1L]])
+    expect_equal(resolved$command$title, "1 call")
+    expect_equal(resolved$command$command, "editor.showCallHierarchy")
+
+    notify(client, "textDocument/didChange", list(
+        textDocument = list(uri = uri, version = 2L),
+        contentChanges = list(list(
+            range = list(
+                start = list(line = 0L, character = 0L),
+                end = list(line = 0L, character = 3L)
+            ),
+            rangeLength = 3L,
+            text = "bar"
+        ))
+    ))
+    changed_lenses <- respond(
+        client,
+        "textDocument/codeLens",
+        list(textDocument = list(uri = uri))
+    )
+    expect_equal(changed_lenses[[1L]]$data$symbol, "bar")
+})

--- a/tests/testthat/test-inlay-hint.R
+++ b/tests/testthat/test-inlay-hint.R
@@ -1,0 +1,155 @@
+test_that("inlay hints name non-obvious positional R arguments", {
+    expect_true(ServerCapabilities$inlayHintProvider$resolveProvider)
+    fixture <- provider_fixture(
+        "mean(values, TRUE, na.rm = FALSE)",
+        formals_resolver = function(...) alist(x =, trim = 0, na.rm = FALSE)
+    )
+    reply <- inlay_hint_reply(
+        1L,
+        fixture$uri,
+        fixture$workspace,
+        fixture$document,
+        list(
+            start = list(line = 0L, character = 0L),
+            end = list(line = 0L, character = 35L)
+        )
+    )
+
+    expect_equal(
+        vapply(reply$result, `[[`, character(1L), "label"),
+        "trim ="
+    )
+    expect_true(all(vapply(reply$result, `[[`, integer(1L), "kind") == 2L))
+
+    resolved <- inlay_hint_resolve_reply(2L, reply$result[[1L]])$result
+    expect_match(resolved$tooltip$value, "`trim`")
+    expect_match(resolved$tooltip$value, "`mean\\(\\)`")
+})
+
+test_that("inlay hints skip syntax and simple calls", {
+    fixture <- provider_fixture(
+        c(
+            "if (argument) value",
+            "fun <- function(argument, second, third) other(argument)",
+            "other(argument)",
+            "other(argument, second)"
+        ),
+        formals_resolver = function(...) {
+            alist(argument =, second =, third =)
+        }
+    )
+    reply <- inlay_hint_reply(
+        1L,
+        fixture$uri,
+        fixture$workspace,
+        fixture$document,
+        list(
+            start = list(line = 0L, character = 0L),
+            end = list(line = 3L, character = 30L)
+        )
+    )
+
+    expect_length(reply$result, 0L)
+})
+
+test_that("inlay hints are shown for two supplied arguments", {
+    fixture <- provider_fixture(
+        "target(one, two)",
+        formals_resolver = function(...) alist(first =, second =)
+    )
+    reply <- inlay_hint_reply(
+        1L,
+        fixture$uri,
+        fixture$workspace,
+        fixture$document,
+        list(
+            start = list(line = 0L, character = 0L),
+            end = list(line = 0L, character = 16L)
+        )
+    )
+
+    expect_equal(
+        vapply(reply$result, `[[`, character(1L), "label"),
+        c("first =", "second =")
+    )
+})
+
+test_that("inlay hint argument length excludes an initial dot", {
+    old_minimum <- lsp_settings$get("inlay_hints_minimum_argument_length")
+    withr::defer(lsp_settings$set(
+        "inlay_hints_minimum_argument_length",
+        old_minimum
+    ))
+    lsp_settings$set("inlay_hints_minimum_argument_length", 3L)
+
+    fixture <- provider_fixture(
+        "target(one, two)",
+        formals_resolver = function(...) alist(.ab =, .abc =)
+    )
+    reply <- inlay_hint_reply(
+        1L,
+        fixture$uri,
+        fixture$workspace,
+        fixture$document,
+        list(
+            start = list(line = 0L, character = 0L),
+            end = list(line = 0L, character = 16L)
+        )
+    )
+
+    expect_equal(
+        vapply(reply$result, `[[`, character(1L), "label"),
+        ".abc ="
+    )
+})
+
+test_that("inlay hints do not use global formals for member calls", {
+    fixture <- provider_fixture(
+        c(
+            "ResponseErrorMessage$new(",
+            "    id,",
+            "    errortype = \"RequestCancelled\",",
+            "    message = \"Cannot rename the symbol\"",
+            ")"
+        ),
+        formals_resolver = function(...) alist(Class =, ...)
+    )
+    reply <- inlay_hint_reply(
+        1L,
+        fixture$uri,
+        fixture$workspace,
+        fixture$document,
+        list(
+            start = list(line = 0L, character = 0L),
+            end = list(line = 4L, character = 1L)
+        )
+    )
+
+    expect_length(reply$result, 0L)
+})
+
+test_that("inlay hints work through the language server", {
+    skip_on_cran()
+    client <- language_client(capabilities = list(textDocument = list(
+        inlayHint = list(resolveSupport = list(properties = list("tooltip")))
+    )))
+    path <- withr::local_tempfile(fileext = ".R")
+    writeLines("stats::rnorm(10, 1, 2)", path)
+    client %>% did_open(path)
+
+    hints <- respond(
+        client,
+        "textDocument/inlayHint",
+        list(
+            textDocument = list(uri = path_to_uri(path)),
+            range = list(
+                start = list(line = 0L, character = 0L),
+                end = list(line = 0L, character = 24L)
+            )
+        )
+    )
+    expect_equal(
+        vapply(hints, `[[`, character(1L), "label"),
+        c("mean =", "sd =")
+    )
+})

--- a/tests/testthat/test-inline-value.R
+++ b/tests/testthat/test-inline-value.R
@@ -1,0 +1,58 @@
+test_that("inline values request debugger lookups for R variables", {
+    expect_true(ServerCapabilities$inlineValueProvider)
+    fixture <- provider_fixture(c(
+        "foo <- function(x) {",
+        "  y <- x + 1",
+        "  y",
+        "}"
+    ))
+    reply <- inline_value_reply(
+        1L,
+        fixture$uri,
+        fixture$workspace,
+        fixture$document,
+        list(
+            start = list(line = 0L, character = 0L),
+            end = list(line = 3L, character = 1L)
+        )
+    )
+
+    variable_names <- vapply(reply$result, `[[`, character(1L), "variableName")
+    expect_true(all(c("x", "y") %in% variable_names))
+    expect_true(all(vapply(
+        reply$result, `[[`, logical(1L), "caseSensitiveLookup")))
+})
+
+test_that("inline values work through the language server", {
+    skip_on_cran()
+    client <- language_client()
+    path <- withr::local_tempfile(fileext = ".R")
+    writeLines(c(
+        "foo <- function(x) {",
+        "  y <- x + 1",
+        "  y",
+        "}"
+    ), path)
+    client %>% did_open(path)
+
+    result <- respond(
+        client,
+        "textDocument/inlineValue",
+        list(
+            textDocument = list(uri = path_to_uri(path)),
+            range = list(
+                start = list(line = 0L, character = 0L),
+                end = list(line = 3L, character = 1L)
+            ),
+            context = list(
+                frameId = 1L,
+                stoppedLocation = list(
+                    start = list(line = 1L, character = 0L),
+                    end = list(line = 1L, character = 12L)
+                )
+            )
+        )
+    )
+    expect_true("x" %in% vapply(
+        result, `[[`, character(1L), "variableName"))
+})

--- a/tests/testthat/test-linked-editing.R
+++ b/tests/testthat/test-linked-editing.R
@@ -1,0 +1,41 @@
+test_that("linked editing connects roxygen parameters and R formals", {
+    expect_true(ServerCapabilities$linkedEditingRangeProvider)
+    fixture <- provider_fixture(c(
+        "#' Add one",
+        "#' @param x A value.",
+        "foo <- function(x) x + 1"
+    ))
+    reply <- linked_editing_range_reply(
+        1L,
+        fixture$uri,
+        fixture$workspace,
+        fixture$document,
+        list(line = 1L, character = 10L)
+    )
+
+    expect_length(reply$result$ranges, 2L)
+    expect_equal(reply$result$ranges[[1L]]$start$line, 2L)
+    expect_equal(reply$result$ranges[[2L]]$start$line, 1L)
+})
+
+test_that("linked editing works through the language server", {
+    skip_on_cran()
+    client <- language_client()
+    path <- withr::local_tempfile(fileext = ".R")
+    writeLines(c(
+        "#' Add one",
+        "#' @param x A value.",
+        "foo <- function(x) x + 1"
+    ), path)
+    client %>% did_open(path)
+
+    result <- respond(
+        client,
+        "textDocument/linkedEditingRange",
+        list(
+            textDocument = list(uri = path_to_uri(path)),
+            position = list(line = 1L, character = 10L)
+        )
+    )
+    expect_length(result$ranges, 2L)
+})

--- a/tests/testthat/test-lsp-3-18.R
+++ b/tests/testthat/test-lsp-3-18.R
@@ -1,0 +1,63 @@
+test_that("general LSP 3.18 capabilities are advertised", {
+    expect_equal(ServerCapabilities$positionEncoding, "utf-16")
+    expect_equal(
+        ServerCapabilities$textDocumentSync$change,
+        TextDocumentSyncKind$Incremental
+    )
+    expect_true(ServerCapabilities$documentRangeFormattingProvider$rangesSupport)
+    expect_equal(tail(ServerCapabilities$semanticTokensProvider$legend$tokenTypes, 1), "label")
+})
+
+test_that("incremental document changes are sequential and UTF-16 aware", {
+    document <- Document$new(
+        "file:///incremental.R",
+        version = 1L,
+        content = c("a\U0001f600b", "second")
+    )
+    document$apply_content_changes(2L, list(
+        list(
+            range = list(
+                start = list(line = 0L, character = 1L),
+                end = list(line = 0L, character = 3L)
+            ),
+            text = "X"
+        ),
+        list(
+            range = list(
+                start = list(line = 0L, character = 2L),
+                end = list(line = 0L, character = 2L)
+            ),
+            text = "\nnew"
+        )
+    ))
+
+    expect_equal(document$content, c("aX", "newb", "second"))
+    expect_equal(document$version, 2L)
+    expect_equal(document$nline, 3L)
+})
+
+test_that("LSP 3.18 multiple-range formatting returns non-overlapping edits", {
+    document <- Document$new(
+        "file:///format.R",
+        language = "r",
+        version = 1L,
+        content = c("x<-1", "", "y<-2")
+    )
+    reply <- ranges_formatting_reply(
+        1L,
+        document$uri,
+        document,
+        list(
+            list(start = list(row = 0L, col = 0L), end = list(row = 0L, col = 4L)),
+            list(start = list(row = 2L, col = 0L), end = list(row = 2L, col = 4L))
+        ),
+        list(tabSize = 2L, insertSpaces = TRUE)
+    )
+
+    expect_length(reply$result, 2L)
+    expect_equal(vapply(
+        reply$result,
+        function(edit) edit$range$start$line,
+        numeric(1L)
+    ), c(0, 2))
+})


### PR DESCRIPTION
## Summary

- update advertised capabilities and document handling for LSP 3.18, including UTF-16 positions, incremental synchronization, multiple-range formatting, and semantic token labels
- add R-focused code lenses, linked editing, debugger inline values, and configurable parameter-name inlay hints
- improve editing responsiveness by rejecting stale background results, caching workspace routing, and reducing event-loop latency
- keep inlay hints conservative by requiring configurable argument counts and name lengths, and avoid incorrect formals for member calls

## Testing

- `Rscript -e "devtools::test(filter = \"code-lens|inlay-hint|inline-value|linked-editing|lsp-3-18\", stop_on_failure = TRUE)"` (38 passed)