### PR TITLE
Make on-type formatting robust for incomplete expressions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 - Use incremental document synchronization, reject stale background results,
   cache workspace routing, and reduce event-loop latency for more responsive
   editing.
+- Make on-type formatting robust for incomplete R expressions by using
+  parse-validated sentinel completion with a conservative indentation fallback.
 
 **Closed issues:**
 

--- a/R/formatting.R
+++ b/R/formatting.R
@@ -36,6 +36,100 @@ style_text <- function(text, style, indention = 0L, trailing_empty_line = FALSE)
 }
 
 
+#' Find the closing delimiters needed to make an incomplete expression parseable
+#' @noRd
+missing_closing_delimiters <- function(text) {
+    if (!length(text)) return("")
+
+    row <- length(text) - 1L
+    col <- nchar(text[[length(text)]]) - 1L
+    openers <- character()
+
+    while (row >= 0L) {
+        result <- find_unbalanced_bracket(text, row, col)
+        location <- result[[1L]]
+        if (any(location < 0L)) break
+
+        opener <- result[[2L]]
+        if (!opener %in% c("(", "[", "{")) break
+        openers <- c(openers, opener)
+
+        row <- location[[1L]]
+        col <- location[[2L]] - 1L
+        if (col < 0L) {
+            row <- row - 1L
+            if (row >= 0L) col <- nchar(text[[row + 1L]]) - 1L
+        }
+    }
+
+    closing <- c("(" = ")", "[" = "]", "{" = "}")
+    paste0(unname(closing[openers]), collapse = "")
+}
+
+
+#' Complete an incomplete expression with a unique sentinel
+#'
+#' The R parser and styler both require complete syntax. This function only
+#' accepts a completion after the R parser validates it. The sentinel lets the
+#' caller discard all synthesized text after styling without relying on its
+#' formatted length or position.
+#' @noRd
+complete_incomplete_expression <- function(text) {
+    source <- paste0(text, collapse = "\n")
+    if (!nzchar(trimws(source))) return(NULL)
+
+    sentinel <- ".__languageserver_formatting_sentinel__"
+    while (grepl(sentinel, source, fixed = TRUE)) {
+        sentinel <- paste0(sentinel, "_")
+    }
+
+    last_line <- text[[length(text)]]
+    separator <- if (grepl("^\\s*#", last_line)) {
+        "\n"
+    } else if (grepl("\\s$", source)) {
+        ""
+    } else {
+        " "
+    }
+    closers <- missing_closing_delimiters(text)
+    holes <- c(
+        sentinel,
+        paste0(sentinel, "()"),
+        paste0(sentinel, " in NULL")
+    )
+
+    for (trailing_body in c("", "\nNULL")) {
+        for (hole in holes) {
+            completed <- paste0(
+                source, separator, hole, closers, trailing_body
+            )
+            parsed <- tryCatch(
+                parse(text = completed, keep.source = FALSE),
+                error = function(e) NULL
+            )
+            if (!is.null(parsed) && length(parsed)) {
+                return(list(
+                    text = completed,
+                    sentinel = sentinel,
+                    nexpr = length(parsed)
+                ))
+            }
+        }
+    }
+
+    NULL
+}
+
+
+#' Remove synthesized completion text from styled output
+#' @noRd
+remove_formatting_sentinel <- function(text, sentinel) {
+    locations <- gregexpr(sentinel, text, fixed = TRUE)[[1L]]
+    if (length(locations) != 1L || locations[[1L]] < 1L) return(NULL)
+    substr(text, 1L, locations[[1L]] - 1L)
+}
+
+
 #' Format a document
 #' @noRd
 formatting_reply <- function(id, uri, document, options) {
@@ -177,6 +271,111 @@ ranges_formatting_reply <- function(id, uri, document, ranges, options) {
     Response$new(id, result = edits)
 }
 
+
+#' Find the expression affected by on-type formatting
+#' @noRd
+find_on_type_formatting_chunk <- function(content, end_line, complete_at_end = FALSE) {
+    start_line <- end_line
+    nexpr <- 0L
+    best <- NULL
+
+    while (start_line >= 1L) {
+        text <- content[start_line:end_line]
+        parsed <- tryCatch(
+            parse(text = text, keep.source = FALSE),
+            error = function(e) NULL
+        )
+
+        completion <- NULL
+        if ((isTRUE(complete_at_end) && any(nzchar(trimws(text)))) ||
+                is.null(parsed)) {
+            completion <- complete_incomplete_expression(text)
+        }
+
+        if (!is.null(completion)) {
+            nexpr1 <- completion$nexpr
+        } else if (!is.null(parsed)) {
+            nexpr1 <- length(parsed)
+        } else {
+            nexpr1 <- 0L
+        }
+
+        # Stop after crossing into the preceding expression. An incomplete
+        # line ending in an operator or comma remains part of the current one.
+        if (nexpr > 0L && (nexpr1 > nexpr || nexpr1 == 0L) &&
+                !is_incomplete_line(content[[start_line]])) {
+            break
+        }
+
+        if (nexpr1 > 0L) {
+            best <- list(
+                start_line = start_line,
+                text = if (is.null(completion)) text else completion$text,
+                sentinel = if (is.null(completion)) NULL else completion$sentinel
+            )
+        }
+        nexpr <- nexpr1
+        start_line <- start_line - 1L
+    }
+
+    best
+}
+
+
+#' Return a conservative indentation-only edit
+#' @noRd
+indentation_only_reply <- function(id, document, point, options) {
+    row <- point$row
+    if (row < 0L || row >= document$nline) return(Response$new(id))
+
+    line <- document$line0(row)
+    if (!grepl("^\\s*$", line)) return(Response$new(id))
+
+    tab_size <- options$tabSize
+    if (is.null(tab_size) || length(tab_size) != 1L || is.na(tab_size) ||
+            tab_size < 1L) {
+        tab_size <- 2L
+    }
+    indent_unit <- if (isFALSE(options$insertSpaces)) {
+        "\t"
+    } else {
+        strrep(" ", tab_size)
+    }
+
+    result <- find_unbalanced_bracket(
+        document$content,
+        row,
+        nchar(line) - 1L
+    )
+    location <- result[[1L]]
+
+    if (all(location >= 0L)) {
+        context_line <- document$line0(location[[1L]])
+        base <- stringi::stri_extract_first_regex(context_line, "^\\s*")
+        indentation <- paste0(base, indent_unit)
+    } else {
+        previous <- row - 1L
+        while (previous >= 0L && !grepl("\\S", document$line0(previous))) {
+            previous <- previous - 1L
+        }
+        if (previous < 0L) return(Response$new(id))
+
+        previous_line <- document$line0(previous)
+        indentation <- stringi::stri_extract_first_regex(previous_line, "^\\s*")
+        if (is_incomplete_line(previous_line)) {
+            indentation <- paste0(indentation, indent_unit)
+        }
+    }
+
+    if (identical(line, indentation)) return(Response$new(id))
+
+    edit_range <- range(
+        start = document$to_lsp_position(row = row, col = 0L),
+        end = document$to_lsp_position(row = row, col = nchar(line))
+    )
+    Response$new(id, list(text_edit(range = edit_range, new_text = indentation)))
+}
+
 #' Format on type
 #' @noRd
 on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
@@ -185,58 +384,30 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
     }
 
     content <- document$content
-    end_line <- point$row + 1
-    use_completer <- FALSE
+    end_line <- point$row + 1L
+    complete_at_end <- FALSE
     if (ch == "\n") {
-        start_line <- end_line - 1
+        start_line <- end_line - 1L
+        if (start_line < 1L) return(Response$new(id))
         if (grepl("^\\s*(#.*)?$", content[[start_line]])) {
             return(Response$new(id))
         }
         if (grepl("^\\s*(#.*)?$", content[[end_line]])) {
-            # use completer to complete the potentially incomplete expression
-            last_line <- content[end_line]
-            content[end_line] <- "f()"
-            use_completer <- TRUE
+            complete_at_end <- TRUE
         }
-    } else {
-        start_line <- end_line
     }
 
-    # backward parse until more expressions or non-parseable
-    expr <- NULL
-    nexpr <- 0
-    res <- tryCatchTimeout({
-        while (start_line >= 1) {
-            expr <- tryCatch(parse(
-                text = content[start_line:end_line],
-                keep.source = FALSE
-            ), error = function(e) NULL)
-            nexpr1 <- length(expr)
-            # stop backward parsing when
-            # 1. we have at least one expression parsed; and
-            # 2. we are entering the previous expression:
-            #    * if it is one-line expression, then we got 1 more expression.
-            #    * if it is multi-line expression, then we got no expression
-            # 3. the previous line is not an incomplete expression ending with binary operator or comma
-            if (nexpr > 0 && (nexpr1 > nexpr || nexpr1 == 0) && !is_incomplete_line(content[[start_line]])) {
-                start_line <- start_line + 1
-                break
-            }
-            nexpr <- nexpr1
-            start_line <- start_line - 1
+    chunk <- tryCatchTimeout(
+        find_on_type_formatting_chunk(content, end_line, complete_at_end),
+        timeout = 0.1,
+        error = function(e) {
+            logger$info("on_type_formatting_reply:parser:", e)
+            NULL
         }
-        TRUE
-    }, timeout = 0.1, error = function(e) logger$info("on_type_formatting_reply:parser:", e))
+    )
 
-    if (is.null(res)) {
-        # timeout
-        return(Response$new(id))
-    }
-
-    if (nexpr >= 1) {
-        if (start_line == 0) {
-            start_line <- 1
-        }
+    if (!is.null(chunk)) {
+        start_line <- chunk$start_line
 
         # find first non-empty line for the detection of indention
         while (start_line < end_line) {
@@ -259,25 +430,32 @@ on_type_formatting_reply <- function(id, uri, document, point, ch, options) {
 
         indention <- nchar(stringi::stri_extract_first_regex(content[start_line], "^\\s*"))
         new_text <- tryCatchTimeout(
-            style_text(content[start_line:end_line], style, indention = indention),
+            style_text(chunk$text, style, indention = indention),
             timeout = 1,
             error = function(e) logger$info("on_type_formatting_reply:styler:", e)
         )
         if (!is.null(new_text)) {
-            if (use_completer) {
-                # remove completer from formatted text
-                new_text <- substr(new_text, 1, nchar(new_text) - 3)
-                new_text <- paste0(new_text, trimws(last_line))
+            if (!is.null(chunk$sentinel)) {
+                new_text <- remove_formatting_sentinel(
+                    new_text, chunk$sentinel
+                )
             }
-            range <- range(
-                start = document$to_lsp_position(row = start_line - 1, col = 0),
-                end = document$to_lsp_position(row = end_line - 1, col = nchar(document$line(end_line)))
-            )
-            TextEdit <- text_edit(range = range, new_text = new_text)
-            TextEditList <- list(TextEdit)
-            return(Response$new(id, TextEditList))
+            if (!is.null(new_text)) {
+                edit_range <- range(
+                    start = document$to_lsp_position(row = start_line - 1L, col = 0L),
+                    end = document$to_lsp_position(
+                        row = end_line - 1L,
+                        col = nchar(document$line(end_line))
+                    )
+                )
+                TextEdit <- text_edit(range = edit_range, new_text = new_text)
+                return(Response$new(id, list(TextEdit)))
+            }
         }
     }
 
+    if (ch == "\n") {
+        return(indentation_only_reply(id, document, point, options))
+    }
     Response$new(id)
 }

--- a/tests/testthat/test-formatting.R
+++ b/tests/testthat/test-formatting.R
@@ -178,6 +178,80 @@ test_that("On type formatting works", {
     ))
 })
 
+test_that("On type formatting safely completes incomplete expressions", {
+    withr::local_options(languageserver.formatting_style = NULL)
+    options <- list(tabSize = 4L, insertSpaces = TRUE)
+    cases <- list(
+        call = list(
+            content = c("foo(", "  a=1,", ""),
+            expected = "foo(\n    a = 1,\n    "
+        ),
+        pipeline = list(
+            content = c("data%>%", " mutate(a=1)%>%", ""),
+            expected = "data %>%\n    mutate(a = 1) %>%\n    "
+        ),
+        block = list(
+            content = c("if(x){", ""),
+            expected = "if (x) {\n    "
+        ),
+        for_loop = list(
+            content = c("for(", ""),
+            expected = "for (\n    "
+        )
+    )
+
+    for (case in cases) {
+        document <- Document$new(
+            "file:///incomplete.R",
+            language = "r",
+            content = case$content
+        )
+        point <- list(
+            row = length(case$content) - 1L,
+            col = nchar(case$content[[length(case$content)]])
+        )
+        reply <- on_type_formatting_reply(
+            1L, document$uri, document, point, "\n", options
+        )
+
+        expect_length(reply$result, 1L)
+        expect_equal(reply$result[[1L]]$newText, case$expected)
+        expect_false(grepl("languageserver_formatting_sentinel", reply$result[[1L]]$newText))
+    }
+})
+
+test_that("On type formatting falls back to indentation for unsafe syntax", {
+    withr::local_options(languageserver.formatting_style = NULL)
+    document <- Document$new(
+        "file:///incomplete.R",
+        language = "r",
+        content = c(
+            "f <- function() {",
+            "    x <- \"unterminated",
+            ""
+        )
+    )
+    reply <- on_type_formatting_reply(
+        1L,
+        document$uri,
+        document,
+        list(row = 2L, col = 0L),
+        "\n",
+        list(tabSize = 4L, insertSpaces = TRUE)
+    )
+
+    expect_length(reply$result, 1L)
+    expect_equal(
+        unclass(reply$result[[1L]]$range$start),
+        list(line = 2L, character = 0L)
+    )
+    expect_equal(
+        unclass(reply$result[[1L]]$range$end),
+        list(line = 2L, character = 0L)
+    )
+    expect_equal(reply$result[[1L]]$newText, "    ")
+})
+
 test_that("Formatting in Rmarkdown works", {
     skip_on_cran()
     client <- language_client()


### PR DESCRIPTION
## Summary
- replace fixed f() completion with unique, parse-validated sentinels
- synthesize missing delimiters and control-flow bodies before invoking styler
- fall back to indentation-only edits when incomplete syntax cannot be completed safely
- add coverage for incomplete calls, pipelines, blocks, loops, and unsafe strings

## Testing
- Full test suite: 1,271 passed, 1 skipped, 0 failed
- git diff --check