### PR TITLE
Add extract and inline refactorings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@
 - Add preferred quick fixes for common `lintr` diagnostics and a conflict-aware
   `source.fixAll` action, while making multi-line `nolint` actions apply to every
   affected line.
+- Add previewable `refactor.extract` actions for variables and functions with
+  local free-variable analysis, plus a conservative `refactor.inline` action
+  for single-use local variables.
 - Add LSP 3.18 capability updates, including multiple-range formatting,
   explicit UTF-16 position encoding, and the semantic token `label` type.
 - Add R-focused code lenses for function call counts, linked editing between
@@ -44,6 +47,7 @@
 
 **Closed issues:**
 
+- Add extract and inline refactorings (#94)
 - Failed to run diagnostics: ! in callr subprocess. Caused by error in `call[[1L]]` (#723)
 
 **Merged pull requests:**

--- a/R/capabilities.R
+++ b/R/capabilities.R
@@ -47,7 +47,8 @@ DocumentLinkOptions <- list(
 )
 
 CodeActionOptions <- list(
-    codeActionKinds = list("quickfix", "source.fixAll")
+    codeActionKinds = list(
+        "quickfix", "refactor.extract", "refactor.inline", "source.fixAll")
 )
 
 RenameOptions <- list(

--- a/R/code_action.R
+++ b/R/code_action.R
@@ -12,7 +12,16 @@ CodeActionKind <- list(
 
 #' Create a workspace edit for one document
 #' @noRd
-code_action_workspace_edit <- function(uri, edits) {
+code_action_workspace_edit <- function(uri, edits, document = NULL,
+    client_capabilities = NULL) {
+    supports_document_changes <- isTRUE(
+        client_capabilities$workspace$workspaceEdit$documentChanges)
+    if (supports_document_changes && !is.null(document)) {
+        return(list(documentChanges = list(list(
+            textDocument = list(uri = uri, version = document$version),
+            edits = edits
+        ))))
+    }
     changes <- list(edits)
     names(changes) <- uri
     list(changes = changes)
@@ -441,7 +450,8 @@ code_action_suppression_actions <- function(uri, document, diagnostics) {
 #' The response to a textDocument/codeAction Request
 #'
 #' @keywords internal
-document_code_action_reply <- function(id, uri, workspace, document, range, context) {
+document_code_action_reply <- function(id, uri, workspace, document, range, context,
+    client_capabilities = NULL) {
     diagnostics <- context$diagnostics
     if (is.null(diagnostics)) diagnostics <- list()
     only <- context$only
@@ -471,6 +481,12 @@ document_code_action_reply <- function(id, uri, workspace, document, range, cont
                 uri, lapply(selected, function(fix) fix$edit))
         )
     }
+
+    result <- c(
+        result,
+        refactor_code_actions(
+            uri, workspace, document, range, only, client_capabilities)
+    )
 
     result <- Filter(function(action) {
         code_action_kind_requested(action$kind, only)

--- a/R/completion.R
+++ b/R/completion.R
@@ -58,6 +58,10 @@ completion_parse_data <- function(data) {
         list(
             name = character(),
             line = integer(),
+            definition_line1 = integer(),
+            definition_col1 = integer(),
+            definition_line2 = integer(),
+            definition_col2 = integer(),
             line1 = integer(),
             col1 = integer(),
             line2 = integer(),
@@ -94,6 +98,10 @@ completion_parse_data <- function(data) {
         list(
             name = data$text[name_rows],
             line = data$line1[name_rows],
+            definition_line1 = data$line1[name_rows],
+            definition_col1 = data$col1[name_rows],
+            definition_line2 = data$line2[name_rows],
+            definition_col2 = data$col2[name_rows],
             line1 = data$line1[range_rows],
             col1 = data$col1[range_rows],
             line2 = data$line2[range_rows],

--- a/R/handlers-langfeatures.R
+++ b/R/handlers-langfeatures.R
@@ -178,7 +178,9 @@ text_document_code_action  <- function(self, id, params) {
         end = document$from_lsp_position(params$range$end)
     )
     context <- params$context
-    self$deliver(document_code_action_reply(id, uri, workspace, document, range, context))
+    self$deliver(document_code_action_reply(
+        id, uri, workspace, document, range, context,
+        self$ClientCapabilities))
 }
 
 #' `textDocument/codeLens` request handler

--- a/R/refactor.R
+++ b/R/refactor.R
@@ -1,0 +1,976 @@
+#' Compare internal code-point positions
+#' @noRd
+refactor_compare_point <- function(left, right) {
+    if (left$row < right$row ||
+            left$row == right$row && left$col < right$col) {
+        -1L
+    } else if (left$row > right$row ||
+            left$row == right$row && left$col > right$col) {
+        1L
+    } else {
+        0L
+    }
+}
+
+#' Convert an XML parse node to an internal code-point range
+#' @noRd
+refactor_node_range <- function(node) {
+    list(
+        start = list(
+            row = as.integer(xml_attr(node, "line1")) - 1L,
+            col = as.integer(xml_attr(node, "col1")) - 1L
+        ),
+        end = list(
+            row = as.integer(xml_attr(node, "line2")) - 1L,
+            col = as.integer(xml_attr(node, "col2"))
+        )
+    )
+}
+
+#' Test internal range relationships
+#' @noRd
+refactor_range_equal <- function(left, right) {
+    refactor_compare_point(left$start, right$start) == 0L &&
+        refactor_compare_point(left$end, right$end) == 0L
+}
+
+#' @noRd
+refactor_range_contains <- function(outer, inner) {
+    refactor_compare_point(outer$start, inner$start) <= 0L &&
+        refactor_compare_point(outer$end, inner$end) >= 0L
+}
+
+#' Extract text from an internal code-point range
+#' @noRd
+refactor_range_text <- function(document, item_range) {
+    start <- item_range$start
+    end <- item_range$end
+    if (start$row == end$row) {
+        return(substr(
+            document$line0(start$row), start$col + 1L, end$col
+        ))
+    }
+    lines <- document$content[(start$row:end$row) + 1L]
+    lines[[1L]] <- substr(lines[[1L]], start$col + 1L, nchar(lines[[1L]]))
+    lines[[length(lines)]] <- substr(
+        lines[[length(lines)]], 1L, end$col
+    )
+    paste(lines, collapse = "\n")
+}
+
+#' Move one code-point position forward
+#' @noRd
+refactor_next_point <- function(document, point) {
+    line_length <- nchar(document$line0(point$row))
+    if (point$col < line_length) {
+        list(row = point$row, col = point$col + 1L)
+    } else if (point$row + 1L < document$nline) {
+        list(row = point$row + 1L, col = 0L)
+    } else {
+        point
+    }
+}
+
+#' Move one code-point position backward
+#' @noRd
+refactor_previous_point <- function(document, point) {
+    if (point$col > 0L) {
+        list(row = point$row, col = point$col - 1L)
+    } else if (point$row > 0L) {
+        row <- point$row - 1L
+        list(row = row, col = nchar(document$line0(row)))
+    } else {
+        point
+    }
+}
+
+#' Trim whitespace around an internal range
+#' @noRd
+refactor_trim_range <- function(document, item_range) {
+    start <- item_range$start
+    end <- item_range$end
+    while (refactor_compare_point(start, end) < 0L) {
+        line <- document$line0(start$row)
+        character <- if (start$col < nchar(line)) {
+            substr(line, start$col + 1L, start$col + 1L)
+        } else {
+            "\n"
+        }
+        if (!grepl("\\s", character, perl = TRUE)) break
+        next_point <- refactor_next_point(document, start)
+        if (refactor_compare_point(next_point, start) == 0L) break
+        start <- next_point
+    }
+    while (refactor_compare_point(start, end) < 0L) {
+        previous <- refactor_previous_point(document, end)
+        line <- document$line0(previous$row)
+        character <- if (previous$col < nchar(line)) {
+            substr(line, previous$col + 1L, previous$col + 1L)
+        } else {
+            "\n"
+        }
+        if (!grepl("\\s", character, perl = TRUE)) break
+        if (refactor_compare_point(previous, end) == 0L) break
+        end <- previous
+    }
+    list(start = start, end = end)
+}
+
+#' Convert an internal range to an LSP range
+#' @noRd
+refactor_lsp_range <- function(document, item_range) {
+    range(
+        document$to_lsp_position(
+            item_range$start$row, item_range$start$col
+        ),
+        document$to_lsp_position(item_range$end$row, item_range$end$col)
+    )
+}
+
+#' Test whether a node is a sequential statement container
+#' @noRd
+refactor_sequence_container <- function(node) {
+    name <- xml_name(node)
+    identical(name, "exprlist") ||
+        identical(name, "expr") &&
+            length(xml_find_all(node, "OP-LEFT-BRACE")) > 0L
+}
+
+#' Find the statement and sequential container enclosing an expression
+#' @noRd
+refactor_statement_context <- function(node) {
+    current <- node
+    repeat {
+        parent <- xml_parent(current)
+        if (inherits(parent, "xml_missing") || !length(parent)) {
+            return(NULL)
+        }
+        if (refactor_sequence_container(parent)) {
+            return(list(statement = current, container = parent))
+        }
+        parent_tokens <- xml_name(xml_children(parent))
+        if (any(parent_tokens %in% c(
+            "IF", "ELSE", "FOR", "WHILE", "REPEAT", "FUNCTION"
+        ))) {
+            return(NULL)
+        }
+        current <- parent
+    }
+}
+
+#' Test whether two XML nodes are the same node
+#' @noRd
+refactor_same_node <- function(left, right) {
+    identical(xml_path(left), xml_path(right))
+}
+
+#' Test whether an expression can be replaced by another expression
+#' @noRd
+refactor_expression_movable <- function(node, statement) {
+    current <- node
+    repeat {
+        if (refactor_same_node(current, statement)) {
+            return(TRUE)
+        }
+        parent <- xml_parent(current)
+        if (inherits(parent, "xml_missing") || !length(parent)) {
+            return(FALSE)
+        }
+        children <- xml_children(parent)
+        paths <- vapply(children, xml_path, character(1L))
+        current_index <- match(xml_path(current), paths)
+        if (is.na(current_index)) {
+            return(FALSE)
+        }
+        child_names <- xml_name(children)
+
+        assignments <- which(child_names %in% c(
+            "LEFT_ASSIGN", "RIGHT_ASSIGN", "EQ_ASSIGN"
+        ))
+        if (length(assignments)) {
+            operator_index <- assignments[[1L]]
+            right_assignment <- identical(
+                child_names[[operator_index]], "RIGHT_ASSIGN"
+            )
+            if ((!right_assignment && current_index < operator_index) ||
+                    (right_assignment && current_index > operator_index)) {
+                return(FALSE)
+            }
+        }
+
+        open_parenthesis <- which(child_names == "OP-LEFT-PAREN")
+        if (length(open_parenthesis) &&
+                current_index < open_parenthesis[[1L]]) {
+            return(FALSE)
+        }
+
+        member_operators <- which(child_names %in% c(
+            "OP-DOLLAR", "OP-AT", "NS_GET", "NS_GET_INT"
+        ))
+        if (length(member_operators) &&
+                current_index > member_operators[[1L]]) {
+            return(FALSE)
+        }
+        current <- parent
+    }
+}
+
+#' Find an expression exactly matching a selected range
+#' @noRd
+refactor_exact_expression <- function(xdoc, selected_range) {
+    nodes <- xml_find_all(xdoc, "//expr[@line1]")
+    matches <- vapply(nodes, function(node) {
+        refactor_range_equal(refactor_node_range(node), selected_range)
+    }, logical(1L))
+    nodes <- nodes[matches]
+    if (!length(nodes)) {
+        return(NULL)
+    }
+    nodes[[length(nodes)]]
+}
+
+#' Find contiguous statement expressions matching a selected range
+#' @noRd
+refactor_statement_selection <- function(xdoc, selected_range) {
+    containers <- xml_find_all(xdoc, "/exprlist | //expr[OP-LEFT-BRACE]")
+    result <- NULL
+    for (container in containers) {
+        children <- xml_children(container)
+        children <- children[xml_name(children) == "expr"]
+        if (!length(children)) next
+        child_ranges <- lapply(children, refactor_node_range)
+        selected <- which(vapply(child_ranges, function(item_range) {
+            refactor_range_contains(selected_range, item_range)
+        }, logical(1L)))
+        if (!length(selected) || any(diff(selected) != 1L)) next
+        combined <- list(
+            start = child_ranges[[selected[[1L]]]]$start,
+            end = child_ranges[[selected[[length(selected)]]]]$end
+        )
+        if (!refactor_range_equal(combined, selected_range)) next
+        result <- list(
+            nodes = children[selected],
+            container = container,
+            range = combined
+        )
+    }
+    result
+}
+
+#' Validate that a range lies in one R source region
+#' @noRd
+refactor_range_in_r_region <- function(document, item_range) {
+    if (!check_r_region(document, item_range$start)) {
+        return(FALSE)
+    }
+    end_point <- refactor_previous_point(document, item_range$end)
+    if (!check_r_region(document, end_point)) {
+        return(FALSE)
+    }
+    if (!document$is_rmarkdown) {
+        return(TRUE)
+    }
+    start_cell <- literate_r_cell_at(document$regions, item_range$start$row)
+    end_cell <- literate_r_cell_at(document$regions, end_point$row)
+    !is.null(start_cell) && !is.null(end_cell) &&
+        identical(start_cell$start_line, end_cell$start_line)
+}
+
+#' Build the shared context for selection-based refactorings
+#' @noRd
+refactor_selection_context <- function(uri, workspace, document, item_range) {
+    if (is.null(workspace)) {
+        return(NULL)
+    }
+    parse_data <- current_parse_data(uri, workspace, document)
+    if (is.null(parse_data) || isTRUE(parse_data$parse_error) ||
+            is.null(parse_data$xml_doc)) {
+        return(NULL)
+    }
+    selected_range <- refactor_trim_range(document, item_range)
+    if (refactor_compare_point(
+        selected_range$start, selected_range$end
+    ) >= 0L ||
+        !refactor_range_in_r_region(document, selected_range)) {
+        return(NULL)
+    }
+    expression <- refactor_exact_expression(
+        parse_data$xml_doc, selected_range
+    )
+    statements <- refactor_statement_selection(
+        parse_data$xml_doc, selected_range
+    )
+    if (is.null(expression) && is.null(statements)) {
+        return(NULL)
+    }
+    list(
+        parse_data = parse_data,
+        xdoc = parse_data$xml_doc,
+        range = selected_range,
+        expression = expression,
+        statements = statements
+    )
+}
+
+#' Return direct token names contained by a parse node
+#' @noRd
+refactor_token_names <- function(node) {
+    xml_name(xml_find_all(node, ".//*[not(*)]"))
+}
+
+#' Return function-call names contained by a parse node
+#' @noRd
+refactor_call_names <- function(node) {
+    xml_text(xml_find_all(node, ".//SYMBOL_FUNCTION_CALL"))
+}
+
+#' Detect syntax whose evaluation context cannot safely move
+#' @noRd
+refactor_unsafe_syntax <- function(node, extracting_function = FALSE) {
+    token_names <- refactor_token_names(node)
+    token_text <- xml_text(xml_find_all(
+        node,
+        ".//*[self::LEFT_ASSIGN or self::RIGHT_ASSIGN]"
+    ))
+    calls <- refactor_call_names(node)
+    unsafe_calls <- c(
+        "quote", "substitute", "bquote", "expression", "alist",
+        "missing", "match.call", "parent.frame", "sys.call", "sys.calls",
+        "sys.frame", "sys.function"
+    )
+    if (extracting_function) {
+        unsafe_calls <- c(unsafe_calls, "return", "on.exit", "nargs")
+    }
+    any(token_names %in% c("OP-TILDE", "BREAK", "NEXT")) ||
+        extracting_function && any(token_names %in% c("FUNCTION", "OP-LAMBDA")) ||
+        any(token_text %in% c("<<-", "->>")) ||
+        any(calls %in% unsafe_calls)
+}
+
+#' Parse a simple standalone assignment expression
+#' @noRd
+refactor_assignment_parts <- function(node) {
+    if (!identical(xml_name(node), "expr")) {
+        return(NULL)
+    }
+    children <- xml_children(node)
+    names <- xml_name(children)
+    operators <- which(names %in% c(
+        "LEFT_ASSIGN", "RIGHT_ASSIGN", "EQ_ASSIGN"
+    ))
+    if (length(operators) != 1L) {
+        return(NULL)
+    }
+    operator_index <- operators[[1L]]
+    operator <- children[[operator_index]]
+    operator_text <- xml_text(operator)
+    if (operator_text %in% c("<<-", "->>")) {
+        return(NULL)
+    }
+    if (names[[operator_index]] %in% c("LEFT_ASSIGN", "EQ_ASSIGN")) {
+        if (operator_index <= 1L || operator_index >= length(children)) {
+            return(NULL)
+        }
+        target <- children[[operator_index - 1L]]
+        value <- children[[operator_index + 1L]]
+    } else {
+        if (operator_index <= 1L || operator_index >= length(children)) {
+            return(NULL)
+        }
+        value <- children[[operator_index - 1L]]
+        target <- children[[operator_index + 1L]]
+    }
+    target_children <- xml_children(target)
+    if (length(target_children) != 1L ||
+            !identical(xml_name(target_children[[1L]]), "SYMBOL")) {
+        return(NULL)
+    }
+    list(
+        node = node,
+        target = target,
+        target_node = target_children[[1L]],
+        name = xml_text(target_children[[1L]]),
+        value = value,
+        operator = operator_text
+    )
+}
+
+#' Find an assignment ancestor defining a symbol occurrence
+#' @noRd
+refactor_definition_assignment <- function(token_node) {
+    current <- token_node
+    repeat {
+        current <- xml_parent(current)
+        if (inherits(current, "xml_missing") || !length(current)) {
+            return(NULL)
+        }
+        assignment <- refactor_assignment_parts(current)
+        if (!is.null(assignment) &&
+            refactor_range_contains(
+                refactor_node_range(assignment$target),
+                refactor_node_range(token_node)
+            )) {
+            return(assignment)
+        }
+        if (identical(xml_name(current), "exprlist")) {
+            return(NULL)
+        }
+    }
+}
+
+#' Collect names visible to generated refactoring bindings
+#' @noRd
+refactor_bound_names <- function(workspace, uri) {
+    result <- character()
+    for (document_uri in workspace_document_uris(workspace, uri)) {
+        parse_data <- workspace$get_parse_data(document_uri)
+        if (is.null(parse_data)) next
+        result <- c(
+            result,
+            names(parse_data$definitions),
+            parse_data$reference_index$name
+        )
+    }
+    unique(result[nzchar(result)])
+}
+
+#' Generate a deterministic collision-free binding name
+#' @noRd
+refactor_unique_name <- function(base, workspace, uri) {
+    existing <- refactor_bound_names(workspace, uri)
+    if (!base %in% existing) {
+        return(base)
+    }
+    suffix <- 2L
+    repeat {
+        candidate <- paste0(base, "_", suffix)
+        if (!candidate %in% existing) {
+            return(candidate)
+        }
+        suffix <- suffix + 1L
+    }
+}
+
+#' Test whether the workspace index is complete enough for a top-level binding
+#' @noRd
+refactor_index_ready <- function(workspace) {
+    index <- workspace$index
+    is.null(index) || !isTRUE(index$enabled) ||
+        !isTRUE(index$truncated) && !length(index$pending)
+}
+
+#' Reindent source text from its original column
+#' @noRd
+refactor_reindent_text <- function(text, original_col, prefix,
+    trim_first = FALSE) {
+    lines <- strsplit(text, "\n", fixed = TRUE)[[1L]]
+    for (i in seq_along(lines)) {
+        if ((i > 1L || isTRUE(trim_first)) && original_col > 0L) {
+            leading <- attr(regexpr("^[ \\t]*", lines[[i]]), "match.length")
+            remove <- min(leading, original_col)
+            lines[[i]] <- substr(lines[[i]], remove + 1L, nchar(lines[[i]]))
+        }
+        lines[[i]] <- paste0(prefix, lines[[i]])
+    }
+    paste(lines, collapse = "\n")
+}
+
+#' Build non-overlapping insertion and replacement edits
+#' @noRd
+refactor_insert_and_replace <- function(document, insertion_point,
+    insertion_text, replacement_range, replacement_text) {
+    if (refactor_compare_point(
+        insertion_point, replacement_range$start
+    ) == 0L) {
+        return(list(text_edit(
+            refactor_lsp_range(document, replacement_range),
+            paste0(insertion_text, replacement_text)
+        )))
+    }
+    list(
+        text_edit(
+            range(
+                document$to_lsp_position(
+                    insertion_point$row, insertion_point$col
+                ),
+                document$to_lsp_position(
+                    insertion_point$row, insertion_point$col
+                )
+            ),
+            insertion_text
+        ),
+        text_edit(
+            refactor_lsp_range(document, replacement_range),
+            replacement_text
+        )
+    )
+}
+
+#' Return indentation and insertion metadata for a statement
+#' @noRd
+refactor_insertion_context <- function(document, statement) {
+    statement_range <- refactor_node_range(statement)
+    row <- statement_range$start$row
+    line <- document$line0(row)
+    prefix <- substr(line, 1L, statement_range$start$col)
+    if (nzchar(prefix) && !grepl("^[ \\t]*$", prefix)) {
+        return(NULL)
+    }
+    list(
+        point = list(row = row, col = 0L),
+        indent = prefix,
+        statement_range = statement_range
+    )
+}
+
+#' Test whether an expression is only a single atomic token
+#' @noRd
+refactor_atomic_expression <- function(node) {
+    terminals <- xml_find_all(node, ".//*[not(*)]")
+    length(terminals) == 1L && xml_name(terminals[[1L]]) %in% c(
+        "SYMBOL", "NUM_CONST", "STR_CONST", "NULL_CONST"
+    )
+}
+
+#' Create an extract-variable code action
+#' @noRd
+refactor_extract_variable_action <- function(uri, workspace, document,
+    context, client_capabilities = NULL) {
+    node <- context$expression
+    if (is.null(node) || refactor_atomic_expression(node) ||
+        refactor_unsafe_syntax(node) ||
+        any(refactor_token_names(node) %in% c(
+            "LEFT_ASSIGN", "RIGHT_ASSIGN", "EQ_ASSIGN", "FUNCTION"
+        ))) {
+        return(NULL)
+    }
+    statement_context <- refactor_statement_context(node)
+    if (is.null(statement_context)) {
+        return(NULL)
+    }
+    if (!refactor_expression_movable(node, statement_context$statement) ||
+            refactor_unsafe_syntax(statement_context$statement)) {
+        return(NULL)
+    }
+    insertion <- refactor_insertion_context(
+        document, statement_context$statement
+    )
+    if (is.null(insertion)) {
+        return(NULL)
+    }
+    if (identical(xml_name(statement_context$container), "exprlist") &&
+            !refactor_index_ready(workspace)) {
+        return(NULL)
+    }
+
+    name <- refactor_unique_name("extracted_value", workspace, uri)
+    selected_text <- refactor_range_text(document, context$range)
+    continuation <- paste0(
+        insertion$indent,
+        strrep(" ", nchar(name) + nchar(" <- "))
+    )
+    lines <- strsplit(selected_text, "\n", fixed = TRUE)[[1L]]
+    if (length(lines) > 1L) {
+        tail_text <- paste(lines[-1L], collapse = "\n")
+        tail_text <- refactor_reindent_text(
+            tail_text, context$range$start$col, continuation,
+            trim_first = TRUE
+        )
+        selected_text <- paste(lines[[1L]], tail_text, sep = "\n")
+    }
+    insertion_text <- paste0(
+        insertion$indent, name, " <- ", selected_text, "\n"
+    )
+    edits <- refactor_insert_and_replace(
+        document,
+        insertion$point,
+        insertion_text,
+        context$range,
+        name
+    )
+    list(
+        title = "Extract expression to variable",
+        kind = CodeActionKind$RefactorExtract,
+        edit = code_action_workspace_edit(
+            uri, edits, document, client_capabilities
+        )
+    )
+}
+
+#' Return indexed occurrence ranges as internal code-point ranges
+#' @noRd
+refactor_occurrence_range <- function(index, i) {
+    list(
+        start = list(
+            row = index$line[[i]], col = index$code_point_col[[i]]
+        ),
+        end = list(
+            row = index$end_line[[i]], col = index$code_point_end_col[[i]]
+        )
+    )
+}
+
+#' Test whether a selection contains a binding definition
+#' @noRd
+refactor_selection_defines_binding <- function(context) {
+    index <- context$parse_data$reference_index
+    if (is.null(index) || !length(index$name)) return(FALSE)
+    any(vapply(which(index$is_definition), function(i) {
+        refactor_range_contains(
+            context$range, refactor_occurrence_range(index, i))
+    }, logical(1L)))
+}
+
+#' Test whether a selected definition is available to a selected read
+#' @noRd
+refactor_definition_precedes_read <- function(context, index, definition, read) {
+    definition_range <- refactor_occurrence_range(index, definition)
+    read_range <- refactor_occurrence_range(index, read)
+    if (refactor_compare_point(
+        definition_range$end, read_range$start) > 0L) return(FALSE)
+
+    token <- xdoc_find_token(
+        context$xdoc,
+        definition_range$start$row + 1L,
+        definition_range$start$col + 1L
+    )
+    if (inherits(token, "xml_missing")) return(FALSE)
+    assignment <- refactor_definition_assignment(token)
+    if (!is.null(assignment) && refactor_range_contains(
+        refactor_node_range(assignment$node), read_range)) return(FALSE)
+    TRUE
+}
+
+#' Analyze free variables and live-out bindings for function extraction
+#' @noRd
+refactor_function_bindings <- function(context) {
+    index <- context$parse_data$reference_index
+    if (is.null(index) || !length(index$name)) {
+        return(list(free = character(), outputs = character()))
+    }
+    inside <- vapply(seq_along(index$name), function(i) {
+        refactor_range_contains(
+            context$range, refactor_occurrence_range(index, i)
+        )
+    }, logical(1L))
+    selected <- which(inside)
+    selected_definitions <- unique(index$definition_key[
+        selected[index$is_definition[selected]]
+    ])
+    reads <- selected[!index$is_definition[selected]]
+    free <- reads[vapply(reads, function(read) {
+        definition_key <- index$definition_key[[read]]
+        if (!startsWith(definition_key, "local:")) return(FALSE)
+        definitions <- selected[
+            index$is_definition[selected] &
+                index$definition_key[selected] == definition_key
+        ]
+        !length(definitions) || !any(vapply(definitions, function(definition) {
+            refactor_definition_precedes_read(
+                context, index, definition, read)
+        }, logical(1L)))
+    }, logical(1L))]
+    free_names <- unique(index$name[free])
+
+    output_indices <- integer()
+    for (definition_key in selected_definitions) {
+        definitions <- selected[
+            index$is_definition[selected] &
+                index$definition_key[selected] == definition_key
+        ]
+        if (!length(definitions)) next
+        later_reads <- which(
+            !index$is_definition &
+                index$definition_key == definition_key &
+                vapply(seq_along(index$name), function(i) {
+                    refactor_compare_point(
+                        refactor_occurrence_range(index, i)$start,
+                        context$range$end
+                    ) >= 0L
+                }, logical(1L))
+        )
+        if (length(later_reads)) {
+            output_indices <- c(
+                output_indices, definitions[[length(definitions)]]
+            )
+        }
+    }
+    list(
+        free = free_names,
+        outputs = unique(index$name[output_indices])
+    )
+}
+
+#' Create an extract-function code action
+#' @noRd
+refactor_extract_function_action <- function(uri, workspace, document,
+    context, client_capabilities = NULL) {
+    selection <- context$statements
+    if (is.null(selection)) {
+        node <- context$expression
+        if (is.null(node)) {
+            return(NULL)
+        }
+        statement_context <- refactor_statement_context(node)
+        if (is.null(statement_context)) {
+            return(NULL)
+        }
+        if (refactor_atomic_expression(node) ||
+            !refactor_expression_movable(
+                node, statement_context$statement
+            ) ||
+            refactor_unsafe_syntax(
+                statement_context$statement,
+                extracting_function = TRUE
+            )) {
+            return(NULL)
+        }
+        selection <- list(
+            nodes = list(node),
+            container = statement_context$container,
+            range = context$range
+        )
+        statement <- statement_context$statement
+    } else {
+        statement <- selection$nodes[[1L]]
+    }
+    unsafe <- vapply(
+        selection$nodes,
+        refactor_unsafe_syntax,
+        logical(1L),
+        extracting_function = TRUE
+    )
+    if (any(unsafe)) {
+        return(NULL)
+    }
+    uses_dots <- vapply(selection$nodes, function(node) {
+        "..." %in% xml_text(xml_find_all(
+            node,
+            ".//*[self::SYMBOL or self::SYMBOL_FORMALS]"
+        ))
+    }, logical(1L))
+    if (any(uses_dots)) {
+        return(NULL)
+    }
+
+    insertion <- refactor_insertion_context(document, statement)
+    if (is.null(insertion)) {
+        return(NULL)
+    }
+    if (identical(xml_name(selection$container), "exprlist") &&
+            !refactor_index_ready(workspace)) {
+        return(NULL)
+    }
+    if (identical(xml_name(selection$container), "exprlist") &&
+            refactor_selection_defines_binding(context)) return(NULL)
+
+    bindings <- refactor_function_bindings(context)
+    if (length(bindings$outputs) > 1L) {
+        return(NULL)
+    }
+    if (length(bindings$outputs)) {
+        final_assignment <- refactor_assignment_parts(
+            selection$nodes[[length(selection$nodes)]]
+        )
+        if (is.null(final_assignment) ||
+                !identical(final_assignment$name, bindings$outputs[[1L]])) {
+            return(NULL)
+        }
+    }
+
+    name <- refactor_unique_name("extracted_function", workspace, uri)
+    if (name %in% bindings$free) {
+        return(NULL)
+    }
+    arguments <- paste(bindings$free, collapse = ", ")
+    selected_text <- refactor_range_text(document, context$range)
+    body_indent <- paste0(insertion$indent, "  ")
+    body <- refactor_reindent_text(
+        selected_text, context$range$start$col, body_indent
+    )
+    insertion_text <- paste0(
+        insertion$indent, name, " <- function(", arguments, ") {\n",
+        body, "\n", insertion$indent, "}\n"
+    )
+    call <- paste0(name, "(", arguments, ")")
+    replacement <- if (length(bindings$outputs)) {
+        paste0(bindings$outputs[[1L]], " <- ", call)
+    } else {
+        call
+    }
+    edits <- refactor_insert_and_replace(
+        document,
+        insertion$point,
+        insertion_text,
+        context$range,
+        replacement
+    )
+    list(
+        title = "Extract selection to function",
+        kind = CodeActionKind$RefactorExtract,
+        edit = code_action_workspace_edit(
+            uri, edits, document, client_capabilities
+        )
+    )
+}
+
+#' Find an indexed symbol occurrence at a requested range
+#' @noRd
+refactor_occurrence_at_range <- function(index, item_range) {
+    if (is.null(index) || !length(index$name)) {
+        return(NULL)
+    }
+    point <- item_range$start
+    candidates <- which(vapply(seq_along(index$name), function(i) {
+        occurrence <- refactor_occurrence_range(index, i)
+        refactor_compare_point(occurrence$start, point) <= 0L &&
+            refactor_compare_point(occurrence$end, point) >= 0L
+    }, logical(1L)))
+    if (!length(candidates)) {
+        return(NULL)
+    }
+    candidates[[1L]]
+}
+
+#' Compute the full-line range used to remove a declaration
+#' @noRd
+refactor_declaration_removal_range <- function(document, assignment_range) {
+    start_row <- assignment_range$start$row
+    end_row <- assignment_range$end$row
+    prefix <- substr(
+        document$line0(start_row), 1L, assignment_range$start$col
+    )
+    suffix <- substr(
+        document$line0(end_row), assignment_range$end$col + 1L,
+        nchar(document$line0(end_row))
+    )
+    if (!grepl("^[ \\t]*$", prefix) || !grepl("^[ \\t]*$", suffix)) {
+        return(NULL)
+    }
+    end <- if (end_row + 1L < document$nline) {
+        list(row = end_row + 1L, col = 0L)
+    } else {
+        list(row = end_row, col = nchar(document$line0(end_row)))
+    }
+    list(start = list(row = start_row, col = 0L), end = end)
+}
+
+#' Create an inline-local-variable code action
+#' @noRd
+refactor_inline_variable_action <- function(uri, workspace, document,
+    item_range, client_capabilities = NULL) {
+    if (is.null(workspace) || !check_r_region(document, item_range$start)) {
+        return(NULL)
+    }
+    parse_data <- current_parse_data(uri, workspace, document)
+    if (is.null(parse_data) || isTRUE(parse_data$parse_error) ||
+            is.null(parse_data$xml_doc)) {
+        return(NULL)
+    }
+    index <- parse_data$reference_index
+    selected <- refactor_occurrence_at_range(index, item_range)
+    if (is.null(selected)) {
+        return(NULL)
+    }
+    definition_key <- index$definition_key[[selected]]
+    if (!startsWith(definition_key, paste0("local:", uri, ":"))) {
+        return(NULL)
+    }
+    same_binding <- which(index$definition_key == definition_key)
+    definitions <- same_binding[index$is_definition[same_binding]]
+    reads <- same_binding[!index$is_definition[same_binding]]
+    if (length(definitions) != 1L || length(reads) != 1L ||
+            !identical(index$definition_kind[[definitions]], "variable")) {
+        return(NULL)
+    }
+    definition_range <- refactor_occurrence_range(index, definitions)
+    read_range <- refactor_occurrence_range(index, reads)
+    if (refactor_compare_point(read_range$start, definition_range$end) <= 0L) {
+        return(NULL)
+    }
+
+    token_node <- xdoc_find_token(
+        parse_data$xml_doc,
+        definition_range$start$row + 1L,
+        definition_range$start$col + 1L
+    )
+    if (inherits(token_node, "xml_missing")) {
+        return(NULL)
+    }
+    assignment <- refactor_definition_assignment(token_node)
+    if (is.null(assignment)) {
+        return(NULL)
+    }
+    parent <- xml_parent(assignment$node)
+    if (!refactor_sequence_container(parent) ||
+            refactor_unsafe_syntax(assignment$value)) {
+        return(NULL)
+    }
+
+    removal_range <- refactor_declaration_removal_range(
+        document, refactor_node_range(assignment$node)
+    )
+    if (is.null(removal_range)) {
+        return(NULL)
+    }
+    read_node <- xdoc_find_token(
+        parse_data$xml_doc,
+        read_range$start$row + 1L,
+        read_range$start$col + 1L
+    )
+    if (inherits(read_node, "xml_missing")) {
+        return(NULL)
+    }
+    read_statement <- refactor_statement_context(xml_parent(read_node))
+    if (is.null(read_statement) ||
+            refactor_unsafe_syntax(read_statement$statement)) {
+        return(NULL)
+    }
+
+    value_text <- refactor_range_text(
+        document, refactor_node_range(assignment$value)
+    )
+    edits <- list(
+        text_edit(refactor_lsp_range(document, removal_range), ""),
+        text_edit(
+            refactor_lsp_range(document, read_range),
+            paste0("(", value_text, ")")
+        )
+    )
+    list(
+        title = sprintf("Inline local variable `%s`", index$name[[selected]]),
+        kind = CodeActionKind$RefactorInline,
+        edit = code_action_workspace_edit(
+            uri, edits, document, client_capabilities
+        )
+    )
+}
+
+#' Return all refactoring actions for a code-action request
+#' @noRd
+refactor_code_actions <- function(uri, workspace, document, item_range, only,
+    client_capabilities = NULL) {
+    result <- list()
+    if (code_action_kind_requested(CodeActionKind$RefactorExtract, only)) {
+        context <- refactor_selection_context(
+            uri, workspace, document, item_range
+        )
+        if (!is.null(context)) {
+            variable <- refactor_extract_variable_action(
+                uri, workspace, document, context, client_capabilities
+            )
+            funct <- refactor_extract_function_action(
+                uri, workspace, document, context, client_capabilities
+            )
+            if (!is.null(variable)) result[[length(result) + 1L]] <- variable
+            if (!is.null(funct)) result[[length(result) + 1L]] <- funct
+        }
+    }
+    if (code_action_kind_requested(CodeActionKind$RefactorInline, only)) {
+        inline <- refactor_inline_variable_action(
+            uri, workspace, document, item_range, client_capabilities
+        )
+        if (!is.null(inline)) result[[length(result) + 1L]] <- inline
+    }
+    result
+}

--- a/R/references.R
+++ b/R/references.R
@@ -19,6 +19,8 @@ reference_parse_data <- function(data, content, completion_data, uri,
         code_point_col = integer(),
         code_point_end_col = integer(),
         definition_key = character(),
+        is_definition = logical(),
+        definition_kind = character(),
         qualified_call = logical(),
         call_package = character()
     )
@@ -39,21 +41,32 @@ reference_parse_data <- function(data, content, completion_data, uri,
     rows <- rows[!member]
     if (!length(rows)) return(empty)
 
-    combine_records <- function(...) {
-        records <- list(...)
+    combine_records <- function(records, kinds) {
         list(
             name = unlist(lapply(records, `[[`, "name"), use.names = FALSE),
             line = unlist(lapply(records, `[[`, "line"), use.names = FALSE),
+            definition_line1 = unlist(lapply(
+                records, `[[`, "definition_line1"), use.names = FALSE),
+            definition_col1 = unlist(lapply(
+                records, `[[`, "definition_col1"), use.names = FALSE),
+            definition_line2 = unlist(lapply(
+                records, `[[`, "definition_line2"), use.names = FALSE),
+            definition_col2 = unlist(lapply(
+                records, `[[`, "definition_col2"), use.names = FALSE),
             line1 = unlist(lapply(records, `[[`, "line1"), use.names = FALSE),
             col1 = unlist(lapply(records, `[[`, "col1"), use.names = FALSE),
             line2 = unlist(lapply(records, `[[`, "line2"), use.names = FALSE),
-            col2 = unlist(lapply(records, `[[`, "col2"), use.names = FALSE)
+            col2 = unlist(lapply(records, `[[`, "col2"), use.names = FALSE),
+            kind = rep(kinds, lengths(lapply(records, `[[`, "name")))
         )
     }
     definitions <- combine_records(
-        completion_data$symbols,
-        completion_data$functions,
-        completion_data$formals
+        list(
+            completion_data$symbols,
+            completion_data$functions,
+            completion_data$formals
+        ),
+        c("variable", "function", "formal")
     )
 
     global_lines <- vapply(global_definitions, function(definition) {
@@ -65,6 +78,7 @@ reference_parse_data <- function(data, content, completion_data, uri,
 
     names <- data$text[rows]
     definition_keys <- paste0("global:", names)
+    definition_kinds <- rep("global", length(rows))
     local_names <- unique(definitions$name[local])
     for (name in intersect(unique(names), local_names)) {
         occurrence_indices <- which(names == name)
@@ -108,8 +122,28 @@ reference_parse_data <- function(data, content, completion_data, uri,
                 definitions$col2[[candidate]],
                 sep = ":"
             )
+            definition_kinds[[occurrence_index]] <-
+                definitions$kind[[candidate]]
         }
     }
+
+    definition_positions <- paste(
+        definitions$name,
+        definitions$definition_line1,
+        definitions$definition_col1,
+        definitions$definition_line2,
+        definitions$definition_col2,
+        sep = ":"
+    )
+    occurrence_positions <- paste(
+        names,
+        data$line1[rows],
+        data$col1[rows],
+        data$line2[rows],
+        data$col2[rows],
+        sep = ":"
+    )
+    is_definition <- occurrence_positions %in% definition_positions
 
     cols <- as.integer(data$col1[rows] - 1L)
     end_cols <- as.integer(data$col2[rows])
@@ -159,6 +193,8 @@ reference_parse_data <- function(data, content, completion_data, uri,
         code_point_col = as.integer(data$col1[rows] - 1L),
         code_point_end_col = as.integer(data$col2[rows]),
         definition_key = definition_keys,
+        is_definition = is_definition,
+        definition_kind = definition_kinds,
         qualified_call = qualified_call,
         call_package = call_package
     )

--- a/man/document_code_action_reply.Rd
+++ b/man/document_code_action_reply.Rd
@@ -4,7 +4,15 @@
 \alias{document_code_action_reply}
 \title{The response to a textDocument/codeAction Request}
 \usage{
-document_code_action_reply(id, uri, workspace, document, range, context)
+document_code_action_reply(
+  id,
+  uri,
+  workspace,
+  document,
+  range,
+  context,
+  client_capabilities = NULL
+)
 }
 \description{
 The response to a textDocument/codeAction Request

--- a/tests/testthat/test-code-action.R
+++ b/tests/testthat/test-code-action.R
@@ -207,7 +207,7 @@ test_that("Nolint actions cover all affected lines and extend directives", {
 test_that("Code action capabilities and request interface are precise", {
   expect_equal(
     unlist(ServerCapabilities$codeActionProvider$codeActionKinds),
-    c("quickfix", "source.fixAll")
+    c("quickfix", "refactor.extract", "refactor.inline", "source.fixAll")
   )
   request_range <- range(position(0, 0), position(0, 1))
   params <- code_action_params(document_uri("file:///test.R"), request_range)

--- a/tests/testthat/test-refactor.R
+++ b/tests/testthat/test-refactor.R
@@ -1,0 +1,397 @@
+refactor_test_range <- function(content, row, text) {
+    start <- regexpr(text, content[[row + 1L]], fixed = TRUE)[[1L]] - 1L
+    stopifnot(start >= 0L)
+    list(
+        start = list(row = row, col = start),
+        end = list(row = row, col = start + nchar(text))
+    )
+}
+
+refactor_test_offset <- function(document, point) {
+    point <- document$from_lsp_position(point)
+    preceding <- if (point$row > 0L) {
+        sum(nchar(document$content[seq_len(point$row)])) + point$row
+    } else {
+        0L
+    }
+    preceding + point$col
+}
+
+refactor_apply_edits <- function(content, edits) {
+    document <- Document$new("file:///apply-refactor.R", content = content)
+    starts <- vapply(edits, function(edit) {
+        refactor_test_offset(document, edit$range$start)
+    }, numeric(1L))
+    ends <- vapply(edits, function(edit) {
+        refactor_test_offset(document, edit$range$end)
+    }, numeric(1L))
+    order <- order(starts, ends, decreasing = TRUE)
+    text <- paste(content, collapse = "\n")
+    for (i in order) {
+        before <- if (starts[[i]] > 0L) {
+            substr(text, 1L, starts[[i]])
+        } else {
+            ""
+        }
+        after <- if (ends[[i]] < nchar(text)) {
+            substr(text, ends[[i]] + 1L, nchar(text))
+        } else {
+            ""
+        }
+        text <- paste0(before, edits[[i]]$newText, after)
+    }
+    text
+}
+
+refactor_action_with_title <- function(actions, title) {
+    titles <- vapply(actions, `[[`, character(1L), "title")
+    actions[[match(title, titles)]]
+}
+
+test_that("extract variable creates a previewable collision-free edit", {
+    content <- c(
+        "outer <- function(a) {",
+        "  extracted_value <- 0",
+        "  result <- sqrt(a + 1)",
+        "}"
+    )
+    fixture <- provider_fixture(content)
+    selected <- refactor_test_range(content, 2L, "a + 1")
+
+    actions <- refactor_code_actions(
+        fixture$uri, fixture$workspace, fixture$document,
+        selected, list("refactor.extract")
+    )
+    action <- refactor_action_with_title(
+        actions, "Extract expression to variable")
+
+    expect_equal(action$kind, "refactor.extract")
+    expect_named(action$edit, "changes")
+    actual <- refactor_apply_edits(
+        content, action$edit$changes[[fixture$uri]])
+    expect_equal(actual, paste(c(
+        "outer <- function(a) {",
+        "  extracted_value <- 0",
+        "  extracted_value_2 <- a + 1",
+        "  result <- sqrt(extracted_value_2)",
+        "}"
+    ), collapse = "\n"))
+    expect_silent(parse(text = actual))
+})
+
+test_that("refactor workspace edits are versioned when the client supports them", {
+    content <- c(
+        "outer <- function(argument) {",
+        "  result <- argument + 1",
+        "}"
+    )
+    fixture <- provider_fixture(content)
+    selected <- refactor_test_range(content, 1L, "argument + 1")
+    capabilities <- list(workspace = list(workspaceEdit = list(
+        documentChanges = TRUE
+    )))
+
+    actions <- refactor_code_actions(
+        fixture$uri, fixture$workspace, fixture$document,
+        selected, list("refactor.extract"), capabilities
+    )
+    action <- refactor_action_with_title(
+        actions, "Extract expression to variable")
+
+    expect_named(action$edit, "documentChanges")
+    expect_equal(
+        action$edit$documentChanges[[1L]]$textDocument,
+        list(uri = fixture$uri, version = fixture$document$version)
+    )
+    expect_length(action$edit$documentChanges[[1L]]$edits, 2L)
+})
+
+test_that("extract variable preserves valid multiline source", {
+    content <- c(
+        "outer <- function(argument) {",
+        "  result <- sum(",
+        "    argument,",
+        "    2",
+        "  )",
+        "}"
+    )
+    fixture <- provider_fixture(content)
+    selected <- list(
+        start = list(row = 1L, col = 12L),
+        end = list(row = 4L, col = 3L)
+    )
+    context <- refactor_selection_context(
+        fixture$uri, fixture$workspace, fixture$document, selected)
+    action <- refactor_extract_variable_action(
+        fixture$uri, fixture$workspace, fixture$document, context)
+    actual <- refactor_apply_edits(
+        content, action$edit$changes[[fixture$uri]])
+
+    expect_match(actual, "extracted_value <- sum\\(")
+    expect_match(actual, "result <- extracted_value", fixed = TRUE)
+    expect_silent(parse(text = actual))
+})
+
+test_that("extract function passes local free variables only", {
+    content <- c(
+        "global_value <- 10",
+        "outer <- function(argument) {",
+        "  result <- sqrt(argument + global_value)",
+        "}"
+    )
+    fixture <- provider_fixture(content)
+    selected <- refactor_test_range(
+        content, 2L, "argument + global_value")
+
+    actions <- refactor_code_actions(
+        fixture$uri, fixture$workspace, fixture$document,
+        selected, list("refactor.extract")
+    )
+    action <- refactor_action_with_title(
+        actions, "Extract selection to function")
+    actual <- refactor_apply_edits(
+        content, action$edit$changes[[fixture$uri]])
+
+    expect_equal(actual, paste(c(
+        "global_value <- 10",
+        "outer <- function(argument) {",
+        "  extracted_function <- function(argument) {",
+        "    argument + global_value",
+        "  }",
+        "  result <- sqrt(extracted_function(argument))",
+        "}"
+    ), collapse = "\n"))
+    expect_silent(parse(text = actual))
+})
+
+test_that("extract function supports one live-out binding", {
+    content <- c(
+        "outer <- function(argument) {",
+        "  intermediate <- argument + 1",
+        "  result <- intermediate * 2",
+        "  print(result)",
+        "}"
+    )
+    fixture <- provider_fixture(content)
+    selected <- list(
+        start = list(row = 1L, col = 2L),
+        end = list(row = 2L, col = nchar(content[[3L]]))
+    )
+    context <- refactor_selection_context(
+        fixture$uri, fixture$workspace, fixture$document, selected)
+
+    expect_equal(
+        refactor_function_bindings(context),
+        list(free = "argument", outputs = "result")
+    )
+    action <- refactor_extract_function_action(
+        fixture$uri, fixture$workspace, fixture$document, context)
+    actual <- refactor_apply_edits(
+        content, action$edit$changes[[fixture$uri]])
+    expect_equal(actual, paste(c(
+        "outer <- function(argument) {",
+        "  extracted_function <- function(argument) {",
+        "    intermediate <- argument + 1",
+        "    result <- intermediate * 2",
+        "  }",
+        "  result <- extracted_function(argument)",
+        "  print(result)",
+        "}"
+    ), collapse = "\n"))
+    expect_silent(parse(text = actual))
+})
+
+test_that("extract function passes a binding read by its own assignment", {
+    content <- c(
+        "outer <- function(value) {",
+        "  value <- value + 1",
+        "  print(value)",
+        "}"
+    )
+    fixture <- provider_fixture(content)
+    selected <- refactor_test_range(content, 1L, "value <- value + 1")
+    context <- refactor_selection_context(
+        fixture$uri, fixture$workspace, fixture$document, selected)
+
+    expect_equal(
+        refactor_function_bindings(context),
+        list(free = "value", outputs = "value")
+    )
+    action <- refactor_extract_function_action(
+        fixture$uri, fixture$workspace, fixture$document, context)
+    actual <- refactor_apply_edits(
+        content, action$edit$changes[[fixture$uri]])
+    expect_equal(actual, paste(c(
+        "outer <- function(value) {",
+        "  extracted_function <- function(value) {",
+        "    value <- value + 1",
+        "  }",
+        "  value <- extracted_function(value)",
+        "  print(value)",
+        "}"
+    ), collapse = "\n"))
+})
+
+test_that("inline local variable removes its declaration and preserves precedence", {
+    content <- c(
+        "outer <- function(argument) {",
+        "  value <- argument + 1",
+        "  print(value * 2)",
+        "}"
+    )
+    fixture <- provider_fixture(content)
+    selected <- refactor_test_range(content, 2L, "value")
+
+    actions <- refactor_code_actions(
+        fixture$uri, fixture$workspace, fixture$document,
+        selected, list("refactor.inline")
+    )
+    expect_length(actions, 1L)
+    expect_equal(actions[[1L]]$kind, "refactor.inline")
+    actual <- refactor_apply_edits(
+        content, actions[[1L]]$edit$changes[[fixture$uri]])
+    expect_equal(actual, paste(c(
+        "outer <- function(argument) {",
+        "  print((argument + 1) * 2)",
+        "}"
+    ), collapse = "\n"))
+    expect_silent(parse(text = actual))
+})
+
+test_that("inline local variable rejects ambiguous bindings", {
+    multiple_reads <- c(
+        "outer <- function(argument) {",
+        "  value <- argument + 1",
+        "  value + value",
+        "}"
+    )
+    fixture <- provider_fixture(multiple_reads)
+    selected <- refactor_test_range(multiple_reads, 2L, "value")
+    expect_null(refactor_inline_variable_action(
+        fixture$uri, fixture$workspace, fixture$document, selected))
+
+    reassigned <- c(
+        "outer <- function(argument) {",
+        "  value <- argument + 1",
+        "  value <- value * 2",
+        "  print(value)",
+        "}"
+    )
+    fixture <- provider_fixture(reassigned)
+    selected <- refactor_test_range(reassigned, 3L, "value")
+    expect_null(refactor_inline_variable_action(
+        fixture$uri, fixture$workspace, fixture$document, selected))
+
+    commented <- c(
+        "outer <- function(argument) {",
+        "  value <- argument + 1 # keep this explanation",
+        "  print(value)",
+        "}"
+    )
+    fixture <- provider_fixture(commented)
+    selected <- refactor_test_range(commented, 2L, "value")
+    expect_null(refactor_inline_variable_action(
+        fixture$uri, fixture$workspace, fixture$document, selected))
+})
+
+test_that("extract refactorings reject unsafe evaluation contexts", {
+    assignment_target <- c(
+        "outer <- function(values) {",
+        "  values[1] <- compute()",
+        "}"
+    )
+    fixture <- provider_fixture(assignment_target)
+    selected <- refactor_test_range(assignment_target, 1L, "values[1]")
+    expect_identical(refactor_code_actions(
+        fixture$uri, fixture$workspace, fixture$document,
+        selected, list("refactor.extract")), list())
+
+    quoted <- c(
+        "outer <- function(argument) {",
+        "  quoted <- quote(argument + 1)",
+        "}"
+    )
+    fixture <- provider_fixture(quoted)
+    selected <- refactor_test_range(quoted, 1L, "argument + 1")
+    expect_identical(refactor_code_actions(
+        fixture$uri, fixture$workspace, fixture$document,
+        selected, list("refactor.extract")), list())
+
+    multiple_outputs <- c(
+        "outer <- function(argument) {",
+        "  first <- argument + 1",
+        "  second <- argument + 2",
+        "  first + second",
+        "}"
+    )
+    fixture <- provider_fixture(multiple_outputs)
+    selected <- list(
+        start = list(row = 1L, col = 2L),
+        end = list(row = 2L, col = nchar(multiple_outputs[[3L]]))
+    )
+    expect_identical(refactor_code_actions(
+        fixture$uri, fixture$workspace, fixture$document,
+        selected, list("refactor.extract")), list())
+
+    top_level_definition <- c(
+        "first <- argument + 1",
+        "print(first)"
+    )
+    fixture <- provider_fixture(top_level_definition)
+    selected <- refactor_test_range(
+        top_level_definition, 0L, "first <- argument + 1")
+    expect_identical(refactor_code_actions(
+        fixture$uri, fixture$workspace, fixture$document,
+        selected, list("refactor.extract")), list())
+})
+
+test_that("refactor actions honor requested kinds and current parse versions", {
+    content <- c(
+        "outer <- function(argument) {",
+        "  result <- argument + 1",
+        "}"
+    )
+    fixture <- provider_fixture(content)
+    selected <- refactor_test_range(content, 1L, "argument + 1")
+
+    expect_identical(refactor_code_actions(
+        fixture$uri, fixture$workspace, fixture$document,
+        selected, list("quickfix")), list())
+    fixture$document$version <- fixture$document$version + 1L
+    expect_identical(refactor_code_actions(
+        fixture$uri, fixture$workspace, fixture$document,
+        selected, list("refactor")), list())
+})
+
+test_that("refactor selections cannot cross literate R cells", {
+    uri <- "file:///refactor.qmd"
+    content <- c(
+        "```{r}",
+        "first <- 1 + 2",
+        "```",
+        "",
+        "```{r}",
+        "second <- first * 2",
+        "```"
+    )
+    document <- Document$new(
+        uri, language = "quarto", version = 1L, content = content)
+    parse_data <- parse_document(uri, content, is_rmarkdown = TRUE)
+    parse_data$version <- document$version
+    parse_data$xml_doc <- xml2::read_xml(parse_data$xml_data)
+    document$update_parse_data(parse_data)
+    documents <- collections::dict()
+    documents$set(uri, document)
+    workspace <- new.env(parent = baseenv())
+    workspace$documents <- documents
+    workspace$get_parse_data <- function(request_uri) {
+        documents$get(request_uri, NULL)$parse_data
+    }
+    selected <- list(
+        start = list(row = 1L, col = 0L),
+        end = list(row = 5L, col = nchar(content[[6L]]))
+    )
+
+    expect_null(refactor_selection_context(
+        uri, workspace, document, selected))
+})


### PR DESCRIPTION
## Summary

- advertise `refactor.extract` and `refactor.inline` code actions
- add extract-variable and extract-function edits, including indexed free-variable and live-out analysis
- add conservative single-use local-variable inlining
- return previewable workspace edits, using versioned document changes when supported
- guard stale parses, literate cells, index readiness, NSE and control flow, assignment targets, multiple outputs, and name collisions

This builds on workspace indexing so cross-file symbol analysis is trustworthy.

## Validation

- focused code-action and refactoring tests
- full test suite; feature tests pass, with the unrelated closed-input connection test observed flaky once and passing in isolation
- `R CMD INSTALL` to a temporary library
- `git diff --check`

Addresses #94.