### PR TITLE
Improve completion responsiveness

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 - Use incremental document synchronization, reject stale background results,
   cache workspace routing, and reduce event-loop latency for more responsive
   editing.
+- Pre-index document completion candidates during background parsing and bound
+  broad result sets before constructing completion items.
 - Make on-type formatting robust for incomplete R expressions by using
   parse-validated sentinel completion with a conservative indentation fallback.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,9 @@
 - Use incremental document synchronization, reject stale background results,
   cache workspace routing, and reduce event-loop latency for more responsive
   editing.
-- Pre-index document completion candidates during background parsing and bound
-  broad result sets before constructing completion items.
+- Pre-index document completion candidates during background parsing with a
+  native parse-tree traversal, and bound broad result sets before constructing
+  completion items.
 - Make on-type formatting robust for incomplete R expressions by using
   parse-validated sentinel completion with a conservative indentation fallback.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,8 +11,8 @@
   cache workspace routing, and reduce event-loop latency for more responsive
   editing.
 - Pre-index document completion candidates during background parsing with a
-  native parse-tree traversal, and bound broad result sets before constructing
-  completion items.
+  native parse-tree traversal, bound broad result sets before constructing
+  completion items, and use deterministic native top-N selection.
 - Make on-type formatting robust for incomplete R expressions by using
   parse-validated sentinel completion with a conservative indentation fallback.
 

--- a/R/completion.R
+++ b/R/completion.R
@@ -47,6 +47,202 @@ constants <- c("TRUE", "FALSE", "NULL",
     "NA", "NA_integer_", "NA_real_", "NA_complex_", "NA_character_",
     "Inf", "NaN")
 
+#' Build the symbol indexes used by completion providers
+#'
+#' This runs with the document parser so completion requests do not have to
+#' repeatedly walk the complete XML parse tree. All values stored here are
+#' ordinary R vectors and can therefore be returned by the parse subprocess.
+#' @noRd
+completion_parse_data <- function(data) {
+    empty_scope <- function() {
+        list(
+            name = character(),
+            line = integer(),
+            line1 = integer(),
+            col1 = integer(),
+            line2 = integer(),
+            col2 = integer()
+        )
+    }
+
+    if (is.null(data) || !nrow(data)) {
+        return(list(
+            tokens = character(),
+            empty_tokens = character(),
+            symbols = empty_scope(),
+            functions = empty_scope(),
+            formals = empty_scope()
+        ))
+    }
+
+    rows <- seq_len(nrow(data))
+    children <- list2env(split(rows, data$parent), hash = TRUE,
+        parent = emptyenv())
+    row_by_id <- integer(max(data$id) + 1L)
+    row_by_id[data$id + 1L] <- rows
+
+    child_rows <- function(id) {
+        children[[as.character(id)]]
+    }
+
+    top_row <- function(row) {
+        parent <- data$parent[[row]]
+        while (parent != 0L) {
+            row <- row_by_id[[parent + 1L]]
+            parent <- data$parent[[row]]
+        }
+        row
+    }
+
+    symbol_row <- function(expr_row) {
+        expr_children <- child_rows(data$id[[expr_row]])
+        if (length(expr_children) == 1L &&
+                data$token[[expr_children]] == "SYMBOL") {
+            expr_children
+        } else {
+            NA_integer_
+        }
+    }
+
+    is_function_expr <- function(expr_row) {
+        expr_children <- child_rows(data$id[[expr_row]])
+        any(data$token[expr_children] %in% c("FUNCTION", "'\\\\'"))
+    }
+
+    assignment_rows <- which(data$token %in%
+            c("LEFT_ASSIGN", "RIGHT_ASSIGN", "EQ_ASSIGN"))
+    for_rows <- which(data$token == "forcond")
+    formal_rows <- which(data$token == "SYMBOL_FORMALS")
+
+    symbol_name_rows <- integer(length(assignment_rows) + length(for_rows))
+    symbol_range_rows <- integer(length(symbol_name_rows))
+    function_name_rows <- integer(length(assignment_rows))
+    function_range_rows <- integer(length(function_name_rows))
+    formal_name_rows <- integer(length(formal_rows))
+    formal_range_rows <- integer(length(formal_name_rows))
+    symbol_count <- 0L
+    function_count <- 0L
+    formal_count <- 0L
+
+    for (assignment_row in assignment_rows) {
+        siblings <- child_rows(data$parent[[assignment_row]])
+        expr_siblings <- siblings[data$token[siblings] == "expr"]
+        is_left <- data$token[[assignment_row]] != "RIGHT_ASSIGN"
+
+        if (is_left) {
+            candidates <- expr_siblings[
+                data$line2[expr_siblings] < data$line1[[assignment_row]] |
+                    data$line2[expr_siblings] == data$line1[[assignment_row]] &
+                        data$col2[expr_siblings] < data$col1[[assignment_row]]
+            ]
+            candidates <- candidates[order(
+                data$line2[candidates], data$col2[candidates])]
+            name_expr <- tail(candidates, 1L)
+
+            value_candidates <- expr_siblings[
+                data$line1[expr_siblings] > data$line2[[assignment_row]] |
+                    data$line1[expr_siblings] == data$line2[[assignment_row]] &
+                        data$col1[expr_siblings] > data$col2[[assignment_row]]
+            ]
+            value_candidates <- value_candidates[order(
+                data$line1[value_candidates], data$col1[value_candidates])]
+            value_expr <- head(value_candidates, 1L)
+        } else {
+            candidates <- expr_siblings[
+                data$line1[expr_siblings] > data$line2[[assignment_row]] |
+                    data$line1[expr_siblings] == data$line2[[assignment_row]] &
+                        data$col1[expr_siblings] > data$col2[[assignment_row]]
+            ]
+            candidates <- candidates[order(
+                data$line1[candidates], data$col1[candidates])]
+            name_expr <- head(candidates, 1L)
+
+            value_candidates <- expr_siblings[
+                data$line2[expr_siblings] < data$line1[[assignment_row]] |
+                    data$line2[expr_siblings] == data$line1[[assignment_row]] &
+                        data$col2[expr_siblings] < data$col1[[assignment_row]]
+            ]
+            value_candidates <- value_candidates[order(
+                data$line2[value_candidates], data$col2[value_candidates])]
+            value_expr <- tail(value_candidates, 1L)
+        }
+
+        if (!length(name_expr) || !length(value_expr)) {
+            next
+        }
+        name_row <- symbol_row(name_expr)
+        if (is.na(name_row)) {
+            next
+        }
+        range_row <- top_row(name_row)
+        if (is_function_expr(value_expr)) {
+            function_count <- function_count + 1L
+            function_name_rows[[function_count]] <- name_row
+            function_range_rows[[function_count]] <- range_row
+        } else {
+            symbol_count <- symbol_count + 1L
+            symbol_name_rows[[symbol_count]] <- name_row
+            symbol_range_rows[[symbol_count]] <- range_row
+        }
+    }
+
+    for (for_row in for_rows) {
+        name_rows <- child_rows(data$id[[for_row]])
+        name_rows <- name_rows[data$token[name_rows] == "SYMBOL"]
+        for (name_row in name_rows) {
+            symbol_count <- symbol_count + 1L
+            symbol_name_rows[[symbol_count]] <- name_row
+            symbol_range_rows[[symbol_count]] <- top_row(name_row)
+        }
+    }
+
+    for (name_row in formal_rows) {
+        range_row <- row_by_id[[data$parent[[name_row]] + 1L]]
+        if (!range_row) {
+            next
+        }
+        formal_count <- formal_count + 1L
+        formal_name_rows[[formal_count]] <- name_row
+        formal_range_rows[[formal_count]] <- range_row
+    }
+
+    make_records <- function(name_rows, range_rows, size) {
+        if (!size) {
+            return(empty_scope())
+        }
+        selected <- seq_len(size)
+        name_rows <- name_rows[selected]
+        range_rows <- range_rows[selected]
+        list(
+            name = data$text[name_rows],
+            line = data$line1[name_rows],
+            line1 = data$line1[range_rows],
+            col1 = data$col1[range_rows],
+            line2 = data$line2[range_rows],
+            col2 = data$col2[range_rows]
+        )
+    }
+
+    token_rows <- which(data$token %in%
+            c("SYMBOL", "SYMBOL_SUB", "SYMBOL_FORMALS", "SYMBOL_FUNCTION_CALL"))
+    dollar_parents <- data$parent[data$token == "'$'"]
+    empty_token_rows <- which(
+        data$token == "SYMBOL_SUB" |
+            data$token == "SYMBOL" & data$parent %in% dollar_parents
+    )
+
+    list(
+        tokens = unique(data$text[token_rows]),
+        empty_tokens = unique(data$text[empty_token_rows]),
+        symbols = make_records(
+            symbol_name_rows, symbol_range_rows, symbol_count),
+        functions = make_records(
+            function_name_rows, function_range_rows, function_count),
+        formals = make_records(
+            formal_name_rows, formal_range_rows, formal_count)
+    )
+}
+
 #' Complete language constants
 #' @noRd
 constant_completion <- function(token) {
@@ -120,9 +316,14 @@ extract_default_values <- function(default_expr) {
 
 #' Complete argument values based on default parameter values
 #' @noRd
-argument_value_completion <- function(workspace, funct, package, arg_name, token, exported_only = TRUE) {
-    # Get the formals for the function
-    formals_list <- workspace$get_formals(funct, package, exported_only = exported_only)
+argument_value_completion <- function(workspace, funct, package, arg_name, token,
+    exported_only = TRUE, formals_list = NULL) {
+    # Reuse formals already resolved by the caller when completing multiple
+    # arguments from the same function.
+    if (is.null(formals_list)) {
+        formals_list <- workspace$get_formals(funct, package,
+            exported_only = exported_only)
+    }
     
     if (is.null(formals_list) || !is.list(formals_list)) {
         return(list())
@@ -194,7 +395,9 @@ arg_value_completion <- function(uri, workspace, document, point, token, funct, 
             matching_values <- values[match_with(values, token)]
             if (length(matching_values) > 0) {
                 # Generate completions for this parameter
-                param_completions <- argument_value_completion(workspace, funct, package_for_call, param_name, token, exported_only)
+                param_completions <- argument_value_completion(
+                    workspace, funct, package_for_call, param_name, token,
+                    exported_only, formals_list)
                 all_completions <- c(all_completions, param_completions)
             }
         }
@@ -463,26 +666,84 @@ scope_completion_functs_xpath <- paste(
     "(* | descendant-or-self::expr | descendant-or-self::expr_or_assign_or_help)/EQ_ASSIGN[following-sibling::expr/*[self::FUNCTION or self::OP-LAMBDA]]/preceding-sibling::expr[count(*)=1]/SYMBOL",
     sep = "|")
 
-scope_completion <- function(uri, workspace, token, point, snippet_support = NULL) {
-    xdoc <- workspace$get_parse_data(uri)$xml_doc
-    if (is.null(xdoc)) {
-        return(list())
+scope_completion <- function(uri, workspace, token, point,
+    snippet_support = NULL, limit = Inf) {
+    parse_data <- workspace$get_parse_data(uri)
+    completion_data <- parse_data$completion_data
+    row <- point$row + 1L
+    col <- point$col + 1L
+
+    contains_point <- function(records) {
+        (records$line1 < row |
+                records$line1 == row & records$col1 <= col) &
+            (records$line2 > row |
+                    records$line2 == row & records$col2 >= col - 1L)
     }
 
-    enclosing_scopes <- xdoc_find_enclosing_scopes(xdoc,
-        point$row + 1, point$col + 1)
+    if (!is.null(completion_data)) {
+        symbol_selector <- contains_point(completion_data$symbols)
+        formal_selector <- contains_point(completion_data$formals)
+        scope_symbol_names <- c(
+            completion_data$symbols$name[symbol_selector],
+            completion_data$formals$name[formal_selector]
+        )
+        scope_symbol_lines <- c(
+            completion_data$symbols$line[symbol_selector],
+            completion_data$formals$line[formal_selector]
+        )
 
-    scope_symbol_nodes <- xml_find_all(enclosing_scopes, scope_completion_symbols_xpath)
-    scope_symbol_names <- xml_text(scope_symbol_nodes)
-    scope_symbol_lines <- as.integer(xml_attr(scope_symbol_nodes, "line1"))
+        function_selector <- contains_point(completion_data$functions)
+        scope_funct_names <- completion_data$functions$name[function_selector]
+        scope_funct_lines <- completion_data$functions$line[function_selector]
+    } else {
+        xdoc <- parse_data$xml_doc
+        if (is.null(xdoc)) {
+            return(list())
+        }
+
+        enclosing_scopes <- xdoc_find_enclosing_scopes(xdoc, row, col)
+
+        scope_symbol_nodes <- xml_find_all(enclosing_scopes,
+            scope_completion_symbols_xpath)
+        scope_symbol_names <- xml_text(scope_symbol_nodes)
+        scope_symbol_lines <- as.integer(xml_attr(scope_symbol_nodes, "line1"))
+
+        scope_funct_nodes <- xml_find_all(enclosing_scopes,
+            scope_completion_functs_xpath)
+        scope_funct_names <- xml_text(scope_funct_nodes)
+        scope_funct_lines <- as.integer(xml_attr(scope_funct_nodes, "line1"))
+    }
+
     scope_symbol_selector <- match_with(scope_symbol_names, token)
-
     scope_symbol_names <- rev(scope_symbol_names[scope_symbol_selector])
     scope_symbol_lines <- rev(scope_symbol_lines[scope_symbol_selector])
     scope_symbol_selector <- !duplicated(scope_symbol_names)
 
     scope_symbol_names <- scope_symbol_names[scope_symbol_selector]
     scope_symbol_lines <- scope_symbol_lines[scope_symbol_selector]
+
+    scope_funct_selector <- match_with(scope_funct_names, token)
+    scope_funct_names <- rev(scope_funct_names[scope_funct_selector])
+    scope_funct_lines <- rev(scope_funct_lines[scope_funct_selector])
+    scope_funct_selector <- !duplicated(scope_funct_names)
+
+    scope_funct_names <- scope_funct_names[scope_funct_selector]
+    scope_funct_lines <- scope_funct_lines[scope_funct_selector]
+
+    candidate_names <- c(scope_symbol_names, scope_funct_names)
+    truncated <- length(candidate_names) > limit
+    if (truncated) {
+        candidate_order <- order(
+            !startsWith(candidate_names, token), candidate_names)
+        keep <- candidate_order[seq_len(limit)]
+        symbol_keep <- keep[keep <= length(scope_symbol_names)]
+        function_keep <- keep[keep > length(scope_symbol_names)] -
+            length(scope_symbol_names)
+        scope_symbol_names <- scope_symbol_names[symbol_keep]
+        scope_symbol_lines <- scope_symbol_lines[symbol_keep]
+        scope_funct_names <- scope_funct_names[function_keep]
+        scope_funct_lines <- scope_funct_lines[function_keep]
+    }
 
     scope_symbol_completions <- .mapply(function(symbol, line) {
         list(
@@ -497,18 +758,6 @@ scope_completion <- function(uri, workspace, token, point, snippet_support = NUL
             )
         )
     }, list(scope_symbol_names, scope_symbol_lines), NULL)
-
-    scope_funct_nodes <- xml_find_all(enclosing_scopes, scope_completion_functs_xpath)
-    scope_funct_names <- xml_text(scope_funct_nodes)
-    scope_funct_lines <- as.integer(xml_attr(scope_funct_nodes, "line1"))
-    scope_funct_selector <- match_with(scope_funct_names, token)
-
-    scope_funct_names <- rev(scope_funct_names[scope_funct_selector])
-    scope_funct_lines <- rev(scope_funct_lines[scope_funct_selector])
-    scope_funct_selector <- !duplicated(scope_funct_names)
-
-    scope_funct_names <- scope_funct_names[scope_funct_selector]
-    scope_funct_lines <- scope_funct_lines[scope_funct_selector]
 
     if (isTRUE(snippet_support)) {
         scope_funct_completions <- .mapply(function(symbol, line) {
@@ -543,42 +792,68 @@ scope_completion <- function(uri, workspace, token, point, snippet_support = NUL
     }
 
     completions <- c(scope_symbol_completions, scope_funct_completions)
+    if (truncated) {
+        attr(completions, "truncated") <- TRUE
+    }
     completions
 }
 
-token_completion <- function(uri, workspace, token, exclude = NULL) {
-    xdoc <- workspace$get_parse_data(uri)$xml_doc
-    if (is.null(xdoc)) {
-        return(list())
-    }
+token_completion <- function(uri, workspace, token, exclude = NULL, limit = Inf) {
+    parse_data <- workspace$get_parse_data(uri)
+    completion_data <- parse_data$completion_data
+    if (!is.null(completion_data)) {
+        symbols <- if (nzchar(token)) {
+            completion_data$tokens
+        } else {
+            completion_data$empty_tokens
+        }
+        symbols <- symbols[startsWith(symbols, token)]
+    } else {
+        xdoc <- parse_data$xml_doc
+        if (is.null(xdoc)) {
+            return(list())
+        }
 
-    token_quote <- xml_single_quote(token)
+        token_quote <- xml_single_quote(token)
 
-    symbols <- xml_text(xml_find_all(xdoc,
-        glue("//*[
-            (self::SYMBOL[preceding-sibling::OP-DOLLAR] or self::SYMBOL_SUB) and
-            starts-with(text(),'{token_quote}')]",
-            token_quote = token_quote
-        )
-    ))
-
-    if (nzchar(token)) {
-        symbols <- c(symbols, xml_text(xml_find_all(xdoc,
-            glue("//*[(self::SYMBOL or self::SYMBOL_SUB or self::SYMBOL_FORMALS or self::SYMBOL_FUNCTION_CALL) and
-                starts-with(text(),'{token_quote}')]",
+        symbols <- xml_text(xml_find_all(
+            xdoc,
+            glue(
+                "//*[
+                    (self::SYMBOL[preceding-sibling::OP-DOLLAR] or self::SYMBOL_SUB) and
+                    starts-with(text(),'{token_quote}')]",
                 token_quote = token_quote
             )
-        )))
+        ))
+
+        if (nzchar(token)) {
+            symbols <- c(symbols, xml_text(xml_find_all(
+                xdoc,
+                glue(
+                    "//*[(self::SYMBOL or self::SYMBOL_SUB or self::SYMBOL_FORMALS or self::SYMBOL_FUNCTION_CALL) and
+                        starts-with(text(),'{token_quote}')]",
+                    token_quote = token_quote
+                )
+            )))
+        }
     }
 
     symbols <- setdiff(symbols, exclude)
-    token_completions <- lapply(symbols, function(symbol) {
+    truncated <- length(symbols) > limit
+    if (truncated) {
+        symbols <- sort(symbols)[seq_len(limit)]
+    }
+    completions <- lapply(symbols, function(symbol) {
         list(
             label = symbol,
             kind = CompletionItemKind$Text,
             sortText = paste0(sort_prefixes$token, symbol)
         )
     })
+    if (truncated) {
+        attr(completions, "truncated") <- TRUE
+    }
+    completions
 }
 
 #' The response to a textDocument/completion request
@@ -596,6 +871,7 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
     t0 <- Sys.time()
     snippet_support <- isTRUE(capabilities$completionItem$snippetSupport) &&
         lsp_settings$get("snippet_support")
+    nmax <- lsp_settings$get("max_completions")
 
     token_result <- document$detect_token(point, forward = FALSE)
 
@@ -604,14 +880,19 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
     package <- token_result$package
 
     completions <- list()
+    providers_incomplete <- FALSE
 
     if (nzchar(full_token)) {
         if (is.null(package)) {
+            scope_completions <- scope_completion(uri, workspace, token, point,
+                snippet_support, nmax)
+            providers_incomplete <- providers_incomplete ||
+                isTRUE(attr(scope_completions, "truncated"))
             completions <- c(
                 completions,
                 constant_completion(token),
                 package_completion(token),
-                scope_completion(uri, workspace, token, point, snippet_support))
+                scope_completions)
         }
         completions <- c(
             completions,
@@ -635,16 +916,19 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
 
     if (is.null(token_result$package)) {
         existing_symbols <- vapply(completions, "[[", character(1), "label")
+        token_completions <- token_completion(
+            uri, workspace, token, existing_symbols, nmax)
+        providers_incomplete <- providers_incomplete ||
+            isTRUE(attr(token_completions, "truncated"))
         completions <- c(
             completions,
-            token_completion(uri, workspace, token, existing_symbols)
+            token_completions
         )
     }
 
     init_count <- length(completions)
-    nmax <- lsp_settings$get("max_completions")
 
-    if (init_count > nmax) {
+    if (providers_incomplete || init_count > nmax) {
         isIncomplete <- TRUE
         label_text <- vapply(completions, "[[", character(1), "label")
         sort_text <- vapply(completions, "[[", character(1), "sortText")

--- a/R/completion.R
+++ b/R/completion.R
@@ -427,12 +427,55 @@ imported_object_completion <- function(workspace, token, snippet_support) {
     completions
 }
 
+#' Select the best completion candidates without constructing completion items
+#' @noRd
+completion_select_indices <- function(labels, sort_text, token, limit) {
+    if (length(labels) <= limit) {
+        return(seq_along(labels))
+    }
+    selected <- .Call(
+        "completion_select_c",
+        PACKAGE = "languageserver",
+        labels,
+        sort_text,
+        token,
+        as.integer(limit)
+    )
+    if (is.null(selected)) {
+        candidate_order <- order(
+            !startsWith(labels, token), sort_text, method = "radix")
+        selected <- candidate_order[seq_len(limit)]
+    }
+    selected
+}
+
 
 #' Complete any object in the workspace
 #' @noRd
 workspace_completion <- function(workspace, token,
-    package = NULL, exported_only = TRUE, snippet_support = NULL) {
-    completions <- list()
+    package = NULL, exported_only = TRUE, snippet_support = NULL, limit = Inf) {
+    candidates <- list()
+
+    append_candidates <- function(objects, kind, detail, sort_prefix,
+        type, package, is_function = FALSE) {
+        if (!length(objects)) {
+            return(NULL)
+        }
+        size <- length(objects)
+        recycle <- function(value) {
+            if (length(value) == 1L) rep.int(value, size) else value
+        }
+        candidates[[length(candidates) + 1L]] <<- list(
+            label = objects,
+            kind = recycle(kind),
+            detail = recycle(detail),
+            sort_text = paste0(sort_prefix, objects),
+            type = recycle(type),
+            package = recycle(package),
+            is_function = recycle(is_function)
+        )
+        NULL
+    }
 
     if (is.null(package)) {
         packages <- c(WORKSPACE, workspace$loaded_packages)
@@ -454,66 +497,118 @@ workspace_completion <- function(workspace, token,
                 sort_prefix <- sort_prefixes$global
             }
 
-            functs_completions <- ns_function_completion(ns, token,
-                exported_only = TRUE, snippet_support = snippet_support)
+            functs <- ns$get_symbols(want_functs = TRUE, exported_only = TRUE)
+            functs <- functs[match_with(functs, token)]
+            append_candidates(
+                functs, CompletionItemKind$Function, tag, sort_prefix,
+                "function", nsname, is_function = TRUE)
 
             nonfuncts <- ns$get_symbols(want_functs = FALSE, exported_only = TRUE)
             nonfuncts <- nonfuncts[match_with(nonfuncts, token)]
-            nonfuncts_completions <- lapply(nonfuncts, function(object) {
-                list(label = object,
-                     kind = CompletionItemKind$Field,
-                     detail = tag,
-                     sortText = paste0(sort_prefix, object),
-                     data = list(
-                         type = "nonfunction",
-                         package = nsname
-                     ))
-            })
+            append_candidates(
+                nonfuncts, CompletionItemKind$Field, tag, sort_prefix,
+                "nonfunction", nsname)
+
             lazydata <- ns$get_lazydata()
             lazydata <- lazydata[match_with(lazydata, token)]
-            lazydata_completions <- lapply(lazydata, function(object) {
-                list(label = object,
-                     kind = CompletionItemKind$Field,
-                     detail = tag,
-                     sortText = paste0(sort_prefix, object),
-                     data = list(
-                         type = "lazydata",
-                         package = nsname
-                     ))
-            })
-            completions <- c(completions,
-                functs_completions,
-                nonfuncts_completions,
-                lazydata_completions)
+            append_candidates(
+                lazydata, CompletionItemKind$Field, tag, sort_prefix,
+                "lazydata", nsname)
         }
     } else {
         ns <- workspace$get_namespace(package)
         if (!is.null(ns)) {
             tag <- paste0("{", package, "}")
-            functs_completions <- ns_function_completion(ns, token,
-                exported_only = FALSE, snippet_support = snippet_support)
+            functs <- ns$get_symbols(want_functs = TRUE, exported_only = FALSE)
+            functs <- functs[match_with(functs, token)]
+            append_candidates(
+                functs, CompletionItemKind$Function, tag, sort_prefixes$global,
+                "function", package, is_function = TRUE)
 
             nonfuncts <- ns$get_symbols(want_functs = FALSE, exported_only = FALSE)
             nonfuncts <- nonfuncts[match_with(nonfuncts, token)]
-            nonfuncts_completions <- lapply(nonfuncts, function(object) {
-                list(label = object,
-                     kind = CompletionItemKind$Field,
-                     detail = tag,
-                     sortText = paste0(sort_prefixes$global, object),
-                     data = list(
-                         type = "nonfunction",
-                         package = package
-                     ))
-            })
-            completions <- c(completions,
-                functs_completions,
-                nonfuncts_completions)
+            append_candidates(
+                nonfuncts, CompletionItemKind$Field, tag, sort_prefixes$global,
+                "nonfunction", package)
         }
     }
 
     if (is.null(package)) {
-        imported_completions <- imported_object_completion(workspace, token, snippet_support)
-        completions <- c(completions, imported_completions)
+        keys <- as.character(workspace$imported_objects$keys())
+        keys <- keys[match_with(keys, token)]
+        imported_labels <- character(length(keys))
+        imported_packages <- character(length(keys))
+        imported_count <- 0L
+        for (object in keys) {
+            nsname <- workspace$imported_objects$get(object)
+            ns <- workspace$get_namespace(nsname)
+            if (!is.null(ns) && ns$exists_funct(object)) {
+                imported_count <- imported_count + 1L
+                imported_labels[[imported_count]] <- object
+                imported_packages[[imported_count]] <- nsname
+            }
+        }
+        if (imported_count) {
+            selected <- seq_len(imported_count)
+            imported_labels <- imported_labels[selected]
+            imported_packages <- imported_packages[selected]
+            append_candidates(
+                imported_labels,
+                CompletionItemKind$Function,
+                paste0("{", imported_packages, "}"),
+                sort_prefixes$imported,
+                "function",
+                imported_packages,
+                is_function = TRUE
+            )
+        }
+    }
+
+    if (!length(candidates)) {
+        return(list())
+    }
+
+    combine <- function(name) {
+        unlist(lapply(candidates, "[[", name), use.names = FALSE)
+    }
+    labels <- combine("label")
+    sort_text <- combine("sort_text")
+    truncated <- length(labels) > limit
+    selected <- completion_select_indices(labels, sort_text, token, limit)
+
+    labels <- labels[selected]
+    kinds <- combine("kind")[selected]
+    details <- combine("detail")[selected]
+    sort_text <- sort_text[selected]
+    types <- combine("type")[selected]
+    packages <- combine("package")[selected]
+    functions <- combine("is_function")[selected]
+
+    completions <- unname(Map(function(label, kind, detail, sort_text,
+        type, package, is_function) {
+        if (isTRUE(snippet_support) && is_function) {
+            list(
+                label = label,
+                kind = kind,
+                detail = detail,
+                sortText = sort_text,
+                insertText = paste0(label, "($0)"),
+                insertTextFormat = InsertTextFormat$Snippet,
+                data = list(type = type, package = package)
+            )
+        } else {
+            list(
+                label = label,
+                kind = kind,
+                detail = detail,
+                sortText = sort_text,
+                data = list(type = type, package = package)
+            )
+        }
+    }, labels, kinds, details, sort_text, types, packages, functions))
+
+    if (truncated) {
+        attr(completions, "truncated") <- TRUE
     }
 
     completions
@@ -600,9 +695,8 @@ scope_completion <- function(uri, workspace, token, point,
     candidate_names <- c(scope_symbol_names, scope_funct_names)
     truncated <- length(candidate_names) > limit
     if (truncated) {
-        candidate_order <- order(
-            !startsWith(candidate_names, token), candidate_names)
-        keep <- candidate_order[seq_len(limit)]
+        keep <- completion_select_indices(
+            candidate_names, candidate_names, token, limit)
         symbol_keep <- keep[keep <= length(scope_symbol_names)]
         function_keep <- keep[keep > length(scope_symbol_names)] -
             length(scope_symbol_names)
@@ -708,7 +802,8 @@ token_completion <- function(uri, workspace, token, exclude = NULL, limit = Inf)
     symbols <- setdiff(symbols, exclude)
     truncated <- length(symbols) > limit
     if (truncated) {
-        symbols <- sort(symbols)[seq_len(limit)]
+        selected <- completion_select_indices(symbols, symbols, token, limit)
+        symbols <- symbols[selected]
     }
     completions <- lapply(symbols, function(symbol) {
         list(
@@ -761,10 +856,12 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
                 package_completion(token),
                 scope_completions)
         }
-        completions <- c(
-            completions,
-            workspace_completion(
-                workspace, token, package, token_result$accessor == "::", snippet_support))
+        workspace_completions <- workspace_completion(
+            workspace, token, package, token_result$accessor == "::",
+            snippet_support, nmax)
+        providers_incomplete <- providers_incomplete ||
+            isTRUE(attr(workspace_completions, "truncated"))
+        completions <- c(completions, workspace_completions)
     }
 
     if (token_result$accessor == "") {
@@ -799,8 +896,9 @@ completion_reply <- function(id, uri, workspace, document, point, capabilities) 
         isIncomplete <- TRUE
         label_text <- vapply(completions, "[[", character(1), "label")
         sort_text <- vapply(completions, "[[", character(1), "sortText")
-        order <- order(!startsWith(label_text, token), sort_text)
-        completions <- completions[order][seq_len(nmax)]
+        selected <- completion_select_indices(
+            label_text, sort_text, token, nmax)
+        completions <- completions[selected]
     } else {
         isIncomplete <- FALSE
     }

--- a/R/completion.R
+++ b/R/completion.R
@@ -75,144 +75,22 @@ completion_parse_data <- function(data) {
         ))
     }
 
-    rows <- seq_len(nrow(data))
-    children <- list2env(split(rows, data$parent), hash = TRUE,
-        parent = emptyenv())
-    row_by_id <- integer(max(data$id) + 1L)
-    row_by_id[data$id + 1L] <- rows
+    index <- .Call(
+        "completion_parse_index_c",
+        PACKAGE = "languageserver",
+        data$id,
+        data$parent,
+        data$token,
+        data$line1,
+        data$col1,
+        data$line2,
+        data$col2
+    )
 
-    child_rows <- function(id) {
-        children[[as.character(id)]]
-    }
-
-    top_row <- function(row) {
-        parent <- data$parent[[row]]
-        while (parent != 0L) {
-            row <- row_by_id[[parent + 1L]]
-            parent <- data$parent[[row]]
-        }
-        row
-    }
-
-    symbol_row <- function(expr_row) {
-        expr_children <- child_rows(data$id[[expr_row]])
-        if (length(expr_children) == 1L &&
-                data$token[[expr_children]] == "SYMBOL") {
-            expr_children
-        } else {
-            NA_integer_
-        }
-    }
-
-    is_function_expr <- function(expr_row) {
-        expr_children <- child_rows(data$id[[expr_row]])
-        any(data$token[expr_children] %in% c("FUNCTION", "'\\\\'"))
-    }
-
-    assignment_rows <- which(data$token %in%
-            c("LEFT_ASSIGN", "RIGHT_ASSIGN", "EQ_ASSIGN"))
-    for_rows <- which(data$token == "forcond")
-    formal_rows <- which(data$token == "SYMBOL_FORMALS")
-
-    symbol_name_rows <- integer(length(assignment_rows) + length(for_rows))
-    symbol_range_rows <- integer(length(symbol_name_rows))
-    function_name_rows <- integer(length(assignment_rows))
-    function_range_rows <- integer(length(function_name_rows))
-    formal_name_rows <- integer(length(formal_rows))
-    formal_range_rows <- integer(length(formal_name_rows))
-    symbol_count <- 0L
-    function_count <- 0L
-    formal_count <- 0L
-
-    for (assignment_row in assignment_rows) {
-        siblings <- child_rows(data$parent[[assignment_row]])
-        expr_siblings <- siblings[data$token[siblings] == "expr"]
-        is_left <- data$token[[assignment_row]] != "RIGHT_ASSIGN"
-
-        if (is_left) {
-            candidates <- expr_siblings[
-                data$line2[expr_siblings] < data$line1[[assignment_row]] |
-                    data$line2[expr_siblings] == data$line1[[assignment_row]] &
-                        data$col2[expr_siblings] < data$col1[[assignment_row]]
-            ]
-            candidates <- candidates[order(
-                data$line2[candidates], data$col2[candidates])]
-            name_expr <- tail(candidates, 1L)
-
-            value_candidates <- expr_siblings[
-                data$line1[expr_siblings] > data$line2[[assignment_row]] |
-                    data$line1[expr_siblings] == data$line2[[assignment_row]] &
-                        data$col1[expr_siblings] > data$col2[[assignment_row]]
-            ]
-            value_candidates <- value_candidates[order(
-                data$line1[value_candidates], data$col1[value_candidates])]
-            value_expr <- head(value_candidates, 1L)
-        } else {
-            candidates <- expr_siblings[
-                data$line1[expr_siblings] > data$line2[[assignment_row]] |
-                    data$line1[expr_siblings] == data$line2[[assignment_row]] &
-                        data$col1[expr_siblings] > data$col2[[assignment_row]]
-            ]
-            candidates <- candidates[order(
-                data$line1[candidates], data$col1[candidates])]
-            name_expr <- head(candidates, 1L)
-
-            value_candidates <- expr_siblings[
-                data$line2[expr_siblings] < data$line1[[assignment_row]] |
-                    data$line2[expr_siblings] == data$line1[[assignment_row]] &
-                        data$col2[expr_siblings] < data$col1[[assignment_row]]
-            ]
-            value_candidates <- value_candidates[order(
-                data$line2[value_candidates], data$col2[value_candidates])]
-            value_expr <- tail(value_candidates, 1L)
-        }
-
-        if (!length(name_expr) || !length(value_expr)) {
-            next
-        }
-        name_row <- symbol_row(name_expr)
-        if (is.na(name_row)) {
-            next
-        }
-        range_row <- top_row(name_row)
-        if (is_function_expr(value_expr)) {
-            function_count <- function_count + 1L
-            function_name_rows[[function_count]] <- name_row
-            function_range_rows[[function_count]] <- range_row
-        } else {
-            symbol_count <- symbol_count + 1L
-            symbol_name_rows[[symbol_count]] <- name_row
-            symbol_range_rows[[symbol_count]] <- range_row
-        }
-    }
-
-    for (for_row in for_rows) {
-        name_rows <- child_rows(data$id[[for_row]])
-        name_rows <- name_rows[data$token[name_rows] == "SYMBOL"]
-        for (name_row in name_rows) {
-            symbol_count <- symbol_count + 1L
-            symbol_name_rows[[symbol_count]] <- name_row
-            symbol_range_rows[[symbol_count]] <- top_row(name_row)
-        }
-    }
-
-    for (name_row in formal_rows) {
-        range_row <- row_by_id[[data$parent[[name_row]] + 1L]]
-        if (!range_row) {
-            next
-        }
-        formal_count <- formal_count + 1L
-        formal_name_rows[[formal_count]] <- name_row
-        formal_range_rows[[formal_count]] <- range_row
-    }
-
-    make_records <- function(name_rows, range_rows, size) {
-        if (!size) {
+    make_records <- function(name_rows, range_rows) {
+        if (!length(name_rows)) {
             return(empty_scope())
         }
-        selected <- seq_len(size)
-        name_rows <- name_rows[selected]
-        range_rows <- range_rows[selected]
         list(
             name = data$text[name_rows],
             line = data$line1[name_rows],
@@ -223,23 +101,12 @@ completion_parse_data <- function(data) {
         )
     }
 
-    token_rows <- which(data$token %in%
-            c("SYMBOL", "SYMBOL_SUB", "SYMBOL_FORMALS", "SYMBOL_FUNCTION_CALL"))
-    dollar_parents <- data$parent[data$token == "'$'"]
-    empty_token_rows <- which(
-        data$token == "SYMBOL_SUB" |
-            data$token == "SYMBOL" & data$parent %in% dollar_parents
-    )
-
     list(
-        tokens = unique(data$text[token_rows]),
-        empty_tokens = unique(data$text[empty_token_rows]),
-        symbols = make_records(
-            symbol_name_rows, symbol_range_rows, symbol_count),
-        functions = make_records(
-            function_name_rows, function_range_rows, function_count),
-        formals = make_records(
-            formal_name_rows, formal_range_rows, formal_count)
+        tokens = unique(data$text[index$token]),
+        empty_tokens = unique(data$text[index$empty_token]),
+        symbols = make_records(index$symbol_name, index$symbol_range),
+        functions = make_records(index$function_name, index$function_range),
+        formals = make_records(index$formal_name, index$formal_range)
     )
 }
 

--- a/R/document.R
+++ b/R/document.R
@@ -509,12 +509,14 @@ parse_document <- function(uri, content) {
             env$documentation <- list()
             env$xml_data <- NULL
             env$xml_doc <- NULL
+            env$completion_data <- NULL
             env$content_hash <- content_hash  # Store hash for cache validation
             env
         }
         env <- parse_env()
         parse_expr(content, expr, env)
         env$packages <- basename(find.package(env$packages, quiet = TRUE))
+        env$completion_data <- completion_parse_data(getParseData(expr))
         # Performance: XML generation is expensive, but necessary for analysis
         env$xml_data <- xmlparsedata::xml_parse_data(expr)
         # IMPORTANT: Do NOT create xml_doc here - this function runs in a child process

--- a/R/utils.R
+++ b/R/utils.R
@@ -644,16 +644,48 @@ glue <- function(.x, ...) {
     .x
 }
 
+xdoc_top_level_index <- function(x) {
+    nodes <- xml_children(x)
+    nodes <- nodes[xml_name(nodes) == "expr"]
+    list(
+        nodes = nodes,
+        line1 = as.integer(xml_attr(nodes, "line1")),
+        col1 = as.integer(xml_attr(nodes, "col1")),
+        line2 = as.integer(xml_attr(nodes, "line2")),
+        col2 = as.integer(xml_attr(nodes, "col2"))
+    )
+}
+
 xdoc_find_enclosing_scopes <- function(x, line, col, top = FALSE) {
-    if (top) {
-        xpath <- "/exprlist | //expr[(@line1 < {line} or (@line1 = {line} and @col1 <= {col})) and
-                (@line2 > {line} or (@line2 = {line} and @col2 >= {col}-1))]"
+    index <- attr(x, "top_level_index", exact = TRUE)
+    condition <- paste(
+        "(@line1 < {line} or (@line1 = {line} and @col1 <= {col})) and",
+        "(@line2 > {line} or (@line2 = {line} and @col2 >= {col}-1))"
+    )
+    condition <- glue(condition, line = line, col = col)
+
+    if (is.null(index)) {
+        xpath <- paste0(
+            "/exprlist/expr[", condition,
+            "]/descendant-or-self::expr[", condition, "]"
+        )
+        scopes <- xml_find_all(x, xpath)
     } else {
-        xpath <- "//expr[(@line1 < {line} or (@line1 = {line} and @col1 <= {col})) and
-                (@line2 > {line} or (@line2 = {line} and @col2 >= {col}-1))]"
+        selected <-
+            (index$line1 < line |
+                index$line1 == line & index$col1 <= col) &
+            (index$line2 > line |
+                index$line2 == line & index$col2 >= col - 1L)
+        scopes <- xml_find_all(index$nodes[selected],
+            paste0("descendant-or-self::expr[", condition, "]"))
     }
-    xpath <- glue(xpath, line = line, col = col)
-    xml_find_all(x, xpath)
+
+    if (top) {
+        root <- xml_find_all(x, "/exprlist")
+        structure(c(unclass(root), unclass(scopes)), class = "xml_nodeset")
+    } else {
+        scopes
+    }
 }
 
 xdoc_find_token <- function(x, line, col) {

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -254,6 +254,10 @@ Workspace <- R6::R6Class("Workspace",
             if (!is.null(parse_data$xml_data)) {
                 parse_data$xml_doc <- tryCatch(
                     xml2::read_xml(parse_data$xml_data), error = function(e) NULL)
+                if (!is.null(parse_data$xml_doc)) {
+                    attr(parse_data$xml_doc, "top_level_index") <-
+                        xdoc_top_level_index(parse_data$xml_doc)
+                }
             }
             self$documents$get(uri)$update_parse_data(parse_data)
             

--- a/src/completion.c
+++ b/src/completion.c
@@ -1,0 +1,331 @@
+#include "completion.h"
+
+#include <limits.h>
+#include <string.h>
+
+typedef enum {
+    TOKEN_OTHER = 0,
+    TOKEN_EXPR,
+    TOKEN_SYMBOL,
+    TOKEN_SYMBOL_SUB,
+    TOKEN_SYMBOL_FORMALS,
+    TOKEN_SYMBOL_FUNCTION_CALL,
+    TOKEN_FUNCTION,
+    TOKEN_LAMBDA,
+    TOKEN_LEFT_ASSIGN,
+    TOKEN_RIGHT_ASSIGN,
+    TOKEN_EQ_ASSIGN,
+    TOKEN_FORCOND,
+    TOKEN_DOLLAR
+} completion_token_kind;
+
+static completion_token_kind classify_token(SEXP value) {
+    if (value == NA_STRING) {
+        return TOKEN_OTHER;
+    }
+
+    const char *token = CHAR(value);
+    if (strcmp(token, "expr") == 0) return TOKEN_EXPR;
+    if (strcmp(token, "SYMBOL") == 0) return TOKEN_SYMBOL;
+    if (strcmp(token, "SYMBOL_SUB") == 0) return TOKEN_SYMBOL_SUB;
+    if (strcmp(token, "SYMBOL_FORMALS") == 0) return TOKEN_SYMBOL_FORMALS;
+    if (strcmp(token, "SYMBOL_FUNCTION_CALL") == 0) return TOKEN_SYMBOL_FUNCTION_CALL;
+    if (strcmp(token, "FUNCTION") == 0) return TOKEN_FUNCTION;
+    if (strcmp(token, "'\\\\'") == 0) return TOKEN_LAMBDA;
+    if (strcmp(token, "LEFT_ASSIGN") == 0) return TOKEN_LEFT_ASSIGN;
+    if (strcmp(token, "RIGHT_ASSIGN") == 0) return TOKEN_RIGHT_ASSIGN;
+    if (strcmp(token, "EQ_ASSIGN") == 0) return TOKEN_EQ_ASSIGN;
+    if (strcmp(token, "forcond") == 0) return TOKEN_FORCOND;
+    if (strcmp(token, "'$'") == 0) return TOKEN_DOLLAR;
+    return TOKEN_OTHER;
+}
+
+static int is_before(
+    int row,
+    int assignment,
+    const int *line1,
+    const int *col1,
+    const int *line2,
+    const int *col2
+) {
+    return line2[row] < line1[assignment] ||
+        (line2[row] == line1[assignment] && col2[row] < col1[assignment]);
+}
+
+static int is_after(
+    int row,
+    int assignment,
+    const int *line1,
+    const int *col1,
+    const int *line2,
+    const int *col2
+) {
+    return line1[row] > line2[assignment] ||
+        (line1[row] == line2[assignment] && col1[row] > col2[assignment]);
+}
+
+static int simple_symbol_row(
+    int expr_row,
+    const int *id,
+    const int *first_child,
+    const int *next_sibling,
+    const completion_token_kind *kind
+) {
+    int child = first_child[id[expr_row]];
+    if (child >= 0 && next_sibling[child] < 0 && kind[child] == TOKEN_SYMBOL) {
+        return child;
+    }
+    return -1;
+}
+
+static int is_function_expr(
+    int expr_row,
+    const int *id,
+    const int *first_child,
+    const int *next_sibling,
+    const completion_token_kind *kind
+) {
+    int child = first_child[id[expr_row]];
+    while (child >= 0) {
+        if (kind[child] == TOKEN_FUNCTION || kind[child] == TOKEN_LAMBDA) {
+            return 1;
+        }
+        child = next_sibling[child];
+    }
+    return 0;
+}
+
+static int top_row(
+    int row,
+    const int *parent,
+    const int *row_by_id,
+    int max_id
+) {
+    int parent_id = parent[row];
+    while (parent_id != 0) {
+        if (parent_id < 0 || parent_id > max_id || row_by_id[parent_id] < 0) {
+            return -1;
+        }
+        row = row_by_id[parent_id];
+        parent_id = parent[row];
+    }
+    return row;
+}
+
+static SEXP row_vector(const int *rows, int size) {
+    SEXP result = Rf_allocVector(INTSXP, size);
+    int *out = INTEGER(result);
+    for (int i = 0; i < size; i++) {
+        out[i] = rows[i] + 1;
+    }
+    return result;
+}
+
+SEXP completion_parse_index_c(
+    SEXP id,
+    SEXP parent,
+    SEXP token,
+    SEXP line1,
+    SEXP col1,
+    SEXP line2,
+    SEXP col2
+) {
+    if (!Rf_isInteger(id) || !Rf_isInteger(parent) ||
+            !Rf_isInteger(line1) || !Rf_isInteger(col1) ||
+            !Rf_isInteger(line2) || !Rf_isInteger(col2) ||
+            !Rf_isString(token)) {
+        Rf_error("completion parse columns have invalid types");
+    }
+
+    R_xlen_t n_long = XLENGTH(id);
+    if (n_long > INT_MAX) {
+        Rf_error("completion parse data is too large");
+    }
+    int n = (int) n_long;
+    if (XLENGTH(parent) != n || XLENGTH(token) != n ||
+            XLENGTH(line1) != n || XLENGTH(col1) != n ||
+            XLENGTH(line2) != n || XLENGTH(col2) != n) {
+        Rf_error("completion parse columns have different lengths");
+    }
+
+    const int *id_ptr = INTEGER(id);
+    const int *parent_ptr = INTEGER(parent);
+    const int *line1_ptr = INTEGER(line1);
+    const int *col1_ptr = INTEGER(col1);
+    const int *line2_ptr = INTEGER(line2);
+    const int *col2_ptr = INTEGER(col2);
+
+    int max_id = 0;
+    for (int i = 0; i < n; i++) {
+        if (id_ptr[i] < 0) {
+            Rf_error("completion parse ids must be non-negative");
+        }
+        if (id_ptr[i] > max_id) max_id = id_ptr[i];
+        if (parent_ptr[i] > max_id) max_id = parent_ptr[i];
+    }
+    if (max_id == INT_MAX) {
+        Rf_error("completion parse id is too large");
+    }
+
+    int *row_by_id = (int *) R_alloc((size_t) max_id + 1, sizeof(int));
+    int *first_child = (int *) R_alloc((size_t) max_id + 1, sizeof(int));
+    int *last_child = (int *) R_alloc((size_t) max_id + 1, sizeof(int));
+    int *next_sibling = (int *) R_alloc((size_t) n, sizeof(int));
+    int *parent_has_dollar = (int *) R_alloc((size_t) max_id + 1, sizeof(int));
+    completion_token_kind *kind = (completion_token_kind *)
+        R_alloc((size_t) n, sizeof(completion_token_kind));
+
+    for (int i = 0; i <= max_id; i++) {
+        row_by_id[i] = -1;
+        first_child[i] = -1;
+        last_child[i] = -1;
+        parent_has_dollar[i] = 0;
+    }
+    for (int i = 0; i < n; i++) {
+        next_sibling[i] = -1;
+        kind[i] = classify_token(STRING_ELT(token, i));
+
+        int node_id = id_ptr[i];
+        if (node_id > 0) {
+            if (row_by_id[node_id] >= 0) {
+                Rf_error("completion parse ids must be unique");
+            }
+            row_by_id[node_id] = i;
+        }
+
+        int parent_id = parent_ptr[i];
+        if (parent_id >= 0) {
+            if (first_child[parent_id] < 0) {
+                first_child[parent_id] = i;
+            } else {
+                next_sibling[last_child[parent_id]] = i;
+            }
+            last_child[parent_id] = i;
+            if (kind[i] == TOKEN_DOLLAR) {
+                parent_has_dollar[parent_id] = 1;
+            }
+        }
+    }
+
+    int *symbol_name = (int *) R_alloc((size_t) n, sizeof(int));
+    int *symbol_range = (int *) R_alloc((size_t) n, sizeof(int));
+    int *function_name = (int *) R_alloc((size_t) n, sizeof(int));
+    int *function_range = (int *) R_alloc((size_t) n, sizeof(int));
+    int *formal_name = (int *) R_alloc((size_t) n, sizeof(int));
+    int *formal_range = (int *) R_alloc((size_t) n, sizeof(int));
+    int *token_rows = (int *) R_alloc((size_t) n, sizeof(int));
+    int *empty_token_rows = (int *) R_alloc((size_t) n, sizeof(int));
+    int symbol_count = 0;
+    int function_count = 0;
+    int formal_count = 0;
+    int token_count = 0;
+    int empty_token_count = 0;
+
+    for (int i = 0; i < n; i++) {
+        if ((i & 16383) == 0) R_CheckUserInterrupt();
+
+        if (kind[i] == TOKEN_SYMBOL || kind[i] == TOKEN_SYMBOL_SUB ||
+                kind[i] == TOKEN_SYMBOL_FORMALS ||
+                kind[i] == TOKEN_SYMBOL_FUNCTION_CALL) {
+            token_rows[token_count++] = i;
+        }
+        if (kind[i] == TOKEN_SYMBOL_SUB ||
+                (kind[i] == TOKEN_SYMBOL && parent_ptr[i] >= 0 &&
+                    parent_has_dollar[parent_ptr[i]])) {
+            empty_token_rows[empty_token_count++] = i;
+        }
+
+        if (kind[i] == TOKEN_SYMBOL_FORMALS) {
+            int parent_id = parent_ptr[i];
+            if (parent_id < 0 || parent_id > max_id) continue;
+            int range_row = row_by_id[parent_id];
+            if (range_row >= 0) {
+                formal_name[formal_count] = i;
+                formal_range[formal_count++] = range_row;
+            }
+            continue;
+        }
+
+        if (kind[i] != TOKEN_LEFT_ASSIGN &&
+                kind[i] != TOKEN_RIGHT_ASSIGN &&
+                kind[i] != TOKEN_EQ_ASSIGN) {
+            continue;
+        }
+
+        if (parent_ptr[i] < 0 || parent_ptr[i] > max_id) continue;
+        int before = -1;
+        int after = -1;
+        int sibling = first_child[parent_ptr[i]];
+        while (sibling >= 0) {
+            if (kind[sibling] == TOKEN_EXPR) {
+                if (is_before(sibling, i, line1_ptr, col1_ptr, line2_ptr, col2_ptr)) {
+                    before = sibling;
+                } else if (after < 0 && is_after(
+                        sibling, i, line1_ptr, col1_ptr, line2_ptr, col2_ptr)) {
+                    after = sibling;
+                }
+            }
+            sibling = next_sibling[sibling];
+        }
+
+        int is_left = kind[i] != TOKEN_RIGHT_ASSIGN;
+        int name_expr = is_left ? before : after;
+        int value_expr = is_left ? after : before;
+        if (name_expr < 0 || value_expr < 0) continue;
+
+        int name_row = simple_symbol_row(
+            name_expr, id_ptr, first_child, next_sibling, kind);
+        if (name_row < 0) continue;
+        int range_row = top_row(name_row, parent_ptr, row_by_id, max_id);
+        if (range_row < 0) continue;
+
+        if (is_function_expr(value_expr, id_ptr, first_child, next_sibling, kind)) {
+            function_name[function_count] = name_row;
+            function_range[function_count++] = range_row;
+        } else {
+            symbol_name[symbol_count] = name_row;
+            symbol_range[symbol_count++] = range_row;
+        }
+    }
+
+    /* Keep loop variables after assignments to preserve provider ordering. */
+    for (int i = 0; i < n; i++) {
+        if (kind[i] != TOKEN_FORCOND) continue;
+        int child = first_child[id_ptr[i]];
+        while (child >= 0) {
+            if (kind[child] == TOKEN_SYMBOL) {
+                int range_row = top_row(child, parent_ptr, row_by_id, max_id);
+                if (range_row >= 0) {
+                    symbol_name[symbol_count] = child;
+                    symbol_range[symbol_count++] = range_row;
+                }
+            }
+            child = next_sibling[child];
+        }
+    }
+
+    SEXP result = PROTECT(Rf_allocVector(VECSXP, 8));
+    SEXP names = PROTECT(Rf_allocVector(STRSXP, 8));
+    const char *result_names[] = {
+        "symbol_name", "symbol_range", "function_name", "function_range",
+        "formal_name", "formal_range", "token", "empty_token"
+    };
+    const int *result_rows[] = {
+        symbol_name, symbol_range, function_name, function_range,
+        formal_name, formal_range, token_rows, empty_token_rows
+    };
+    int result_sizes[] = {
+        symbol_count, symbol_count, function_count, function_count,
+        formal_count, formal_count, token_count, empty_token_count
+    };
+
+    for (int i = 0; i < 8; i++) {
+        SET_STRING_ELT(names, i, Rf_mkChar(result_names[i]));
+        SEXP value = PROTECT(row_vector(result_rows[i], result_sizes[i]));
+        SET_VECTOR_ELT(result, i, value);
+        UNPROTECT(1);
+    }
+    Rf_setAttrib(result, R_NamesSymbol, names);
+    UNPROTECT(2);
+    return result;
+}

--- a/src/completion.c
+++ b/src/completion.c
@@ -121,6 +121,153 @@ static SEXP row_vector(const int *rows, int size) {
     return result;
 }
 
+typedef struct {
+    const char **labels;
+    const char **sort_text;
+    const char *token;
+    size_t token_length;
+} completion_order_context;
+
+static int starts_with_token(
+    const char *label,
+    const completion_order_context *context
+) {
+    return strlen(label) >= context->token_length &&
+        strncmp(label, context->token, context->token_length) == 0;
+}
+
+/* Negative means a should sort before b. */
+static int compare_completion_candidates(
+    int a,
+    int b,
+    const completion_order_context *context
+) {
+    int a_prefix = starts_with_token(context->labels[a], context);
+    int b_prefix = starts_with_token(context->labels[b], context);
+    if (a_prefix != b_prefix) return b_prefix - a_prefix;
+
+    int comparison = strcmp(context->sort_text[a], context->sort_text[b]);
+    if (comparison != 0) return comparison;
+    return a < b ? -1 : a > b;
+}
+
+/* The heap root is the worst currently selected candidate. */
+static void completion_heap_sift_up(
+    int *heap,
+    int child,
+    const completion_order_context *context
+) {
+    while (child > 0) {
+        int parent = (child - 1) / 2;
+        if (compare_completion_candidates(
+                heap[parent], heap[child], context) >= 0) break;
+        int value = heap[parent];
+        heap[parent] = heap[child];
+        heap[child] = value;
+        child = parent;
+    }
+}
+
+static void completion_heap_sift_down(
+    int *heap,
+    int size,
+    const completion_order_context *context
+) {
+    int parent = 0;
+    while (1) {
+        int left = parent * 2 + 1;
+        if (left >= size) break;
+        int right = left + 1;
+        int worse = left;
+        if (right < size && compare_completion_candidates(
+                heap[left], heap[right], context) < 0) {
+            worse = right;
+        }
+        if (compare_completion_candidates(
+                heap[parent], heap[worse], context) >= 0) break;
+        int value = heap[parent];
+        heap[parent] = heap[worse];
+        heap[worse] = value;
+        parent = worse;
+    }
+}
+
+SEXP completion_select_c(
+    SEXP labels,
+    SEXP sort_text,
+    SEXP token,
+    SEXP limit
+) {
+    if (!Rf_isString(labels) || !Rf_isString(sort_text) ||
+            !Rf_isString(token) || XLENGTH(token) != 1 ||
+            !Rf_isInteger(limit) || XLENGTH(limit) != 1) {
+        Rf_error("invalid completion selector arguments");
+    }
+    R_xlen_t n_long = XLENGTH(labels);
+    if (n_long > INT_MAX || XLENGTH(sort_text) != n_long) {
+        Rf_error("invalid completion selector lengths");
+    }
+    int n = (int) n_long;
+    int max_selected = INTEGER(limit)[0];
+    if (max_selected == NA_INTEGER || max_selected < 0) {
+        Rf_error("completion selector limit must be non-negative");
+    }
+    if (max_selected > n) max_selected = n;
+
+    if (STRING_ELT(token, 0) == NA_STRING) {
+        Rf_error("completion selector token must not be missing");
+    }
+    const char **label_text = (const char **)
+        R_alloc((size_t) n, sizeof(const char *));
+    const char **sort_text_values = (const char **)
+        R_alloc((size_t) n, sizeof(const char *));
+    for (int i = 0; i < n; i++) {
+        if (STRING_ELT(labels, i) == NA_STRING ||
+                STRING_ELT(sort_text, i) == NA_STRING) {
+            Rf_error("completion selector candidates must not be missing");
+        }
+        label_text[i] = Rf_translateCharUTF8(STRING_ELT(labels, i));
+        sort_text_values[i] = Rf_translateCharUTF8(STRING_ELT(sort_text, i));
+    }
+    const char *token_text = Rf_translateCharUTF8(STRING_ELT(token, 0));
+
+    completion_order_context context = {
+        label_text,
+        sort_text_values,
+        token_text,
+        strlen(token_text)
+    };
+
+    int *heap = (int *) R_alloc((size_t) max_selected, sizeof(int));
+    int heap_size = 0;
+    for (int i = 0; i < n; i++) {
+        if ((i & 16383) == 0) R_CheckUserInterrupt();
+        if (heap_size < max_selected) {
+            heap[heap_size] = i;
+            completion_heap_sift_up(heap, heap_size, &context);
+            heap_size++;
+        } else if (max_selected > 0 && compare_completion_candidates(
+                i, heap[0], &context) < 0) {
+            heap[0] = i;
+            completion_heap_sift_down(heap, heap_size, &context);
+        }
+    }
+
+    /* Sorting at most max_completions entries is cheap and deterministic. */
+    for (int i = 1; i < heap_size; i++) {
+        int value = heap[i];
+        int position = i;
+        while (position > 0 && compare_completion_candidates(
+                value, heap[position - 1], &context) < 0) {
+            heap[position] = heap[position - 1];
+            position--;
+        }
+        heap[position] = value;
+    }
+
+    return row_vector(heap, heap_size);
+}
+
 SEXP completion_parse_index_c(
     SEXP id,
     SEXP parent,

--- a/src/completion.h
+++ b/src/completion.h
@@ -1,0 +1,18 @@
+#ifndef COMPLETION_H__
+#define COMPLETION_H__
+
+#include <R.h>
+#include <Rinternals.h>
+
+/* Extract row indexes needed to build document completion indexes. */
+SEXP completion_parse_index_c(
+    SEXP id,
+    SEXP parent,
+    SEXP token,
+    SEXP line1,
+    SEXP col1,
+    SEXP line2,
+    SEXP col2
+);
+
+#endif /* end of include guard: COMPLETION_H__ */

--- a/src/completion.h
+++ b/src/completion.h
@@ -15,4 +15,12 @@ SEXP completion_parse_index_c(
     SEXP col2
 );
 
+/* Select the best completion candidate indexes with bounded memory. */
+SEXP completion_select_c(
+    SEXP labels,
+    SEXP sort_text,
+    SEXP token,
+    SEXP limit
+);
+
 #endif /* end of include guard: COMPLETION_H__ */

--- a/src/languageserver.c
+++ b/src/languageserver.c
@@ -4,6 +4,7 @@
 #include "encoding.h"
 #include "token.h"
 #include "match.h"
+#include "completion.h"
 
 #ifdef _WIN32
 
@@ -37,6 +38,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"scan_token_c", (DL_FUNC) &scan_token_c, 3},
     {"match_with_c", (DL_FUNC) &match_with_c, 2},
     {"fuzzy_find_c", (DL_FUNC) &fuzzy_find_c, 2},
+    {"completion_parse_index_c", (DL_FUNC) &completion_parse_index_c, 7},
 #if !defined(_WIN32)
     {"process_is_detached", (DL_FUNC) &process_is_detached},
 #endif

--- a/src/languageserver.c
+++ b/src/languageserver.c
@@ -39,6 +39,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"match_with_c", (DL_FUNC) &match_with_c, 2},
     {"fuzzy_find_c", (DL_FUNC) &fuzzy_find_c, 2},
     {"completion_parse_index_c", (DL_FUNC) &completion_parse_index_c, 7},
+    {"completion_select_c", (DL_FUNC) &completion_select_c, 4},
 #if !defined(_WIN32)
     {"process_is_detached", (DL_FUNC) &process_is_detached},
 #endif

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -1334,3 +1334,81 @@ test_that("Completion of argument values for positional in multi-parameter funct
     expect_false("slow" %in% labels)
     expect_false("plain" %in% labels)
 })
+
+test_that("Completion providers use precomputed document indexes", {
+    fixture <- provider_fixture(c(
+        "xvar0 <- rnorm(10)",
+        "my_fun <- function(xvar1) {",
+        "    xvar2 = 1",
+        "    2 -> xvar3",
+        "    for (xvar4 in 1:10) {",
+        "        xvar",
+        "    }",
+        "}"
+    ))
+    parse_data <- fixture$workspace$get_parse_data(fixture$uri)
+
+    # Prove these providers do not need to traverse the XML document.
+    parse_data$xml_doc <- NULL
+    scope_items <- scope_completion(
+        fixture$uri,
+        fixture$workspace,
+        "xvar",
+        list(row = 5L, col = 12L)
+    )
+    scope_labels <- vapply(scope_items, `[[`, character(1L), "label")
+    expect_setequal(scope_labels, c("xvar1", "xvar2", "xvar3", "xvar4"))
+
+    token_items <- token_completion(
+        fixture$uri, fixture$workspace, "xvar")
+    token_labels <- vapply(token_items, `[[`, character(1L), "label")
+    expect_setequal(token_labels,
+        c("xvar0", "xvar1", "xvar2", "xvar3", "xvar4", "xvar"))
+})
+
+test_that("Completion providers bound broad result sets early", {
+    variables <- sprintf("    value_%04d <- %d", 1:500, 1:500)
+    fixture <- provider_fixture(c(
+        "my_fun <- function() {",
+        variables,
+        "    value_",
+        "}"
+    ))
+
+    items <- scope_completion(
+        fixture$uri,
+        fixture$workspace,
+        "value_",
+        list(row = 501L, col = 10L),
+        limit = 20L
+    )
+
+    expect_length(items, 20L)
+    expect_true(isTRUE(attr(items, "truncated")))
+    expect_equal(
+        sort(vapply(items, `[[`, character(1L), "label")),
+        sprintf("value_%04d", 1:20)
+    )
+})
+
+test_that("Argument value completion resolves formals once", {
+    calls <- 0L
+    workspace <- new.env(parent = baseenv())
+    workspace$guess_namespace <- function(...) "example"
+    workspace$get_formals <- function(...) {
+        calls <<- calls + 1L
+        alist(
+            method = c("auto", "manual"),
+            style = c("plain", "fancy")
+        )
+    }
+
+    items <- arg_value_completion(
+        NULL, workspace, NULL, NULL, "a", "my_fun")
+
+    expect_equal(calls, 1L)
+    expect_setequal(
+        vapply(items, `[[`, character(1L), "label"),
+        c("auto", "manual", "plain", "fancy")
+    )
+})

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -1412,3 +1412,24 @@ test_that("Argument value completion resolves formals once", {
         c("auto", "manual", "plain", "fancy")
     )
 })
+
+test_that("Completion parse index handles supported symbol forms", {
+    parse_data <- parse_document("file:///completion-index.R", c(
+        "# assignments",
+        "left_value <- 1",
+        "2 -> right_value",
+        "equal_value = 3",
+        "left_fun <- function(argument) argument",
+        "lambda_fun <- \\(lambda_argument) lambda_argument",
+        "for (loop_value in 1:3) print(loop_value)",
+        "object$member",
+        "target(named = 1)"
+    ))$completion_data
+
+    expect_setequal(parse_data$symbols$name,
+        c("left_value", "right_value", "equal_value", "loop_value"))
+    expect_setequal(parse_data$functions$name, c("left_fun", "lambda_fun"))
+    expect_setequal(parse_data$formals$name,
+        c("argument", "lambda_argument"))
+    expect_setequal(parse_data$empty_tokens, c("member", "named"))
+})

--- a/tests/testthat/test-completion.R
+++ b/tests/testthat/test-completion.R
@@ -1389,6 +1389,54 @@ test_that("Completion providers bound broad result sets early", {
         sort(vapply(items, `[[`, character(1L), "label")),
         sprintf("value_%04d", 1:20)
     )
+
+    namespace <- new.env(parent = baseenv())
+    namespace$get_symbols <- function(want_functs, ...) {
+        if (want_functs) {
+            sprintf("value_function_%04d", 500:1)
+        } else {
+            sprintf("value_field_%04d", 500:1)
+        }
+    }
+    namespace$get_lazydata <- function() sprintf("value_data_%04d", 500:1)
+    workspace <- new.env(parent = baseenv())
+    workspace$get_namespace <- function(...) namespace
+
+    workspace_items <- workspace_completion(
+        workspace,
+        "value_",
+        package = "example",
+        exported_only = TRUE,
+        limit = 20L
+    )
+    all_labels <- c(
+        namespace$get_symbols(TRUE),
+        namespace$get_symbols(FALSE),
+        namespace$get_lazydata()
+    )
+    expected <- all_labels[
+        order(paste0(sort_prefixes$global, all_labels), method = "radix")
+    ][1:20]
+
+    expect_length(workspace_items, 20L)
+    expect_true(isTRUE(attr(workspace_items, "truncated")))
+    expect_equal(
+        vapply(workspace_items, `[[`, character(1L), "label"),
+        expected
+    )
+})
+
+test_that("Completion candidate selection uses stable UTF-8 radix ordering", {
+    labels <- c("zeta", "äther", "Alpha", ".hidden", "_private", "alpha")
+    sort_text <- paste0(sort_prefixes$global, labels)
+    token <- "a"
+    expected <- order(
+        !startsWith(labels, token), sort_text, method = "radix")[1:4]
+
+    expect_identical(
+        completion_select_indices(labels, sort_text, token, 4L),
+        expected
+    )
 })
 
 test_that("Argument value completion resolves formals once", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -22,3 +22,21 @@ test_that("xdoc_find_token retains document order for other boundaries", {
     token <- xdoc_find_token(xdoc, line = 1, col = 3)
     expect_equal(xml2::xml_name(token), "OP-LEFT-PAREN")
 })
+
+test_that("indexed enclosing scope lookup preserves results", {
+    xdoc <- parse_xdoc(c(
+        "first <- 1",
+        "fun <- function(argument) {",
+        "  nested <- argument",
+        "  nested",
+        "}"
+    ))
+    expected <- xdoc_find_enclosing_scopes(xdoc, line = 4L, col = 5L,
+        top = TRUE)
+
+    attr(xdoc, "top_level_index") <- xdoc_top_level_index(xdoc)
+    actual <- xdoc_find_enclosing_scopes(xdoc, line = 4L, col = 5L,
+        top = TRUE)
+
+    expect_equal(xml2::xml_path(actual), xml2::xml_path(expected))
+})


### PR DESCRIPTION
## Summary

- pre-index document completion candidates during background parsing and cache reusable workspace data
- bound workspace, scope, and token providers before constructing LSP completion items
- add native parse-tree indexing and bounded top-N selection for completion hot paths
- use deterministic UTF-8 radix ordering for truncated completion lists

## Performance compared with master

The benchmark compares clean source archives of untouched `master` at `a3c8133` and this PR at `19539bc`.

| Completion path | master median | PR median | Speedup | Time reduction |
| --- | ---: | ---: | ---: | ---: |
| Full completion request | 5,357.40 ms | 18.00 ms | 297.6x | 99.66% |
| Scope provider | 5,178.08 ms | 6.46 ms | 801.7x | 99.88% |
| Token provider | 134.94 ms | 1.28 ms | 105.3x | 99.05% |
| Workspace provider | 23.78 ms | 3.95 ms | 6.0x | 83.38% |

The full request returns the same configured maximum of 200 completion items on both revisions. Measured R allocations for that request fall from 5.66 MB to 4.24 MB, a 25.1% reduction.

### Benchmark methodology

- R 4.5.1 on arm64 macOS
- 10,000 matching in-scope symbols and 10,000 matching workspace symbols
- token `value_`, snippets disabled, and `max_completions = 200`
- three warm-up runs followed by 10 measured iterations per path; table reports `bench::mark()` medians
- parsing and fixture setup excluded to measure completion-request latency after background parse data is available
- provider result counts are intentionally different: master constructs all 10,000 candidates before final truncation, while the PR bounds each broad provider at 200; the end-to-end request returns 200 on both

## Testing

- completion test suite: 175 passed, 0 failed
- utility test suite passed
- native compilation succeeded
- `git diff --check` passed