### PR TITLE
Improve inlay hint argument tooltips

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
   parameter-name inlay hints.
 - Make parameter-name inlay hints conservative by default and open VS Code's
   semantic call hierarchy when a function call-count lens is clicked.
+- Show function signatures and argument documentation in parameter-name inlay
+  hint tooltips, consistent with function-argument hovers.
 - Use incremental document synchronization, reject stale background results,
   cache workspace routing, and reduce event-loop latency for more responsive
   editing.

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -544,7 +544,8 @@ text_document_inlay_hint <- function(self, id, params) {
 #' `inlayHint/resolve` request handler
 #' @noRd
 inlay_hint_resolve <- function(self, id, params) {
-    self$deliver(inlay_hint_resolve_reply(id, params))
+    workspace <- self$get_workspace(params$data$uri)
+    self$deliver(inlay_hint_resolve_reply(id, workspace, params))
 }
 
 #' `textDocument/semanticTokens/full` request handler

--- a/R/hover.R
+++ b/R/hover.R
@@ -6,6 +6,28 @@ hover_xpath <- paste(
     "forcond/SYMBOL[text() = '{token_quote}' and @line1 <= {row}]",
     sep = "|")
 
+#' Format hover contents for a function argument
+#' @noRd
+function_argument_hover_contents <- function(workspace, funct, package, parameter) {
+    doc <- workspace$get_documentation(funct, package, isf = TRUE)
+    if (!is.list(doc)) return(NULL)
+
+    doc_string <- doc$arguments[[parameter]]
+    if (is.null(doc_string)) {
+        doc_string <- doc$arguments$...
+        parameter <- "..."
+    }
+    if (is.null(doc_string)) return(NULL)
+
+    sig <- workspace$get_signature(funct, package)
+    if (is.null(sig)) return(doc_string)
+
+    c(
+        sprintf("```r\n%s\n```", str_trunc(sig, 300)),
+        sprintf("`%s` - %s", parameter, doc_string)
+    )
+}
+
 #' The response to a textDocument/hover Request
 #'
 #' When hovering on a symbol, if it is a function, return its help text
@@ -141,26 +163,8 @@ hover_reply <- function(id, uri, workspace, document, point) {
                     }
 
                     if (!resolved) {
-                        doc <- workspace$get_documentation(funct, package, isf = TRUE)
-                        doc_string <- NULL
-                        if (is.list(doc)) {
-                            doc_string <- doc$arguments[[token_text]]
-                            if (is.null(doc_string)) {
-                                doc_string <- doc$arguments$...
-                                token_text <- "..."
-                            }
-                        }
-                        if (!is.null(doc_string)) {
-                            sig <- workspace$get_signature(funct, package)
-                            if (is.null(sig)) {
-                                contents <- doc_string
-                            } else {
-                                sig <- str_trunc(sig, 300)
-                                contents <- c(
-                                    sprintf("```r\n%s\n```", sig),
-                                    sprintf("`%s` - %s", token_text, doc_string))
-                            }
-                        }
+                        contents <- function_argument_hover_contents(
+                            workspace, funct, package, token_text)
                         resolved <- TRUE
                     }
                 }

--- a/R/inlay_hint.R
+++ b/R/inlay_hint.R
@@ -149,6 +149,7 @@ inlay_hint_reply <- function(id, uri, workspace, document, request_range) {
                 kind = 2L,
                 paddingRight = TRUE,
                 data = list(
+                    uri = uri,
                     functionName = function_name,
                     package = package,
                     parameter = formal_name
@@ -164,7 +165,7 @@ inlay_hint_reply <- function(id, uri, workspace, document, request_range) {
 
 #' Resolve explanatory text for an inlay hint
 #' @noRd
-inlay_hint_resolve_reply <- function(id, hint) {
+inlay_hint_resolve_reply <- function(id, workspace, hint) {
     function_name <- hint$data$functionName
     parameter <- hint$data$parameter
     package <- hint$data$package
@@ -177,9 +178,15 @@ inlay_hint_resolve_reply <- function(id, hint) {
     } else {
         paste0(package, "::", function_name)
     }
+    contents <- function_argument_hover_contents(
+        workspace, function_name, package, parameter)
+    if (is.null(contents)) {
+        contents <- sprintf(
+            "Parameter `%s` of `%s()`.", parameter, qualified_name)
+    }
     hint$tooltip <- list(
         kind = "markdown",
-        value = sprintf("Parameter `%s` of `%s()`.", parameter, qualified_name)
+        value = paste(contents, collapse = "\n\n")
     )
     Response$new(id, result = hint)
 }

--- a/tests/testthat/test-inlay-hint.R
+++ b/tests/testthat/test-inlay-hint.R
@@ -21,9 +21,21 @@ test_that("inlay hints name non-obvious positional R arguments", {
     )
     expect_true(all(vapply(reply$result, `[[`, integer(1L), "kind") == 2L))
 
-    resolved <- inlay_hint_resolve_reply(2L, reply$result[[1L]])$result
-    expect_match(resolved$tooltip$value, "`trim`")
-    expect_match(resolved$tooltip$value, "`mean\\(\\)`")
+    fixture$workspace$get_documentation <- function(...) {
+        list(arguments = list(trim = "the fraction of observations to trim."))
+    }
+    fixture$workspace$get_signature <- function(...) {
+        "mean(x, trim = 0, na.rm = FALSE)"
+    }
+    resolved <- inlay_hint_resolve_reply(
+        2L, fixture$workspace, reply$result[[1L]])$result
+    expect_equal(
+        resolved$tooltip$value,
+        paste0(
+            "```r\nmean(x, trim = 0, na.rm = FALSE)\n```\n\n",
+            "`trim` - the fraction of observations to trim."
+        )
+    )
 })
 
 test_that("inlay hints skip syntax and simple calls", {
@@ -152,4 +164,8 @@ test_that("inlay hints work through the language server", {
         vapply(hints, `[[`, character(1L), "label"),
         c("mean =", "sd =")
     )
+
+    resolved <- respond(client, "inlayHint/resolve", hints[[1L]])
+    expect_match(resolved$tooltip$value, "```r\\nrnorm\\(")
+    expect_match(resolved$tooltip$value, "`mean` - vector of means")
 })


### PR DESCRIPTION
## Summary

- reuse function-argument hover formatting for inlay hint tooltips
- include function signatures and parameter documentation when available
- resolve hints against the originating workspace and retain the existing fallback

## Tests

- `devtools::test(filter = "inlay-hint", stop_on_failure = TRUE)` (11 passed)
- `devtools::test(filter = "hover", stop_on_failure = TRUE)` (166 passed)