### PR TITLE
Avoid redundant package resolution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,9 @@
   until the current parse is ready.
 - Bound parse and diagnostics caches by memory and reuse indexed references for
   rename, highlights, call hierarchy, and code-lens call counts.
+- Track the last successful ordered package request for each document, avoiding
+  redundant `callr` subprocesses after transient parse errors or representation
+  changes while preserving package attachment order (#754).
 
 **Closed issues:**
 

--- a/R/document.R
+++ b/R/document.R
@@ -11,6 +11,7 @@ Document <- R6::R6Class(
         is_rmarkdown = NULL,
         regions = NULL,
         loaded_packages = NULL,
+        requested_packages = NULL,
         pending_diagnostics = FALSE,
         diagnostics_delay = 0,
 
@@ -21,6 +22,7 @@ Document <- R6::R6Class(
             self$is_rmarkdown <- is_rmarkdown(uri, language)
             self$set_content(version, content)
             self$loaded_packages <- character()
+            self$requested_packages <- NULL
         },
 
         did_open = function() {
@@ -644,6 +646,11 @@ parse_document <- function(uri, content, is_rmarkdown = FALSE,
 }
 
 
+normalize_package_request <- function(packages) {
+    enc2utf8(unname(as.character(packages)))
+}
+
+
 parse_callback <- function(self, uri, version, parse_data) {
     workspace <- self$get_workspace(uri)
     if (is.null(parse_data) || !workspace$documents$has(uri)) return(NULL)
@@ -660,6 +667,11 @@ parse_callback <- function(self, uri, version, parse_data) {
 
     parse_data$version <- version
     old_parse_data <- doc$parse_data
+    previous_packages <- doc$requested_packages
+    if (is.null(previous_packages) && !is.null(old_parse_data) &&
+            !isTRUE(old_parse_data$parse_error)) {
+        previous_packages <- normalize_package_request(old_parse_data$packages)
+    }
     workspace$update_parse_data(uri, parse_data)
 
     if (isTRUE(doc$pending_diagnostics)) {
@@ -675,14 +687,20 @@ parse_callback <- function(self, uri, version, parse_data) {
         workspace$parse_cache$set(parse_data$content_hash, cache_entry)
     }
 
-    if (!isTRUE(parse_data$parse_error) &&
-            !identical(old_parse_data$packages, parse_data$packages)) {
-        self$resolve_task_manager$add_task(
-            uri,
-            resolve_task(self, uri, doc, parse_data$packages)
-        )
-        doc$loaded_packages <- parse_data$packages
-        workspace$update_loaded_packages()
+    if (!isTRUE(parse_data$parse_error)) {
+        requested_packages <- normalize_package_request(parse_data$packages)
+        if (is.null(previous_packages) ||
+                !identical(previous_packages, requested_packages)) {
+            doc$requested_packages <- requested_packages
+            self$resolve_task_manager$add_task(
+                uri,
+                resolve_task(self, uri, doc, requested_packages)
+            )
+            doc$loaded_packages <- requested_packages
+            workspace$update_loaded_packages()
+        } else if (is.null(doc$requested_packages)) {
+            doc$requested_packages <- requested_packages
+        }
     }
 
     pending_replies <- self$pending_replies$get(uri, NULL)

--- a/tests/testthat/test-document-core.R
+++ b/tests/testthat/test-document-core.R
@@ -60,3 +60,51 @@ test_that("Parse callbacks discard stale work and superseded replies", {
     self$get_workspace <- function(...) missing_workspace
     expect_null(resolve_callback(self, uri, 2L, character()))
 })
+
+test_that("Parse callbacks only resolve when the package request changes", {
+    uri <- "file:///resolve-request.R"
+    workspace <- Workspace$new(NULL)
+
+    resolve_count <- 0L
+    self <- new.env(parent = baseenv())
+    self$get_workspace <- function(...) workspace
+    self$resolve_task_manager <- new.env(parent = baseenv())
+    self$resolve_task_manager$add_task <- function(id, task) {
+        resolve_count <<- resolve_count + 1L
+    }
+    self$pending_replies <- collections::dict()
+    self$request_handlers <- list()
+
+    parse_data <- function(packages, parse_error = FALSE) {
+        data <- parse_document(uri, "")
+        data$packages <- packages
+        data$parse_error <- parse_error
+        data
+    }
+
+    document <- Document$new(uri, version = 1L, content = "")
+    workspace$documents$set(uri, document)
+
+    named_packages <- c(first = "stats", second = "utils")
+    parse_callback(self, uri, 1L, parse_data(named_packages))
+    expect_equal(resolve_count, 1L)
+    expect_identical(document$requested_packages, c("stats", "utils"))
+
+    # Representation-only differences must not schedule another subprocess.
+    parse_callback(self, uri, 1L, parse_data(c("stats", "utils")))
+    expect_equal(resolve_count, 1L)
+
+    # Failed parses must not discard the last successful package request.
+    parse_callback(self, uri, 1L, parse_data(character(), parse_error = TRUE))
+    parse_callback(self, uri, 1L, parse_data(c("stats", "utils")))
+    expect_equal(resolve_count, 1L)
+
+    # Package order controls masking, so reordering must trigger resolution.
+    parse_callback(self, uri, 1L, parse_data(c("utils", "stats")))
+    expect_equal(resolve_count, 2L)
+    expect_identical(document$requested_packages, c("utils", "stats"))
+
+    # Adding or removing a package must also trigger resolution.
+    parse_callback(self, uri, 1L, parse_data(c("utils", "stats", "methods")))
+    expect_equal(resolve_count, 3L)
+})


### PR DESCRIPTION
## Summary

- remember each document's last successful ordered package request
- normalize away vector names/encoding metadata before comparing requests
- avoid restarting package resolution after transient parse errors
- preserve package order so masking and namespace precedence remain correct

Fixes #754.

## Testing

- `Rscript -e 'devtools::test(filter = "document-core|handlers-textsync|workspace-core|completion", reporter = "summary")'`
- `git diff --check`
- changed-file linting

The full local suite was also run. It reached existing environment-related failures in diagnostics/formatting subprocess tests (`gzfile(...): cannot open the connection`), while the focused package-resolution and dependent tests passed.
